### PR TITLE
Write results of surveys to a contact as dynamic attributes

### DIFF
--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -220,7 +220,10 @@ class TestSurveyApplication(ApplicationTestCase, CeleryTestMixIn):
             response = str(questions[i]['valid_responses'][0])
             yield self.reply_to(msg, response)
 
-        last_msg = self.get_dispatched_messages()[-1]
+        expected_replies = 1 + len(questions)
+        all_messages = (yield self.wait_for_messages(expected_replies,
+                                                        expected_replies))
+        last_msg = all_messages[-1]
         self.assertEqual(last_msg['content'],
             'Thanks for completing the survey')
         self.assertEqual(last_msg['session_event'],

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -236,15 +236,3 @@ class TestSurveyApplication(ApplicationTestCase, CeleryTestMixIn):
         self.create_survey(self.conversation)
         yield self.conversation.start()
         yield self.complete_survey(self.default_questions)
-
-    @inlineCallbacks
-    def test_surveys_in_succession(self):
-        yield self.create_contact(u'First', u'Contact',
-            msisdn=u'27831234567', groups=[self.group])
-        self.create_survey(self.conversation)
-        yield self.conversation.start()
-        for i in range(3):
-            last_msg = yield self.complete_survey(self.default_questions,
-                start_at=(i * len(self.default_questions)))
-            # any input will restart the survey
-            yield self.reply_to(last_msg, 'hi')

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -220,9 +220,8 @@ class TestSurveyApplication(ApplicationTestCase, CeleryTestMixIn):
             response = str(questions[i]['valid_responses'][0])
             yield self.reply_to(msg, response)
 
-        expected_replies = 1 + len(questions)
-        all_messages = (yield self.wait_for_messages(expected_replies,
-                                                        expected_replies))
+        nr_of_messages = 1 + len(questions) + start_at
+        all_messages = yield self.wait_for_dispatched_messages(nr_of_messages)
         last_msg = all_messages[-1]
         self.assertEqual(last_msg['content'],
             'Thanks for completing the survey')


### PR DESCRIPTION
Does this on session end. When a new message arrives, any previous
dynamic attributes are saved to the participant before the poll starts
working on that state. Allows for things like global per-account
variables for contacts for things like opt-ins. Does not protect the
user from stomping on previously set variables.
