### PR TITLE
make CSV upload two step & allow for free-form CSV

### DIFF
--- a/go/base/templates/base/includes/messages.html
+++ b/go/base/templates/base/includes/messages.html
@@ -7,7 +7,7 @@
             show
             {% endspaceless %}">
             <a class="close" data-dismiss="alert">×</a>
-            {{message}}
+            {{message|safe}}
         </div>
         {% if error_form.errors %}
         <div class="control-group error">

--- a/go/base/templates/base/includes/messages.html
+++ b/go/base/templates/base/includes/messages.html
@@ -7,7 +7,7 @@
             show
             {% endspaceless %}">
             <a class="close" data-dismiss="alert">×</a>
-            {{message|safe}}
+            {{message}}
         </div>
         {% if error_form.errors %}
         <div class="control-group error">

--- a/go/contacts/templates/contacts/group.html
+++ b/go/contacts/templates/contacts/group.html
@@ -94,6 +94,7 @@
         </div>
     </div>
     {% include "base/includes/pagination.html" %}
+
 {% endblock %}
 
 {% block extra_js %}
@@ -101,6 +102,11 @@
       $(document).ready(function(){
           $('#frm-new-group').validate();
           $('#frm-upload-contacts').validate();
+
+        {% if csv_data_row %}
+            $('#recMatchFrm').modal('show');
+        {% endif %}
+
       });
     </script>
     <link type="text/css" href="{{ STATIC_URL }}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />

--- a/go/contacts/templates/contacts/group.html
+++ b/go/contacts/templates/contacts/group.html
@@ -102,11 +102,7 @@
       $(document).ready(function(){
           $('#frm-new-group').validate();
           $('#frm-upload-contacts').validate();
-
-        {% if csv_data_row %}
-            $('#recMatchFrm').modal('show');
-        {% endif %}
-
+          $('#recMatchFrm').modal('show');
       });
     </script>
     <link type="text/css" href="{{ STATIC_URL }}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -88,8 +88,8 @@
                         <td>
                             <select name="column-{{ forloop.counter0 }}">
                                 <option value="">Please Select:</option>
-                                {% for header_type, label in csv_data_headers.items %}
-                                <option {% if header_type == column %}selected="true"{% endif %}value="{{ header_type }}">{{ label }}</option>
+                                {% for header, label in csv_data_headers.items %}
+                                <option {% if header == column %}selected="true"{% endif %}value="{{ header }}">{{ label }}</option>
                                 {% endfor %}
                             </select>
                         </td>

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -71,7 +71,8 @@
         </div>
     </form>
 </div><!--/uplContactFrm-->
-    
+
+{% if csv_data_headers and csv_data_row %}
 <div class="modal hide fade" id="recMatchFrm" style="display: block; ">
     <div class="modal-header">
         <a class="close" data-dismiss="modal">×</a>
@@ -105,6 +106,7 @@
         {% csrf_token %}
     </form>
 </div>
+{% endif %}
 
 <div class="modal hide fade" id="newGroup">
     <div class="modal-header">

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -72,44 +72,40 @@
     </form>
 </div><!--/uplContactFrm-->
     
-<!-- 
-<div class="modal hide fade" id="recMatchFrm">
-	<div class="modal-header">
-	    <a class="close" data-dismiss="modal">×</a>
-	    <h3>Please match the sample to the fields provided</h3>
-	</div>
-	<form class="form-horizontal" action="people.html">
-	    <div class="modal-body">
-	        <div class="alert alert-success">
-	            <a class="close" data-dismiss="alert">×</a>
-	            <strong>Success!</strong> 55 records found.
-	        </div>
-			<fieldset>
-			<table class="table table-bordered table-striped">
-			  <tbody>
-			    <tr>
-			      <td>
-					<select name="input02">
-					    <option value="">Please Select:</option>
-					    <option value="1">Mobile</option>
-					    <option value="1">Email</option>
-					    <option value="1">Name</option>
-					    <option value="1">Surname</option>
-					</select>
-			      </td>
-			      <td>gustav@praekelt.com</td>
-			    </tr>
-			  </tbody>
-			</table>
-			</fieldset>
-	    </div>
-	    <div class="modal-footer">
-	       <button type="submit" class="btn btn-primary" data-loading-text="saving...">Finish</button>
-	    </div>
+<div class="modal hide fade" id="recMatchFrm" style="display: block; ">
+    <div class="modal-header">
+        <a class="close" data-dismiss="modal">×</a>
+        <h3>Please match the sample to the fields provided</h3>
+    </div>
+    <form class="form-horizontal" action="{% url contacts:group group_key=group.key %}" method="POST">
+        <div class="modal-body">
+            <fieldset>
+              <table class="table table-bordered table-striped">
+                <tbody>
+                    {% for value, column in csv_data_row.items %}
+                      <tr>
+                        <td>
+                            <select name="column-{{ forloop.counter0 }}">
+                                <option value="">Please Select:</option>
+                                {% for header_type, label in csv_data_headers.items %}
+                                <option {% if header_type == column %}selected="true"{% endif %}value="{{ header_type }}">{{ label }}</option>
+                                {% endfor %}
+                            </select>
+                        </td>
+                        <td>{{ value }}</td>
+                      </tr>
+                    {% endfor %}
+                </tbody>
+              </table>
+            </fieldset>
+        </div>
+        <div class="modal-footer">
+            <button type="submit" class="btn btn-primary" name="_complete_csv_upload" data-loading-text="saving...">Finish</button>
+        </div>
+        {% csrf_token %}
     </form>
 </div>
--->
- 
+
 <div class="modal hide fade" id="newGroup">
     <div class="modal-header">
         <a class="close" data-dismiss="modal">×</a>

--- a/go/contacts/templates/contacts/person.html
+++ b/go/contacts/templates/contacts/person.html
@@ -40,6 +40,24 @@
                         </div>
                     </div>
                     {% endfor %}
+
+                    {% if contact_extra_items %}
+                        <strong>Extra Fields</strong>
+                        <p>
+                            These were fields that were either imported
+                            via CSV or assigned during a Vumi conversation.
+                        </p>
+                        <hr/>
+                        {% for field, value in contact_extra_items %}
+                        <div class="control-group">
+                            <label class="control-label">{{field}}</label>
+                            <div class="controls">
+                                <input type="text" readonly="readonly" value="{{value}}"/>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    {% endif %}
+
                     <div class="form-actions">
                         <button type="submit" class="btn btn-primary" data-loading-text="saving...">Save changes</button>
                     </div>

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -139,6 +139,37 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(set([g.key for g in contact.groups.get_all()]),
                     set([g.key for g in self.contact_store.list_groups()]))
 
+    def clear_groups(self, contact_key=None):
+        contact = self.contact_store.get_contact_by_key(
+            contact_key or self.contact_key)
+        contact.groups.clear()
+        contact.save()
+
+    def upload_file(self, csv_file, group_key=None, request_kwargs=None):
+        group_url = reverse('contacts:group', kwargs={
+            'group_key': group_key or self.group_key
+        })
+        kwargs = {
+            'file': csv_file
+        }
+        if request_kwargs:
+            kwargs.update(request_kwargs)
+        return self.client.post(group_url, kwargs)
+
+    def specify_columns(self, group_key=None, columns=None):
+        group_url = reverse('contacts:group', kwargs={
+            'group_key': group_key or self.group_key
+        })
+        defaults = {
+            'column-0': 'name',
+            'column-1': 'surname',
+            'column-2': 'msisdn',
+            '_complete_csv_upload': '1',
+        }
+        if columns:
+            defaults.update(columns)
+        return self.client.post(group_url, defaults)
+
     def test_contact_upload_into_new_group(self):
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
             'fixtures', 'sample-contacts.csv'))
@@ -152,18 +183,21 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_contact_upload_into_existing_group(self):
-        csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
-            'fixtures', 'sample-contacts.csv'))
-        contact = self.contact_store.get_contact_by_key(self.contact_key)
-        contact.groups.clear()
-        contact.save()
 
-        response = self.client.post(reverse('contacts:people'), {
-            'contact_group': self.group_key,
-            'file': csv_file,
-        })
+        self.clear_groups()
+        response = self.upload_file(open(
+            path.join(settings.PROJECT_ROOT, 'base',
+            'fixtures', 'sample-contacts.csv'), 'r'),
+            request_kwargs={
+                'contact_group': self.group_key
+            }
+        )
+
         self.assertRedirects(response, group_url(self.group_key))
         group = self.contact_store.get_group(self.group_key)
+        self.assertEqual(len(group.backlinks.contacts()), 0)
+
+        self.specify_columns()
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_uploading_unicode_chars_in_csv(self):
@@ -200,21 +234,20 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_contact_upload_from_group_page(self):
+
         group_url = reverse('contacts:group', kwargs={
             'group_key': self.group_key
         })
-        csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
-            'fixtures', 'sample-contacts.csv'))
-        contact = self.contact_store.get_contact_by_key(self.contact_key)
-        contact.groups.clear()
-        contact.save()
 
-        response = self.client.post(group_url, {
-            'file': csv_file
-            })
+        self.clear_groups()
+        csv_file = open(
+            path.join(settings.PROJECT_ROOT, 'base',
+                'fixtures', 'sample-contacts.csv'), 'r')
+        response = self.upload_file(csv_file)
 
         # It should redirect to the group page
         self.assertRedirects(response, group_url)
+
         # Wich should show the column-matching dialogue
         response = self.client.get(group_url)
         self.assertContains(response,
@@ -236,13 +269,7 @@ class ContactsTestCase(VumiGoDjangoTestCase):
 
         # Now submit the column names and check that things have been written
         # to the db
-        response = self.client.post(group_url, {
-            'column-0': 'name',
-            'column-1': 'surname',
-            'column-2': 'msisdn',
-            '_complete_csv_upload': '1',
-        })
-
+        response = self.specify_columns()
         # Check the redirect
         self.assertRedirects(response, group_url)
         # 3 records should have been written to the db.

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -179,7 +179,6 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_contact_upload_into_existing_group(self):
-
         self.clear_groups()
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
             'fixtures', 'sample-contacts.csv'), 'r')
@@ -198,17 +197,17 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_uploading_unicode_chars_in_csv(self):
+        self.clear_groups()
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
             'fixtures', 'sample-unicode-contacts.csv'))
-        contact = self.contact_store.get_contact_by_key(self.contact_key)
-        contact.groups.clear()
-        contact.save()
 
         response = self.client.post(reverse('contacts:people'), {
             'contact_group': self.group_key,
             'file': csv_file,
         })
         self.assertRedirects(response, group_url(self.group_key))
+
+        self.specify_columns()
         group = self.contact_store.get_group(self.group_key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
 

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -212,12 +212,10 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_uploading_unicode_chars_in_csv_into_new_group(self):
+        self.clear_groups()
         new_group_name = u'Testing a ünicode grøüp'
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
             'fixtures', 'sample-unicode-contacts.csv'))
-        contact = self.contact_store.get_contact_by_key(self.contact_key)
-        contact.groups.clear()
-        contact.save()
 
         response = self.client.post(reverse('contacts:people'), {
             'name': new_group_name,
@@ -227,6 +225,7 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         group = newest(self.contact_store.list_groups())
         self.assertEqual(group.name, new_group_name)
         self.assertRedirects(response, group_url(group.key))
+        self.specify_columns(group_key=group.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
 
     def test_contact_upload_from_group_page(self):

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from os import path
+from StringIO import StringIO
 
 from django.conf import settings
 from django.test.client import Client
@@ -277,16 +278,17 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         group_url = reverse('contacts:group', kwargs={
             'group_key': self.group_key
         })
-        wrong_file = open(path.join(settings.PROJECT_ROOT, 'base',
-            'fixtures', 'test_user.json'))
-        contact = self.contact_store.get_contact_by_key(self.contact_key)
-        contact.groups.clear()
-        contact.save()
+
+        wrong_file = StringIO('fubar')
+        wrong_file.name = 'fubar.csv'
+
+        self.clear_groups()
 
         response = self.client.post(group_url, {
             'file': wrong_file
             })
 
+        response = self.specify_columns()
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Something is wrong with the file')
 

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -211,6 +211,8 @@ def _import_csv_file(group, csv_path, field_names, has_header):
         # Make sure we normalize the msisdn before saving in the db
         if 'msisdn' in data_dictionary:
             msisdn = data_dictionary['msisdn']
+            # TODO: fix normalization, Vumi Go won't be bound to a single
+            #       country code which can be used for normalization.
             normalized_msisdn = normalize_msisdn(msisdn,
                 country_code=settings.VUMI_COUNTRY_CODE)
             data_dictionary.update({

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -243,15 +243,17 @@ def group(request, group_key):
                 # Populate this with whatever we'll be sending to the
                 # contact to be saved
                 contact_dictionary = {}
+                dynamic_fields = {}
                 for key, value in data_dictionary.items():
                     if key in known_attributes:
                         contact_dictionary[key] = value
                     else:
-                        extra = contact_dictionary.setdefault('extra', {})
-                        extra[key] = value
+                        dynamic_fields[key] = value
 
-                print 'contact_dictionary', contact_dictionary
-                # contact_store.new_contact(**contact_dictionary)
+                contact = contact_store.new_contact(**contact_dictionary)
+                contact.extra.update(dynamic_fields)
+                contact.save()
+
             messages.info(request,
                 '<strong>Success!</strong> %s contacts imported.' %
                     (counter if has_header else counter + 1,))

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -186,8 +186,8 @@ def _import_csv_file(group, csv_path, field_names, has_header):
     data_dictionaries = _read_data_from_csv_file(csv_file,
                                 field_names)
 
-    # We need to know what we can an cannot set and
-    # what fields need to go into the 'extra' Dynamic field
+    # We need to know what we cannot set to avoid a
+    # CSV import overwriting things like account details.
     excluded_attributes = ['user_account',
                             'created_at',
                             'extra']

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -4,7 +4,7 @@ import uuid
 import os.path
 from StringIO import StringIO
 
-from django.http import Http404, HttpResponseBadRequest
+from django.http import Http404
 from django.shortcuts import render, redirect
 from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -266,7 +266,7 @@ def group(request, group_key):
                     contact.save()
 
                 messages.info(request,
-                    '<strong>Success!</strong> %s contacts imported.' % (
+                    'Success! %s contacts imported.' % (
                         count,))
 
                 _clear_file_hints_from_session(request)

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -1,16 +1,23 @@
 import csv
 import re
+import uuid
+import os.path
+from StringIO import StringIO
 
-from django.http import Http404
+from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import render, redirect
 from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
 from django.conf import settings
+from django.utils.datastructures import SortedDict
 
 from vumi.utils import normalize_msisdn
 
+from go.vumitools.contact import Contact
 from go.contacts.forms import (
     ContactForm, NewContactGroupForm, UploadContactsForm,
     SelectContactGroupForm)
@@ -43,18 +50,17 @@ def _filter_contacts(contacts, request_params):
         }
 
 
-def _create_contacts_from_csv_file(contact_store, csvfile, country_code):
+def _read_data_from_csv_file(csvfile, field_names):
     dialect = csv.Sniffer().sniff(csvfile.read(1024))
     csvfile.seek(0)
-    reader = csv.reader(csvfile, dialect=dialect)
-    for name, surname, msisdn in reader:
-        # TODO: none of these fields are mandatory.
-        msisdn = normalize_msisdn(msisdn, country_code=country_code)
-        msisdn = unicode(msisdn, 'utf-8')
-        name = unicode(name, 'utf-8')
-        surname = unicode(surname, 'utf-8')
-        contact = contact_store.new_contact(name, surname, msisdn=msisdn)
-        yield contact
+    reader = csv.DictReader(csvfile, field_names, dialect=dialect)
+    for row in reader:
+        # Only process rows that actually have data
+        if any([column for column in row]):
+            # Our Riak client requires unicode for all keys & values stored.
+            unicoded_row = dict([(key, unicode(value, 'utf-8'))
+                                    for key, value in row.items()])
+            yield unicoded_row
 
 
 def _group_url(group_key):
@@ -100,6 +106,78 @@ def groups(request):
     })
 
 
+def _is_header_row(columns):
+    column_set = set([column.lower() for column in columns])
+    hint_set = set(['phone', 'contact', 'msisdn', 'number'])
+    return hint_set.intersection(column_set)
+
+
+def _guess_headers_and_row(csv_data):
+    [first_row, second_row] = csv.reader(StringIO(csv_data))
+    default_headers = {
+        'name': 'Name',
+        'surname': 'Surname',
+        'bbm_pin': 'BBM Pin',
+        'msisdn': 'Contact Number',
+        'gtalk_id': 'GTalk (or XMPP) address',
+        'dob': 'Date of Birth',
+        'facebook_id': 'Facebook ID',
+        'twitter_handle': 'Twitter handle',
+        'email_address': 'Email address',
+    }
+
+    if _is_header_row(first_row):
+        for column in first_row:
+            sample_row = SortedDict(zip(second_row, first_row))
+            default_headers.setdefault(column, column)
+        return True, default_headers, sample_row
+    return (False, default_headers,
+        SortedDict([(column, None) for column in first_row]))
+
+
+def _get_file_hints(file_object):
+    # Save the file object temporarily so we can present
+    # some UI to help the user figure out which columns are
+    # what of what type.
+    content_file = ContentFile(file_object.read())
+    temp_file_name = uuid.uuid4().hex
+    temp_file_path = default_storage.save(os.path.join('tmp',
+        '%s.csv' % (temp_file_name,)), content_file)
+    # Store the first two lines in the session, we'll present these
+    # in the UI on the following page to help the user determine
+    # which column represents what.
+    content_file.seek(0)
+    first_two_lines = '\n'.join([
+        content_file.readline().strip() for i in range(2)])
+
+    return temp_file_path, first_two_lines
+
+
+def _store_file_hints_in_session(request, path, data):
+    # Not too happy with this method but I don't want to
+    # be writing the same session keys everywhere.
+    request.session['uploaded_csv_path'] = path
+    request.session['uploaded_csv_data'] = data
+    return request
+
+
+def _get_file_hints_from_session(request):
+    return [
+        request.session['uploaded_csv_path'],
+        request.session['uploaded_csv_data'],
+    ]
+
+
+def _clear_file_hints_from_session(request):
+    del request.session['uploaded_csv_data']
+    del request.session['uploaded_csv_path']
+
+
+def _has_uncompleted_csv_import(request):
+    return (('uploaded_csv_data' in request.session)
+        and ('uploaded_csv_path' in request.session))
+
+
 @login_required
 def group(request, group_key):
     contact_store = request.user_api.contact_store
@@ -114,28 +192,97 @@ def group(request, group_key):
                 group.name = group_form.cleaned_data['name']
                 group.save()
             messages.info(request, 'The group name has been updated')
+            return redirect(_group_url(group.key))
+        elif '_complete_csv_upload' in request.POST:
+            csv_path, csv_data = _get_file_hints_from_session(request)
+            has_header, _, sample_row = _guess_headers_and_row(csv_data)
+            full_path = os.path.join(settings.MEDIA_ROOT, csv_path)
+            # open in Universal mode to allow us to reed files with Windows,
+            # MacOS9 & Unix line-endings
+            csv_file = open(full_path, 'rU')
+            # Grab the selected field names from the submitted form
+            # by looping over the expect n number of `column-n` keys being
+            # posted
+            field_names = [request.POST.get('column-%s' % i) for i in
+                            range(len(sample_row))]
+            data_dictionaries = _read_data_from_csv_file(csv_file,
+                                        field_names)
+
+            # We need to know what we can an cannot set and
+            # what fields need to go into the 'extra' Dynamic field
+            excluded_attributes = ['user_account',
+                                    'created_at',
+                                    'extra']
+
+            known_attributes = [attribute
+                for attribute in Contact.field_descriptors.keys()
+                if attribute not in excluded_attributes]
+
+            # It's a generator so loop over it and save as contacts
+            # in the contact_store, normalizing anything we need to
+            for counter, data_dictionary in enumerate(data_dictionaries):
+
+                # If we've determined that the first line of the file is
+                # a header then skip it.
+                if has_header and counter == 0:
+                    continue
+
+                # Make sure we set this group they're being uploaded in to
+                groups = data_dictionary.setdefault('groups', [])
+                groups.append(group.key)
+
+                # Make sure we normalize the msisdn before saving in the db
+                if 'msisdn' in data_dictionary:
+                    msisdn = data_dictionary['msisdn']
+                    normalized_msisdn = normalize_msisdn(msisdn,
+                        country_code=settings.VUMI_COUNTRY_CODE)
+                    data_dictionary.update({
+                        'msisdn': unicode(normalized_msisdn, 'utf-8')
+                    })
+
+                # Populate this with whatever we'll be sending to the
+                # contact to be saved
+                contact_dictionary = {}
+                for key, value in data_dictionary.items():
+                    if key in known_attributes:
+                        contact_dictionary[key] = value
+                    else:
+                        extra = contact_dictionary.setdefault('extra', {})
+                        extra[key] = value
+
+                print 'contact_dictionary', contact_dictionary
+                # contact_store.new_contact(**contact_dictionary)
+            messages.info(request,
+                '<strong>Success!</strong> %s contacts imported.' %
+                    (counter if has_header else counter + 1,))
+
+            _clear_file_hints_from_session(request)
+            return redirect(_group_url(group.key))
         else:
             upload_contacts_form = UploadContactsForm(request.POST,
                                                         request.FILES)
             if upload_contacts_form.is_valid():
-                try:
-                    contacts = list(_create_contacts_from_csv_file(
-                        contact_store, request.FILES['file'],
-                        settings.VUMI_COUNTRY_CODE))
+                file_object = upload_contacts_form.cleaned_data['file']
+                _store_file_hints_in_session(request,
+                    *_get_file_hints(file_object))
+                return redirect(_group_url(group.key))
 
-                    group.add_contacts(contacts)
-                    messages.info(request, '%s contacts added' % (
-                        len(contacts,)))
-                    return redirect(_group_url(group.key))
-                except ValueError:
-                    pass
-
-            messages.error(request, 'Something is wrong with the '
-                                    'file you have uploaded')
     context = {
         'group': group,
         'country_code': settings.VUMI_COUNTRY_CODE,
-        }
+    }
+
+    if 'clear-upload' in request.GET:
+        # FIXME this is a debug statement
+        del request.session['uploaded_csv_data']
+
+    if _has_uncompleted_csv_import(request):
+        csv_path, csv_data = _get_file_hints_from_session(request)
+        has_header, headers, row = _guess_headers_and_row(csv_data)
+        context.update({
+            'csv_data_headers': headers,
+            'csv_data_row': row,
+        })
 
     if ':' in request.GET.get('q', ''):
         query = request.GET['q']
@@ -159,38 +306,29 @@ def people(request):
         # from them for attaching to a group later
         upload_contacts_form = UploadContactsForm(request.POST, request.FILES)
         if upload_contacts_form.is_valid():
-            try:
-                contacts = _create_contacts_from_csv_file(
-                    contact_store, request.FILES['file'],
-                    settings.VUMI_COUNTRY_CODE)
-                group = None
+            # We could be creating a new contact group.
+            if request.POST.get('name'):
+                new_group_form = NewContactGroupForm(request.POST)
+                if new_group_form.is_valid():
+                    group = contact_store.new_group(
+                        new_group_form.cleaned_data['name'])
 
-                # We could be creating a new contact group.
-                if request.POST.get('name'):
-                    new_group_form = NewContactGroupForm(request.POST)
-                    if new_group_form.is_valid():
-                        group = contact_store.new_group(
-                            new_group_form.cleaned_data['name'])
+            # We could be using an existing contact group.
+            if request.POST.get('contact_group'):
+                select_group_form = SelectContactGroupForm(
+                    request.POST, groups=contact_store.list_groups())
+                if select_group_form.is_valid():
+                    group = contact_store.get_group(
+                        select_group_form.cleaned_data['contact_group'])
 
-                # We could be using an existing contact group.
-                if request.POST.get('contact_group'):
-                    select_group_form = SelectContactGroupForm(
-                        request.POST, groups=contact_store.list_groups())
-                    if select_group_form.is_valid():
-                        group = contact_store.get_group(
-                            select_group_form.cleaned_data['contact_group'])
-
-                if group is not None:
-                    group.add_contacts(contacts)
-                    return redirect(_group_url(group.key))
-                else:
-                    messages.error(request, 'Please select a group or provide '
-                        'a new group name.')
-            except UnicodeDecodeError:
-                messages.error(request, 'Something went wrong trying to read '
-                    'the information from your CSV file. '
-                    'Make sure it is saved using the UTF-8 encoding')
-
+            if group is None:
+                messages.error(request, 'Please select a group or provide '
+                    'a new group name.')
+            else:
+                file_object = upload_contacts_form.cleaned_data['file']
+                _store_file_hints_in_session(request,
+                    *_get_file_hints(file_object))
+                return redirect(_group_url(group.key))
         else:
             messages.error(request, 'Something went wrong with the upload.')
     else:

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -178,7 +178,7 @@ def _has_uncompleted_csv_import(request):
         and ('uploaded_csv_path' in request.session))
 
 
-def _import_csv_file(csv_path, field_names, has_header):
+def _import_csv_file(group, csv_path, field_names, has_header):
     full_path = os.path.join(settings.MEDIA_ROOT, csv_path)
     # open in Universal mode to allow us to reed files with Windows,
     # MacOS9 & Unix line-endings
@@ -258,7 +258,7 @@ def group(request, group_key):
                 field_names = [request.POST.get('column-%s' % i) for i in
                                 range(len(sample_row))]
 
-                for csv_data in _import_csv_file(csv_path, field_names,
+                for csv_data in _import_csv_file(group, csv_path, field_names,
                                                     has_header):
                     [count, contact_dictionary, dynamic_fields] = csv_data
                     contact = contact_store.new_contact(**contact_dictionary)

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -222,15 +222,14 @@ def _import_csv_file(group, csv_path, field_names, has_header):
         # Populate this with whatever we'll be sending to the
         # contact to be saved
         contact_dictionary = {}
-        dynamic_fields = {}
         for key, value in data_dictionary.items():
             if key in known_attributes:
                 contact_dictionary[key] = value
             else:
-                dynamic_fields[key] = value
+                extra = contact_dictionary.setdefault('extra', {})
+                extra[key] = value
 
-        yield ((counter if has_header else counter + 1),
-                contact_dictionary, dynamic_fields)
+        yield (counter if has_header else counter + 1, contact_dictionary)
 
 
 @login_required
@@ -261,10 +260,8 @@ def group(request, group_key):
 
                 for csv_data in _import_csv_file(group, csv_path, field_names,
                                                     has_header):
-                    [count, contact_dictionary, dynamic_fields] = csv_data
-                    contact = contact_store.new_contact(**contact_dictionary)
-                    contact.extra.update(dynamic_fields)
-                    contact.save()
+                    [count, contact_dictionary] = csv_data
+                    contact_store.new_contact(**contact_dictionary)
 
                 messages.info(request,
                     'Success! %s contacts imported.' % (

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -366,7 +366,7 @@ def person(request, person_key):
     if contact is None:
         raise Http404
     groups = contact_store.list_groups()
-    if request.POST:
+    if request.method == 'POST':
         form = ContactForm(request.POST, groups=groups)
         if form.is_valid():
             for k, v in form.cleaned_data.items():
@@ -399,6 +399,7 @@ def person(request, person_key):
 
     return render(request, 'contacts/person.html', {
         'contact': contact,
+        'contact_extra_items': contact.extra.items(),
         'form': form,
         'country_code': settings.VUMI_COUNTRY_CODE,
     })

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -135,11 +135,10 @@ def _guess_headers_and_row(csv_data):
         SortedDict([(column, None) for column in first_row]))
 
 
-def _get_file_hints(file_object):
+def _get_file_hints(content_file):
     # Save the file object temporarily so we can present
     # some UI to help the user figure out which columns are
     # what of what type.
-    content_file = ContentFile(file_object.read())
     temp_file_name = uuid.uuid4().hex
     temp_file_path = default_storage.save(os.path.join('tmp',
         '%s.csv' % (temp_file_name,)), content_file)

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -127,8 +127,8 @@ def _guess_headers_and_row(csv_data):
     }
 
     if _is_header_row(first_row):
+        sample_row = SortedDict(zip(second_row, first_row))
         for column in first_row:
-            sample_row = SortedDict(zip(second_row, first_row))
             default_headers.setdefault(column, column)
         return True, default_headers, sample_row
     return (False, default_headers,

--- a/go/vumitools/contact.py
+++ b/go/vumitools/contact.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from twisted.internet.defer import returnValue
 
 from vumi.persist.model import Model, Manager
-from vumi.persist.fields import Unicode, ManyToMany, ForeignKey, Timestamp
+from vumi.persist.fields import (Unicode, ManyToMany, ForeignKey, Timestamp,
+                                    Dynamic)
 
 from go.vumitools.account import UserAccount, PerAccountStore
 
@@ -43,6 +44,7 @@ class Contact(Model):
     gtalk_id = Unicode(null=True)
     created_at = Timestamp(default=datetime.utcnow)
     groups = ManyToMany(ContactGroup)
+    extra = Dynamic()
 
     def add_to_group(self, group):
         if isinstance(group, ContactGroup):
@@ -85,15 +87,14 @@ class ContactStore(PerAccountStore):
         self.groups = self.manager.proxy(ContactGroup)
 
     @Manager.calls_manager
-    def new_contact(self, name, surname, **fields):
+    def new_contact(self, **fields):
         contact_id = uuid4().get_hex()
 
         # These are foreign keys.
         groups = fields.pop('groups', [])
 
         contact = self.contacts(
-            contact_id, user_account=self.user_account_key, name=name,
-            surname=surname, **fields)
+            contact_id, user_account=self.user_account_key, **fields)
         for group in groups:
             contact.add_to_group(group)
 


### PR DESCRIPTION
does somewhat intelligent guessing about whether or not a CSV file has a
header row. If it does it respects it, if it doesn't the user will need
to specify what's what.

Added a `extra` Dynamic field to Contact model to allow us to store the
keys that aren't specified explicitly on the model. The Contact page now
shows these fields are read-only text input-fields. That'll change
later.
