### PR TITLE
Display opt-out status on contact page.

### DIFF
--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -423,6 +423,9 @@ def person(request, person_key):
             'groups': [group.key for group in contact.groups.get_all()],
         })
 
+    if contact_store.contact_has_opted_out(contact):
+        messages.error(request, 'This contact has opted out.')
+
     return render(request, 'contacts/person.html', {
         'contact': contact,
         'contact_extra_items': contact.extra.items(),

--- a/go/vumitools/contact.py
+++ b/go/vumitools/contact.py
@@ -136,6 +136,22 @@ class ContactStore(PerAccountStore):
         returnValue(sorted(groups, key=lambda group: group.name))
 
     @Manager.calls_manager
+    def contact_has_opted_out(self, contact):
+        # FIXME:    Need to import this to make sure the backlinks are created
+        #           even though it isn't used directly.
+        from go.vumitools.opt_out import OptOutStore
+
+        # FIXME:    opt-outs are currently had coded to only work for msisdns
+        if not contact.msisdn:
+            return
+
+        user_account = yield self.get_user_account()
+        optouts = yield user_account.backlinks.optouts(manager=contact.manager)
+        optout_addrs = [optout.key.split(':', 1)[1] for optout in optouts
+                        if optout.key.startswith('msisdn:')]
+        returnValue(contact.msisdn in optout_addrs)
+
+    @Manager.calls_manager
     def contact_for_addr(self, delivery_class, addr):
         if delivery_class in ('sms', 'ussd'):
             addr = '+' + addr.lstrip('+')

--- a/go/vumitools/conversation.py
+++ b/go/vumitools/conversation.py
@@ -105,8 +105,8 @@ class Conversation(Model):
         *NOTE*  This is a work around because it is currently not possible
                 to get back to the parents manager.
         """
-        # Need to import this to make sure the backlinks are created even
-        # though it isn't used directly.
+        # FIXME:    Need to import this to make sure the backlinks are created
+        #           even though it isn't used directly.
         from go.vumitools.opt_out import OptOutStore
         optouts = yield user_account.backlinks.optouts(manager=self.manager)
         optout_addrs = [optout.key.split(':', 1)[1] for optout in optouts


### PR DESCRIPTION
Implemented via a `contact_has_opted_out(contact)` function on the
ContactStore.
