### PR TITLE
Feature/vumigo 50 pick shortcodes

### DIFF
--- a/config/tagpools.yaml
+++ b/config/tagpools.yaml
@@ -42,3 +42,21 @@ pools:
       server_initiated: true
       msg_options:
         transport_name: gtalk_vumigo
+  mama1:
+    tags:
+      - '*120*646*MAMA1'
+    metadata:
+      display_name: "MAMA USSD 1"
+      delivery_class: ussd
+      transport_type: ussd
+      client_intiated: true
+      user_selects_tag: true
+  mama2:
+    tags:
+      - '*120*646*MAMA2'
+    metadata:
+      display_name: "MAMA USSD 2"
+      delivery_class: ussd
+      transport_type: ussd
+      client_intiated: true
+      user_selects_tag: true

--- a/go/apps/bulk_message/templates/bulk_message/includes/new.html
+++ b/go/apps/bulk_message/templates/bulk_message/includes/new.html
@@ -33,7 +33,7 @@
         Pick a method delivery via {{delivery_class}}
     </label>
     <div class="controls">
-        <select id="{{delivery_class}}_tag_pool"  disabled="disabled" name="delivery_tag_pool" class="input-medium">
+        <select id="{{delivery_class}}_tag_pool" disabled="disabled" name="delivery_tag_pool" class="input-medium">
             {% for tag_pool_name, tag_options in tag_pools %}
             <optgroup label="{{tag_pool_name}}">
               {% for tag, label in tag_options %}

--- a/go/apps/bulk_message/templates/bulk_message/includes/new.html
+++ b/go/apps/bulk_message/templates/bulk_message/includes/new.html
@@ -34,8 +34,12 @@
     </label>
     <div class="controls">
         <select id="{{delivery_class}}_tag_pool"  disabled="disabled" name="delivery_tag_pool" class="input-medium">
-            {% for tag_pool, label in tag_pools %}
-            <option value="{{tag_pool}}">{{ label }}</option>
+            {% for tag_pool_name, tag_options in tag_pools %}
+            <optgroup label="{{tag_pool_name}}">
+              {% for tag, label in tag_options %}
+              <option value="{{tag}}">{{ label }}</option>
+              {% endfor %}
+            </optgroup>
             {% endfor %}
         </select>
     </div>

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -67,13 +67,14 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'subject': 'the subject',
             'message': 'the message',
             'delivery_class': 'sms',
-            'delivery_tag_pool': 'longcode',
+            'delivery_tag_pool': 'longcode:',
         })
         self.assertEqual(len(self.conv_store.list_conversations()), 2)
         conversation = max(self.conv_store.list_conversations(),
                            key=lambda c: c.created_at)
         self.assertEqual(conversation.delivery_class, 'sms')
         self.assertEqual(conversation.delivery_tag_pool, 'longcode')
+        self.assertEqual(conversation.delivery_tag, None)
         self.assertRedirects(response, reverse('bulk_message:people', kwargs={
             'conversation_key': conversation.key,
         }))

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -56,8 +56,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         conv = self.conv_store.get_conversation_by_key(self.conv_key)
         return self.user_api.wrap_conversation(conv)
 
-    def test_new_conversation(self):
-        """test the creation of a new conversation"""
+    def run_new_conversation(self, selected_option, pool, tag):
         # render the form
         self.assertEqual(len(self.conv_store.list_conversations()), 1)
         response = self.client.get(reverse('bulk_message:new'))
@@ -67,17 +66,28 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'subject': 'the subject',
             'message': 'the message',
             'delivery_class': 'sms',
-            'delivery_tag_pool': 'longcode:',
+            'delivery_tag_pool': selected_option,
         })
         self.assertEqual(len(self.conv_store.list_conversations()), 2)
         conversation = max(self.conv_store.list_conversations(),
                            key=lambda c: c.created_at)
         self.assertEqual(conversation.delivery_class, 'sms')
-        self.assertEqual(conversation.delivery_tag_pool, 'longcode')
-        self.assertEqual(conversation.delivery_tag, None)
+        self.assertEqual(conversation.delivery_tag_pool, pool)
+        self.assertEqual(conversation.delivery_tag, tag)
         self.assertRedirects(response, reverse('bulk_message:people', kwargs={
             'conversation_key': conversation.key,
         }))
+
+    def test_new_conversation(self):
+        """test the creation of a new conversation"""
+        self.run_new_conversation('longcode:', 'longcode', None)
+
+    def test_new_conversation_with_user_selected_tags(self):
+        tp_meta = self.api.tpm.get_metadata('longcode')
+        tp_meta['user_selects_tag'] = True
+        self.api.tpm.set_metadata('longcode', tp_meta)
+        self.run_new_conversation('longcode:default10001', 'longcode',
+                                  'default10001')
 
     def test_end(self):
         """

--- a/go/apps/bulk_message/views.py
+++ b/go/apps/bulk_message/views.py
@@ -27,6 +27,11 @@ def new(request):
             for key in copy_keys:
                 conversation_data[key] = form.cleaned_data[key]
 
+            tag_info = form.cleaned_data['delivery_tag_pool'].partition(':')
+            conversation_data['delivery_tag_pool'] = tag_info[0]
+            if tag_info[2]:
+                conversation_data['delivery_tag'] = tag_info[2]
+
             start_date = form.cleaned_data['start_date'] or datetime.utcnow()
             start_time = (form.cleaned_data['start_time'] or
                             datetime.utcnow().time())

--- a/go/apps/surveys/templates/surveys/includes/new.html
+++ b/go/apps/surveys/templates/surveys/includes/new.html
@@ -37,7 +37,7 @@
         Pick a method delivery via {{delivery_class}}
     </label>
     <div class="controls">
-        <select id="{{delivery_class}}_tag_pool" name="delivery_tag_pool" class="input-medium">
+        <select id="{{delivery_class}}_tag_pool" disabled="disabled" name="delivery_tag_pool" class="input-medium">
             {% for tag_pool_name, tag_options in tag_pools %}
             <optgroup label="{{tag_pool_name}}">
               {% for tag, label in tag_options %}
@@ -45,6 +45,7 @@
               {% endfor %}
             </optgroup>
             {% endfor %}
+        </select>
     </div>
 </div>
 {% endfor %}

--- a/go/apps/surveys/templates/surveys/includes/new.html
+++ b/go/apps/surveys/templates/surveys/includes/new.html
@@ -38,10 +38,13 @@
     </label>
     <div class="controls">
         <select id="{{delivery_class}}_tag_pool" name="delivery_tag_pool" class="input-medium">
-            {% for tag_pool, label in tag_pools %}
-            <option value="{{tag_pool}}">{{ label }}</option>
+            {% for tag_pool_name, tag_options in tag_pools %}
+            <optgroup label="{{tag_pool_name}}">
+              {% for tag, label in tag_options %}
+              <option value="{{tag}}">{{ label }}</option>
+              {% endfor %}
+            </optgroup>
             {% endfor %}
-        </select>
     </div>
 </div>
 {% endfor %}

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -67,13 +67,14 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             # 'start_date': datetime.utcnow().strftime('%Y-%m-%d'),
             # 'start_time': datetime.utcnow().strftime('%H:%M'),
             'delivery_class': 'sms',
-            'delivery_tag_pool': 'longcode',
+            'delivery_tag_pool': 'longcode:',
         })
         self.assertEqual(len(self.conv_store.list_conversations()), 2)
         conversation = max(self.conv_store.list_conversations(),
                            key=lambda c: c.created_at)
         self.assertEqual(conversation.delivery_class, 'sms')
         self.assertEqual(conversation.delivery_tag_pool, 'longcode')
+        self.assertEqual(conversation.delivery_tag, None)
         self.assertRedirects(response, reverse('survey:contents', kwargs={
             'conversation_key': conversation.key,
         }))

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -54,8 +54,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         conv = self.conv_store.get_conversation_by_key(self.conv_key)
         return self.user_api.wrap_conversation(conv)
 
-    def test_new_conversation(self):
-        """test the creation of a new conversation"""
+    def run_new_conversation(self, selected_option, pool, tag):
         # render the form
         self.assertEqual(len(self.conv_store.list_conversations()), 1)
         response = self.client.get(reverse('survey:new'))
@@ -67,17 +66,28 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             # 'start_date': datetime.utcnow().strftime('%Y-%m-%d'),
             # 'start_time': datetime.utcnow().strftime('%H:%M'),
             'delivery_class': 'sms',
-            'delivery_tag_pool': 'longcode:',
+            'delivery_tag_pool': selected_option,
         })
         self.assertEqual(len(self.conv_store.list_conversations()), 2)
         conversation = max(self.conv_store.list_conversations(),
                            key=lambda c: c.created_at)
         self.assertEqual(conversation.delivery_class, 'sms')
-        self.assertEqual(conversation.delivery_tag_pool, 'longcode')
-        self.assertEqual(conversation.delivery_tag, None)
+        self.assertEqual(conversation.delivery_tag_pool, pool)
+        self.assertEqual(conversation.delivery_tag, tag)
         self.assertRedirects(response, reverse('survey:contents', kwargs={
             'conversation_key': conversation.key,
         }))
+
+    def test_new_conversation(self):
+        """test the creation of a new conversation"""
+        self.run_new_conversation('longcode:', 'longcode', None)
+
+    def test_new_conversation_with_user_selected_tags(self):
+        tp_meta = self.api.tpm.get_metadata('longcode')
+        tp_meta['user_selects_tag'] = True
+        self.api.tpm.set_metadata('longcode', tp_meta)
+        self.run_new_conversation('longcode:default10001', 'longcode',
+                                  'default10001')
 
     def test_end(self):
         """

--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -42,11 +42,15 @@ def new(request):
                 'subject',
                 'message',
                 'delivery_class',
-                'delivery_tag_pool',
             ]
 
             for key in copy_keys:
                 conversation_data[key] = form.cleaned_data[key]
+
+            tag_info = form.cleaned_data['delivery_tag_pool'].partition(':')
+            conversation_data['delivery_tag_pool'] = tag_info[0]
+            if tag_info[2]:
+                conversation_data['delivery_tag'] = tag_info[2]
 
             start_date = form.cleaned_data['start_date'] or datetime.utcnow()
             start_time = (form.cleaned_data['start_time'] or

--- a/go/base/static/js/script.js
+++ b/go/base/static/js/script.js
@@ -27,18 +27,6 @@ $('#convtype').change(function() {
 	$('#newConversationType').attr('action', newAction);
 });
 
-function addOptGroupLabel(selectField) {
-    stripOptGroupLabel(selectField);
-    var selectedOpt = selectField.find('option:selected');
-    var optGroupLabel = selectedOpt.closest('optgroup').attr('label');
-    selectedOpt.prepend("<span class='optgroup-label'>"
-                        + optGroupLabel + ": </span>");
-}
-
-function stripOptGroupLabel(selectField) {
-    selectField.find('.optgroup-label').remove();
-}
-
 /* show or hide the tag pool options depending on the delivery class chosen */
 $('.delivery-class-radio').change(function() {
     delivery_classes = $('.delivery-class-radio[name=delivery_class]');
@@ -49,9 +37,6 @@ $('.delivery-class-radio').change(function() {
         if($(deliveryClass).attr('checked')) {
             tagPoolDiv.show();
             selectField.removeAttr('disabled');
-            selectField.blur(function() { addOptGroupLabel(selectField); });
-            selectField.focus(function() { stripOptGroupLabel(selectField); });
-            addOptGroupLabel(selectField);
         } else {
             tagPoolDiv.hide();
             selectField.attr('disabled', 'disabled');

--- a/go/base/static/js/script.js
+++ b/go/base/static/js/script.js
@@ -27,18 +27,34 @@ $('#convtype').change(function() {
 	$('#newConversationType').attr('action', newAction);
 });
 
+function addOptGroupLabel(selectField) {
+    stripOptGroupLabel(selectField);
+    var selectedOpt = selectField.find('option:selected');
+    var optGroupLabel = selectedOpt.closest('optgroup').attr('label');
+    selectedOpt.prepend("<span class='optgroup-label'>"
+                        + optGroupLabel + ": </span>");
+}
+
+function stripOptGroupLabel(selectField) {
+    selectField.find('.optgroup-label').remove();
+}
+
 /* show or hide the tag pool options depending on the delivery class chosen */
 $('.delivery-class-radio').change(function() {
     delivery_classes = $('.delivery-class-radio[name=delivery_class]');
     delivery_classes.each(function(index, element) {
         var deliveryClass = $(element);
         var tagPoolDiv = $('#' + deliveryClass.val() + '_tag_pool_selection');
+        var selectField = $('#' + deliveryClass.val() + '_tag_pool_selection select');
         if($(deliveryClass).attr('checked')) {
             tagPoolDiv.show();
-            $('#' + deliveryClass.val() + '_tag_pool_selection select').removeAttr('disabled');
+            selectField.removeAttr('disabled');
+            selectField.blur(function() { addOptGroupLabel(selectField); });
+            selectField.focus(function() { stripOptGroupLabel(selectField); });
+            addOptGroupLabel(selectField);
         } else {
             tagPoolDiv.hide();
-            $('#' + deliveryClass.val() + '_tag_pool_selection select').attr('disabled', 'disabled');
+            selectField.attr('disabled', 'disabled');
         }
     });
 

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -76,9 +76,11 @@ class ConversationForm(VumiModelForm):
             delivery_class = self.tagpool_set.delivery_class(pool)
             if delivery_class is None:
                 continue
-            delivery_classes.setdefault(delivery_class, []).append((
-                pool, self.tagpool_set.tagpool_name(pool)))
-        return delivery_classes.items()
+            tag_pool_name = self.tagpool_set.tagpool_name(pool)
+            tag_options = [(pool, "Random")]
+            tag_pools = delivery_classes.setdefault(delivery_class, [])
+            tag_pools.append((tag_pool_name, tag_options))
+        return sorted(delivery_classes.items())
 
     def delivery_class_widgets(self):
         # Backported hack from Django 1.4 to allow me to iterate

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -83,7 +83,8 @@ class ConversationForm(VumiModelForm):
             tag_options = [("%s:%s" % tag, tag[1]) for tag
                            in self.user_api.api.tpm.free_tags(pool)]
         else:
-            tag_options = [("%s:" % pool, "Random")]
+            tag_options = [("%s:" % pool,
+                            "%s (auto)" % self.tagpool_set.display_name(pool))]
         return tag_options
 
     def tagpools_by_delivery_class(self):

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -78,7 +78,7 @@ class ConversationForm(VumiModelForm):
     def tag_options(self, pool):
         if self.tagpool_set.user_selects_tag(pool):
             tag_options = [("%s:%s" % tag, tag[1]) for tag
-                           in self.user_api.api.tpm.freetags(pool)]
+                           in self.user_api.api.tpm.free_tags(pool)]
         else:
             tag_options = [("%s:" % pool, "Random")]
         return tag_options

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -309,7 +309,7 @@ class TagpoolSet(object):
         return self._pools[pool].get('display_name', pool)
 
     def user_selects_tag(self, pool):
-        return self._pools[pool].get('user_select_tag', False)
+        return self._pools[pool].get('user_selects_tag', False)
 
     def delivery_class(self, pool):
         return self._pools[pool].get('delivery_class', None)

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -224,10 +224,16 @@ class ConversationWrapper(object):
                            reverse=True))
 
     @Manager.calls_manager
-    def acquire_tag(self, pool=None):
-        tag = yield self.api.acquire_tag(pool or self.delivery_tag_pool)
-        if tag is None:
-            raise ConversationSendError("No spare messaging tags.")
+    def acquire_tag(self):
+        if self.c.delivery_tag is None:
+            tag = yield self.api.acquire_tag(self.c.delivery_tag_pool)
+            if tag is None:
+                raise ConversationSendError("No spare messaging tags.")
+        else:
+            tag = (self.c.delivery_tag_pool, self.c.delivery_tag)
+            tag = yield self.api.acquire_specific_tag(tag)
+            if tag is None:
+                raise ConversationSendError("Requested tag not available.")
         returnValue(tag)
 
     def dispatch_command(self, command, *args, **kwargs):
@@ -269,7 +275,7 @@ class TagpoolSet(object):
     """Holder for helper methods for retrieving tag pool information.
 
     :param dict pools:
-        Dictionary of `tagpool name` -> `tagpool metadat` mappings.
+        Dictionary of `tagpool name` -> `tagpool metadata` mappings.
     """
 
     # TODO: this should ideally need to be moved somewhere else
@@ -299,8 +305,11 @@ class TagpoolSet(object):
     def pools(self):
         return self._pools.keys()
 
-    def tagpool_name(self, pool):
+    def display_name(self, pool):
         return self._pools[pool].get('display_name', pool)
+
+    def user_selects_tag(self, pool):
+        return self._pools[pool].get('user_select_tag', False)
 
     def delivery_class(self, pool):
         return self._pools[pool].get('delivery_class', None)
@@ -535,9 +544,22 @@ class VumiApi(object):
         :param pool:
             name of the pool to retrieve tags from.
         :rtype:
-            str containing the tag
+            The tag acquired or None if no tag was available.
         """
         return self.tpm.acquire_tag(pool)
+
+    def acquire_specific_tag(self, tag):
+        """Acquire a specific tag.
+
+        Tags should be held for the duration of a conversation.
+
+        :type tag: tag tuple
+        :param tag:
+            The tag to acquire.
+        :rtype:
+            The tag acquired or None if the tag was not available.
+        """
+        return self.tpm.acquire_specific_tag(tag)
 
     def release_tag(self, tag):
         """Release a tag back to the pool it came from.

--- a/go/vumitools/conversation.py
+++ b/go/vumitools/conversation.py
@@ -36,6 +36,7 @@ class Conversation(Model):
     conversation_type = Unicode()
     delivery_class = Unicode(null=True)
     delivery_tag_pool = Unicode(null=True)
+    delivery_tag = Unicode(null=True)
 
     batches = ManyToMany(Batch)
 


### PR DESCRIPTION
This branch isn't complete yet but I wouldn't mind a sanity check of the approach being taken before continuing.

Outstanding things needed are:
- Tests for bulk_message:new and survey:new using a tagpool that has user_selects_tag set in its metadata.
- Some manual testing of the UI by humans to make sure they like it.
- Some thought about where this bit of UI is going in the long term and whether that affects the current ticket (i.e. are people meant to be able to select multiple delivery classes and/or multiple tag pools within each delivery class? will tag pools eventually be autoselected?)
