### PR TITLE
Opt-out middleware and GoAppRouter refactor

### DIFF
--- a/config/application_message_dispatcher.yaml
+++ b/config/application_message_dispatcher.yaml
@@ -1,13 +1,42 @@
-message_store:
+message_store: &MESSAGE_STORE
     store_prefix: vumigo.
+
 transport_names:
   - vumigo_router
 exposed_names:
   - bulk_message_transport
   - survey_transport
   - multi_survey_transport
+  - account_opt_out_transport
+
 router_class: go.vumitools.api_worker.GoApplicationRouter
 conversation_mappings:
     survey: survey_transport
     multi_survey: multi_survey_transport
     bulk_message: bulk_message_transport
+
+# NOTE: the order is important
+middleware:
+  - tagging_middleware: vumi.middleware.TaggingMiddleware
+  - account_middleware: go.vumitools.middleware.LookupAccountMiddleware
+  - batch_middleware: go.vumitools.middleware.LookupBatchMiddleware
+  - conversation_middleware: go.vumitools.middleware.LookupConversationMiddleware
+  - debit_middleware: go.vumitools.middleware.DebitAccountMiddleware
+  - opt_out_middleware: go.vumitools.middleware.OptOutMiddleware
+  - storing_middleware: vumi.middleware.StoringMiddleware
+
+tagging_middleware:
+  message_store: *MESSAGE_STORE
+account_middleware:
+  message_store: *MESSAGE_STORE
+batch_middleware:
+  message_store: *MESSAGE_STORE
+conversation_middleware:
+  message_store: *MESSAGE_STORE
+debit_middleware:
+  message_store: *MESSAGE_STORE
+storing_middleware:
+  message_store: *MESSAGE_STORE
+opt_out_middleware:
+  transport_name: account_opt_out_transport
+  message_store: *MESSAGE_STORE

--- a/config/application_message_dispatcher.yaml
+++ b/config/application_message_dispatcher.yaml
@@ -7,7 +7,10 @@ exposed_names:
   - bulk_message_transport
   - survey_transport
   - multi_survey_transport
-  - account_opt_out_transport
+  - optout_transport
+
+upstream_transport: vumigo_router
+optout_transport: optout_transport
 
 router_class: go.vumitools.api_worker.GoApplicationRouter
 conversation_mappings:
@@ -22,7 +25,7 @@ middleware:
   - batch_middleware: go.vumitools.middleware.LookupBatchMiddleware
   - conversation_middleware: go.vumitools.middleware.LookupConversationMiddleware
   - debit_middleware: go.vumitools.middleware.DebitAccountMiddleware
-  - opt_out_middleware: go.vumitools.middleware.OptOutMiddleware
+  - optout_middleware: go.vumitools.middleware.OptOutMiddleware
   - storing_middleware: vumi.middleware.StoringMiddleware
 
 tagging_middleware:
@@ -37,6 +40,8 @@ debit_middleware:
   message_store: *MESSAGE_STORE
 storing_middleware:
   message_store: *MESSAGE_STORE
-opt_out_middleware:
-  transport_name: account_opt_out_transport
-  message_store: *MESSAGE_STORE
+optout_middleware:
+  keyword_separator: ' '
+  case_sensitive: False
+  optout_keywords:
+    - stop

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -93,7 +93,7 @@ class GoApplicationRouter(BaseDispatchRouter):
             publisher = self.dispatcher.exposed_publisher[application]
             yield publisher.publish_message(msg)
         else:
-            log.error('No application setup for type: %s' % (
+            log.error('No application setup for inbound message type: %s' % (
                         msg,))
 
     @inlineCallbacks
@@ -103,7 +103,7 @@ class GoApplicationRouter(BaseDispatchRouter):
             publisher = self.dispatcher.exposed_event_publisher[application]
             yield publisher.publish_message(msg)
         else:
-            log.error('No application setup for type: %s' % (
+            log.error('No application setup for inbount event type: %s' % (
                         msg,))
 
     def dispatch_outbound_message(self, msg):

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -15,7 +15,7 @@ from vumi import log
 from go.vumitools.api import VumiApiCommand, get_redis
 from go.vumitools.account import AccountStore
 from go.vumitools.conversation import ConversationStore
-from go.vumitools.middleware import DebitAccountMiddleware
+from go.vumitools.middleware import LookupConversationMiddleware
 
 
 class CommandDispatcher(ApplicationWorker):
@@ -82,70 +82,18 @@ class GoApplicationRouter(BaseDispatchRouter):
     def setup_routing(self):
         # map conversation types to applications that deal with them
         self.conversation_mappings = self.config['conversation_mappings']
-        # setup the message_store
-        mdb_config = self.config.get('message_store', {})
-        self.mdb_prefix = mdb_config.get('store_prefix', 'message_store')
-        r_server = get_redis(self.config)
-        self.manager = TxRiakManager.from_config({
-                'bucket_prefix': self.mdb_prefix})
-        self.account_store = AccountStore(self.manager)
-        self.message_store = MessageStore(self.manager, r_server,
-                                            self.mdb_prefix)
 
-    @inlineCallbacks
-    def get_conversation_for_tag(self, tag):
-        current_tag = yield self.message_store.get_tag_info(tag)
-        if current_tag:
-            batch = yield current_tag.current_batch.get()
-            if batch:
-                account_key = batch.metadata['user_account']
-                if account_key:
-                    conversation_store = ConversationStore(self.manager,
-                        account_key)
-                    account_submanager = conversation_store.manager
-                    all_conversations = yield batch.backlinks.conversations(
-                                                            account_submanager)
-                    conversations = [c for c in all_conversations if not
-                                        c.ended()]
-                    if conversations:
-                        if len(conversations) > 1:
-                            conv_keys = [c.key for c in conversations]
-                            log.warning('Multiple conversations found '
-                                'going with most recent: %r' % (conv_keys,))
-                        conversation = sorted(conversations, reverse=True,
-                            key=lambda c: c.start_timestamp)[0]
-                        returnValue(conversation)
-                    log.error('No conversations found for %r' % (batch,))
-                else:
-                    log.error('No account_key found for tag: %r, batch: %r' % (
-                        current_tag, batch))
-            else:
-                log.error("No batch found for tag: %r" % (current_tag,))
-        else:
-            log.error('Cannot find current tag for %s' % (tag,))
-
-    @inlineCallbacks
     def find_application_for_msg(self, msg):
-        tag = TaggingMiddleware.map_msg_to_tag(msg)
-        if tag:
-            conversation = yield self.get_conversation_for_tag(tag)
-            if conversation:
-                conv_type = conversation.conversation_type
-                DebitAccountMiddleware.add_user_to_message(msg,
-                        conversation.user_account.key)
-                metadata = msg['helper_metadata']
-                conv_metadata = metadata.setdefault('conversations', {})
-                conv_metadata.update({
-                    'conversation_key': conversation.key,
-                    'conversation_type': conv_type,
-                })
-                returnValue(self.conversation_mappings.get(conv_type))
+        # Sometimes I don't like pep8
+        helper = LookupConversationMiddleware.map_message_to_conversation_info
+        conversation_info = helper(msg)
+        if conversation_info:
+            conversation_key, conversation_type = conversation_info
+            return self.conversation_mappings[conversation_type]
 
     @inlineCallbacks
     def dispatch_inbound_message(self, msg):
-        tag = TaggingMiddleware.map_msg_to_tag(msg)
-        self.message_store.add_inbound_message(msg, tag=tag)
-        application = yield self.find_application_for_msg(msg)
+        application = self.find_application_for_msg(msg)
         if application:
             publisher = self.dispatcher.exposed_publisher[application]
             yield publisher.publish_message(msg)
@@ -153,9 +101,8 @@ class GoApplicationRouter(BaseDispatchRouter):
             log.error('No application setup for type: %s' % (
                         msg,))
 
+    @inlineCallbacks
     def dispatch_inbound_event(self, msg):
-        tag = TaggingMiddleware.map_msg_to_tag(msg)
-        self.message_store.add_event(msg, tag=tag)
         application = self.find_application_for_msg(msg)
         if application:
             publisher = self.dispatcher.exposed_event_publisher[application]
@@ -165,7 +112,5 @@ class GoApplicationRouter(BaseDispatchRouter):
                         msg,))
 
     def dispatch_outbound_message(self, msg):
-        tag = TaggingMiddleware.map_msg_to_tag(msg)
-        self.message_store.add_outbound_message(msg, tag=tag)
         upstream = self.dispatcher.transport_publisher.keys()[0]
         self.dispatcher.transport_publisher[upstream].publish_message(msg)

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -3,18 +3,13 @@
 
 """Vumi application worker for the vumitools API."""
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from vumi.application import ApplicationWorker
-from vumi.persist.message_store import MessageStore
-from vumi.persist.txriak_manager import TxRiakManager
 from vumi.dispatchers.base import BaseDispatchRouter
-from vumi.middleware.tagger import TaggingMiddleware
 from vumi import log
 
-from go.vumitools.api import VumiApiCommand, get_redis
-from go.vumitools.account import AccountStore
-from go.vumitools.conversation import ConversationStore
+from go.vumitools.api import VumiApiCommand
 from go.vumitools.middleware import LookupConversationMiddleware
 
 

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -234,8 +234,8 @@ class OptOutMiddleware(BaseMiddleware):
     def setup_middleware(self):
         self.keyword_separator = self.config.get('keyword_separator', ' ')
         self.case_sensitive = self.config.get('case_sensitive', False)
-        keywords = self.config.get('opt_out_keywords', [])
-        self.opt_out_keywords = set([self.casing(word)
+        keywords = self.config.get('optout_keywords', [])
+        self.optout_keywords = set([self.casing(word)
                                         for word in keywords])
 
     def casing(self, word):
@@ -244,15 +244,19 @@ class OptOutMiddleware(BaseMiddleware):
         return word
 
     def handle_inbound(self, message, endpoint):
-        content = message['content']
-        keyword, _, _ = content.partition(self.keyword_separator)
+        keyword = message['content'].strip()
         helper_metadata = message['helper_metadata']
         optout_metadata = helper_metadata.setdefault('optout', {})
-        if self.casing(keyword) in self.opt_out_keywords:
-            optout_metadata['opt_out'] = True
-            optout_metadata['opt_out_keyword'] = self.casing(keyword)
+        if self.casing(keyword) in self.optout_keywords:
+            optout_metadata['optout'] = True
+            optout_metadata['optout_keyword'] = self.casing(keyword)
         else:
-            optout_metadata['opt_out'] = False
+            optout_metadata['optout'] = False
+        return message
+
+    @staticmethod
+    def is_optout_message(message):
+        return message['helper_metadata'].setdefault('optout').get('optout')
 
 
 class DebitAccountMiddleware(TransportMiddleware):

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -119,6 +119,8 @@ class LookupAccountMiddleware(GoApplicationRouterMiddleware):
 
     @inlineCallbacks
     def find_account_key_for_message(self, message):
+        # NOTE: there is probably a better way of doing this when given a
+        #       batch key but I'm not seeing it right now.
         tag = TaggingMiddleware.map_msg_to_tag(message)
         if tag:
             current_tag = yield self.message_store.get_tag_info(tag)

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -1,11 +1,19 @@
 # -*- test-case-name: go.vumitools.tests.test_middleware -*-
 import sys
 
-from vumi.middleware import TransportMiddleware, TaggingMiddleware
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+from vumi.middleware import (TransportMiddleware, TaggingMiddleware,
+                                BaseMiddleware)
 from vumi.application import TagpoolManager
 from vumi.utils import normalize_msisdn
+from vumi.persist.txriak_manager import TxRiakManager
+from vumi.persist.message_store import MessageStore
+from vumi import log
 
 from go.vumitools.credit import CreditManager
+from go.vumitools.account import AccountStore
+from go.vumitools.conversation import ConversationStore
 
 
 class NormalizeMsisdnMiddleware(TransportMiddleware):
@@ -40,6 +48,178 @@ class BadTagPool(DebitAccountError):
 class InsufficientCredit(DebitAccountError):
     """Account could not be debited because the user account has
        insufficient credit."""
+
+
+class GoApplicationRouterMiddleware(BaseMiddleware):
+    """
+    Base class for middlewares used by dispatchers using the
+    `GoApplicationRouter`. It configures the `account_store` and the
+    `message_store`.
+
+    :type message_store: dict
+    :param message_store:
+        Dictionary containing the following values:
+
+        *store_prefix*: the store prefix, defaults to 'message_store'
+
+    :type redis: dict
+    :param redis:
+        Dictionary containing the configuration parameters for connecting
+        to Redis with. Passed along as **kwargs to the Redis client.
+
+    """
+    def setup_middleware(self):
+        from go.vumitools.api import get_redis
+        r_server = get_redis(self.config)
+
+        mdb_config = self.config.get('message_store', {})
+        self.mdb_prefix = mdb_config.get('store_prefix', 'message_store')
+        r_server = get_redis(self.config)
+        self.manager = TxRiakManager.from_config({
+                'bucket_prefix': self.mdb_prefix})
+        self.account_store = AccountStore(self.manager)
+        self.message_store = MessageStore(self.manager, r_server,
+                                            self.mdb_prefix)
+
+    def add_metadata_to_message(self, message):
+        """
+        Subclasses should override this method to appropriately set values
+        on a message's `helper_metadata`. If specific message types or
+        directions require different behaviour they can be overridden
+        separately.
+        """
+        raise NotImplementedError("add_metadata_to_message should be "
+                                    "implemented by the subclass")
+
+    @inlineCallbacks
+    def dispatch_inbound_message(self, message):
+        yield self.add_metadata_to_message(message)
+
+    @inlineCallbacks
+    def dispatch_inbound_event(self, event):
+        yield self.add_metadata_to_message(event)
+
+    @inlineCallbacks
+    def dispatch_outbound_message(self, message):
+        yield self.add_metadata_to_message(message)
+
+
+class LookupAccountMiddleware(GoApplicationRouterMiddleware):
+    """
+    Look up the account_key for a given message by retrieving
+    this from the message tag's info.
+
+    *NOTE*  This requires the `TaggingMiddleware` to be configured and placed
+            before this middleware for this to work as it expects certain
+            values to be set in the `helper_metadata`
+    """
+
+    @inlineCallbacks
+    def find_account_key_for_message(self, message):
+        tag = TaggingMiddleware.map_msg_to_tag(message)
+        current_tag = yield self.message_store.get_tag_info(tag)
+        if current_tag:
+            batch = yield current_tag.current_batch.get()
+            if batch:
+                returnValue(batch.metadata.get('user_account', None))
+
+    @inlineCallbacks
+    def add_metadata_to_message(self, message):
+        account_key = yield self.find_account_key_for_message(message)
+        if account_key:
+            helper_metadata = message.setdefault('helper_metadata', {})
+            go_metadata = helper_metadata.setdefault('go', {})
+            go_metadata['user_account'] = account_key
+
+    @staticmethod
+    def map_message_to_account_key(message):
+        go_metadata = message.setdefault('helper_metadata').setdefault('go')
+        return go_metadata.get('user_account')
+
+
+class LookupBatchMiddleware(GoApplicationRouterMiddleware):
+    """
+    Look up a `batch_key` by inspecting the tag for a given message.
+
+    *NOTE*  This requires the `TaggingMiddleware` to be configured and placed
+            before this middleware to ensure that the appropriate tagging
+            values are set in the `helper_metadata`
+    """
+
+    @inlineCallbacks
+    def find_batch_for_message(self, message):
+        tag = TaggingMiddleware.map_msg_to_tag(message)
+        current_tag = yield self.message_store.get_tag_info(tag)
+        if current_tag:
+            batch = yield current_tag.current_batch.get()
+            returnValue(batch)
+
+    @inlineCallbacks
+    def add_metadata_to_message(self, message):
+        batch = yield self.find_batch_for_message(message)
+        if batch:
+            helper_metadata = message.setdefault('helper_metadata', {})
+            go_metadata = helper_metadata.setdefault('go', {})
+            go_metadata['batch_key'] = batch.key
+
+    @staticmethod
+    def map_message_to_batch_key(message):
+        go_metadata = message.get('helper_metadata', {}).get('go', {})
+        return go_metadata.get('batch_key')
+
+
+class LookupConversationMiddleware(GoApplicationRouterMiddleware):
+    """
+    Look up a conversation based on the `account_key` and `batch_key` that
+    have been stored in the `helper_metadata` by the `LookupAccountMiddleware`
+    and the `LookupBatchMiddleware` middlewares.
+
+    *NOTE*  This middleware depends on the `LookupAccountMiddleware`,
+            `LookupBatchMiddleware` and the `TaggingMiddleware` being
+            configured and placed before this middleware to ensure that the
+            appropriate variables are set in the `helper_metadata`
+    """
+
+    @inlineCallbacks
+    def find_conversation_for_message(self, message):
+        account_key = LookupAccountMiddleware.map_message_to_account_key(
+                                                                    message)
+        batch_key = LookupBatchMiddleware.map_message_to_batch_key(message)
+        if account_key and batch_key:
+            conversation_store = ConversationStore(self.manager, account_key)
+            account_submanager = conversation_store.manager
+            batch = self.message_store.batches(batch_key)
+            all_conversations = yield batch.backlinks.conversations(
+                                                            account_submanager)
+            conversations = [c for c in all_conversations if not
+                                c.ended()]
+            if conversations:
+                if len(conversations) > 1:
+                    conv_keys = [c.key for c in conversations]
+                    log.warning('Multiple conversations found '
+                        'going with most recent: %r' % (conv_keys,))
+                conversation = sorted(conversations, reverse=True,
+                    key=lambda c: c.start_timestamp)[0]
+                returnValue(conversation)
+
+    @inlineCallbacks
+    def add_metadata_to_message(self, message):
+        conversation = yield self.find_conversation_for_message(message)
+        if conversation:
+            helper_metadata = message.setdefault('helper_metadata', {})
+            conv_metadata = helper_metadata.setdefault('conversations', {})
+            conv_metadata['conversation_key'] = conversation.key
+            conv_metadata['conversation_type'] = conversation.conversation_type
+
+    @staticmethod
+    def map_message_to_conversation_info(self, message):
+        helper_metadata = message.get('helper_metadata', {})
+        conv_metadata = helper_metadata.get('conversations', {})
+        if conv_metadata:
+            return (
+                conv_metadata['conversation_key'],
+                conv_metadata['conversation_type']
+            )
 
 
 class DebitAccountMiddleware(TransportMiddleware):

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -120,11 +120,12 @@ class LookupAccountMiddleware(GoApplicationRouterMiddleware):
     @inlineCallbacks
     def find_account_key_for_message(self, message):
         tag = TaggingMiddleware.map_msg_to_tag(message)
-        current_tag = yield self.message_store.get_tag_info(tag)
-        if current_tag:
-            batch = yield current_tag.current_batch.get()
-            if batch:
-                returnValue(batch.metadata['user_account'])
+        if tag:
+            current_tag = yield self.message_store.get_tag_info(tag)
+            if current_tag:
+                batch = yield current_tag.current_batch.get()
+                if batch:
+                    returnValue(batch.metadata['user_account'])
 
     @inlineCallbacks
     def add_metadata_to_message(self, message):
@@ -152,10 +153,11 @@ class LookupBatchMiddleware(GoApplicationRouterMiddleware):
     @inlineCallbacks
     def find_batch_for_message(self, message):
         tag = TaggingMiddleware.map_msg_to_tag(message)
-        current_tag = yield self.message_store.get_tag_info(tag)
-        if current_tag:
-            batch = yield current_tag.current_batch.get()
-            returnValue(batch)
+        if tag:
+            current_tag = yield self.message_store.get_tag_info(tag)
+            if current_tag:
+                batch = yield current_tag.current_batch.get()
+                returnValue(batch)
 
     @inlineCallbacks
     def add_metadata_to_message(self, message):

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -163,7 +163,5 @@ class GoApplicationRouterTestCase(DispatcherTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ('this', 'does not exist'))
         with LogCatcher() as log:
             yield self.dispatch(msg, self.transport_name)
-            [err1, err2] = log.errors
-            self.assertTrue('Cannot find current tag for' in
-                                    err1['message'][0])
-            self.assertTrue('No application setup' in err2['message'][0])
+            [error] = log.errors
+            self.assertTrue('No application setup' in error['message'][0])

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -177,7 +177,7 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         self.config = self.default_config.copy()
         self.config.update({
             'keyword_separator': '-',
-            'opt_out_keywords': ['STOP', 'HALT', 'QUIT']
+            'optout_keywords': ['STOP', 'HALT', 'QUIT']
         })
         self.mw = self.create_middleware(OptOutMiddleware, config=self.config)
 
@@ -190,11 +190,11 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
 
     @inlineCallbacks
     def test_optout_flag(self):
-        for keyword in self.config['opt_out_keywords']:
+        for keyword in self.config['optout_keywords']:
             yield self.send_keyword(self.mw, keyword, {
                 'optout': {
-                    'opt_out': True,
-                    'opt_out_keyword': keyword.lower(),
+                    'optout': True,
+                    'optout_keyword': keyword.lower(),
                 }
             })
 
@@ -203,7 +203,7 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         for keyword in ['THESE', 'DO', 'NOT', 'OPT', 'OUT']:
             yield self.send_keyword(self.mw, keyword, {
                 'optout': {
-                    'opt_out': False,
+                    'optout': False,
                 }
             })
 
@@ -217,13 +217,13 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
 
         yield self.send_keyword(mw, 'STOP', {
             'optout': {
-                'opt_out': True,
-                'opt_out_keyword': 'STOP',
+                'optout': True,
+                'optout_keyword': 'STOP',
             }
         })
 
         yield self.send_keyword(mw, 'stop', {
             'optout': {
-                'opt_out': False,
+                'optout': False,
             }
         })

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -1,26 +1,169 @@
 """Tests for go.vumitools.middleware"""
 
 from twisted.trial.unittest import TestCase
+from twisted.internet.defer import inlineCallbacks, returnValue
 
-from go.vumitools.middleware import NormalizeMsisdnMiddleware
+from vumi.persist.txriak_manager import TxRiakManager
+from vumi.persist.message_store import MessageStore
 from vumi.message import TransportUserMessage
+from vumi.tests.utils import FakeRedis
+from vumi.middleware import TaggingMiddleware
+
+from go.vumitools.account import AccountStore
+from go.vumitools.conversation import ConversationStore
+from go.vumitools.middleware import (NormalizeMsisdnMiddleware,
+    LookupAccountMiddleware, LookupBatchMiddleware,
+    LookupConversationMiddleware)
 
 
-class NormalizeMisdnMiddlewareTestCase(TestCase):
+class MiddlewareTestCase(TestCase):
 
+    @inlineCallbacks
     def setUp(self):
+        self.mdb_prefix = 'test_message_store'
+        self.default_config = {
+            'message_store': {
+                'store_prefix': self.mdb_prefix,
+            }
+        }
+        self.r_server = FakeRedis()
+
+        self.manager = TxRiakManager.from_config({
+                'bucket_prefix': self.mdb_prefix})
+        self.account_store = AccountStore(self.manager)
+        self.message_store = MessageStore(self.manager, self.r_server,
+                                            self.mdb_prefix)
+
+        self.account = yield self.account_store.new_user(u'user')
+        self.conversation_store = ConversationStore.from_user_account(
+                                                                self.account)
+        self.tag = ('xmpp', 'test1@xmpp.org')
+
+    @inlineCallbacks
+    def tearDown(self):
+        yield self.manager.purge_all()
+        yield super(MiddlewareTestCase, self).tearDown()
+
+    @inlineCallbacks
+    def create_conversation(self, conversation_type=u'bulk_message',
+        subject=u'subject', message=u'message'):
+        conversation = yield self.conversation_store.new_conversation(
+            conversation_type, subject, message)
+        returnValue(conversation)
+
+    @inlineCallbacks
+    def tag_conversation(self, conversation, tag):
+        batch_id = yield self.message_store.batch_start([tag],
+                            user_account=unicode(self.account.key))
+        conversation.batches.add_key(batch_id)
+        conversation.save()
+        returnValue(batch_id)
+
+    def create_middleware(self, middleware_class, name='dummy_middleware',
+                            config=None):
         dummy_worker = object()
-        self.mw = NormalizeMsisdnMiddleware('dummy_middleware', {
-            'country_code': '256'
-        }, dummy_worker)
-        self.mw.setup_middleware()
+        mw = middleware_class(name, config or self.default_config,
+                                dummy_worker)
+        mw.setup_middleware()
+        return mw
 
     def mk_msg(self, to_addr, from_addr):
         return TransportUserMessage(to_addr=to_addr, from_addr=from_addr,
                                    transport_name="dummy_endpoint",
                                    transport_type="dummy_transport_type")
 
+
+class NormalizeMisdnMiddlewareTestCase(MiddlewareTestCase):
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(NormalizeMisdnMiddlewareTestCase, self).setUp()
+        self.mw = self.create_middleware(NormalizeMsisdnMiddleware, config={
+            'country_code': '256'
+        })
+
     def test_normalization(self):
         msg = self.mk_msg(to_addr='8007', from_addr='256123456789')
         msg = self.mw.handle_inbound(msg, 'dummy_endpoint')
         self.assertEqual(msg['from_addr'], '+256123456789')
+
+
+class LookupAccountMiddlewareTestCase(MiddlewareTestCase):
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(LookupAccountMiddlewareTestCase, self).setUp()
+        conversation = yield self.create_conversation()
+        yield self.tag_conversation(conversation, self.tag)
+        self.mw = self.create_middleware(LookupAccountMiddleware)
+
+    @inlineCallbacks
+    def test_account_lookup(self):
+        msg = self.mk_msg('to@domain.org', 'from@domain.org')
+        TaggingMiddleware.add_tag_to_msg(msg, self.tag)
+        yield self.mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['helper_metadata'], {
+            'tag': {
+                'tag': list(self.tag),
+            },
+            'go': {
+                'user_account': self.account.key,
+            }
+        })
+
+
+class LookupBatchMiddlewareTestCase(MiddlewareTestCase):
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(LookupBatchMiddlewareTestCase, self).setUp()
+        self.mw = self.create_middleware(LookupBatchMiddleware)
+
+    @inlineCallbacks
+    def test_batch_lookup(self):
+        conversation = yield self.create_conversation()
+        batch_id = yield self.tag_conversation(conversation, self.tag)
+        msg = self.mk_msg('to@domain.org', 'from@domain.org')
+        TaggingMiddleware.add_tag_to_msg(msg, self.tag)
+        yield self.mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['helper_metadata'], {
+            'go': {
+                'batch_key': batch_id,
+            },
+            'tag': {
+                'tag': list(self.tag),
+            }
+        })
+
+
+class LookupConversationMiddlewareTestCase(MiddlewareTestCase):
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(LookupConversationMiddlewareTestCase, self).setUp()
+        self.account_mw = self.create_middleware(LookupAccountMiddleware)
+        self.batch_mw = self.create_middleware(LookupBatchMiddleware)
+        self.conv_mw = self.create_middleware(LookupConversationMiddleware)
+
+    @inlineCallbacks
+    def test_conversation_lookup(self):
+        conversation = yield self.create_conversation()
+        batch_id = yield self.tag_conversation(conversation, self.tag)
+        msg = self.mk_msg('to@domain.org', 'from@domain.org')
+        TaggingMiddleware.add_tag_to_msg(msg, self.tag)
+        yield self.account_mw.handle_inbound(msg, 'dummy_endpoint')
+        yield self.batch_mw.handle_inbound(msg, 'dummy_endpoint')
+        yield self.conv_mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['helper_metadata'], {
+            'go': {
+                'batch_key': batch_id,
+                'user_account': self.account.key,
+            },
+            'tag': {
+                'tag': list(self.tag),
+            },
+            'conversations': {
+                'conversation_key': conversation.key,
+                'conversation_type': conversation.conversation_type,
+            }
+        })


### PR DESCRIPTION
A lot of the functionality provided by the GoApplicationRouter has now
been moved to middlewares so they can be moved around our stack easier.

An opt-out middleware has been added and the GoAppRouter routes to the
optout_transport if it detects a message with an optout flag set.

I'm pretty sure there's something I can do better in the
LookupAccountMiddleware when given a batch_id but I'm not seeing it at
the moment. Both the LookupAccountMiddleware and the
LookupBatchMiddleware first get the current_tag stuff which seems
redundant.
