### PR TITLE
Adding a checkbox that gives the option of de-duping to_addrs

### DIFF
--- a/go/apps/bulk_message/templates/bulk_message/send.html
+++ b/go/apps/bulk_message/templates/bulk_message/send.html
@@ -70,8 +70,16 @@
                     </tbody>
                 </table>
                 <div class="btn-toolbar">
-                    <div class="btn-group"><input type="submit" class="btn btn-success btn-large" value="Send Message &rarr;"></div>
+                    <div class="btn-group">
+                        <input type="submit" class="btn btn-success btn-large" value="Send Message &rarr;">
+                    </div>
                     <div class="btn-group"><input type="reset" class="btn" onClick="javascript:history.go(-1)" value="Go Back"></div>
+                    <div class="btn-group">
+                        <label class="checkbox">
+                            <input type="checkbox" value="1" name="dedupe" />
+                            Filter out duplicates from groups
+                        </label>
+                    </div>
                     <!--
                     <div class="btn-group"><input type="reset" class="btn" value="Cancel"></div>
                     -->

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -32,14 +32,14 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.conv_store = self.user_api.conversation_store
 
         # We need a group
-        group = self.contact_store.new_group(TEST_GROUP_NAME)
-        self.group_key = group.key
+        self.group = self.contact_store.new_group(TEST_GROUP_NAME)
+        self.group_key = self.group.key
 
         # Also a contact
         contact = self.contact_store.new_contact(
             name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
             msisdn=u"+27761234567")
-        contact.add_to_group(group)
+        contact.add_to_group(self.group)
         contact.save()
         self.contact_key = contact.key
 
@@ -145,6 +145,23 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             is_client_initiated=conversation.is_client_initiated(),
             )
         self.assertEqual(cmd, expected_cmd)
+
+    def test_start_with_deduplication(self):
+        conversation = self.get_wrapped_conv()
+        self.client.post(reverse('bulk_message:send', kwargs={
+            'conversation_key': conversation.key}), {
+            'dedupe': '1'
+        })
+        [cmd] = self.get_api_commands_sent()
+        self.assertEqual(cmd.payload['kwargs']['dedupe'], True)
+
+    def test_start_without_deduplication(self):
+        conversation = self.get_wrapped_conv()
+        self.client.post(reverse('bulk_message:send', kwargs={
+            'conversation_key': conversation.key}), {
+        })
+        [cmd] = self.get_api_commands_sent()
+        self.assertEqual(cmd.payload['kwargs']['dedupe'], False)
 
     def test_send_fails(self):
         """

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -99,6 +99,51 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         self.assertEqual(dbmsg2, msg2)
 
     @inlineCallbacks
+    def test_start_with_deduplication(self):
+        user_account = yield self.account_store.new_user(u'testuser')
+        user_api = VumiUserApi(user_account.key, {
+                'redis_cls': lambda **kw: self._fake_redis,
+                'riak_manager': {'bucket_prefix': 'test.'},
+                }, TxRiakManager)
+        user_api.api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
+        user_api.api.set_pool_metadata("pool", {
+            "transport_type": "sphex",
+            })
+        group = yield user_api.contact_store.new_group(u'test group')
+
+        # Create two contacts with the same to_addr, they should be deduped
+
+        contact1 = yield user_api.contact_store.new_contact(
+            name=u'First', surname=u'Contact', msisdn=u'27831234567',
+            groups=[group])
+        contact2 = yield user_api.contact_store.new_contact(
+            name=u'Second', surname=u'Contact', msisdn=u'27831234567',
+            groups=[group])
+        conversation = yield user_api.new_conversation(
+            u'bulk_message', u'Subject', u'Message', delivery_tag_pool=u"pool",
+            delivery_class=u'sms')
+        conversation.add_group(group)
+        yield conversation.save()
+        conversation = user_api.wrap_conversation(conversation)
+
+        # Provide the dedupe option to the conversation
+        yield conversation.start(dedupe=True)
+        yield self._amqp.kick_delivery()
+
+        # assert that we've sent the message to the two contacts
+        msgs = yield self.get_dispatched_messages()
+        msgs.sort(key=lambda msg: msg['to_addr'])
+
+        # Make sure only 1 message is sent, the rest were duplicates to the
+        # same to_addr and were filtered out as a result.
+        [msg] = msgs
+
+        # check that the right to_addr & from_addr are set and that the content
+        # of the message equals conversation.message
+        self.assertEqual(msg['to_addr'], contact1.msisdn)
+        self.assertEqual(msg['to_addr'], contact2.msisdn)
+
+    @inlineCallbacks
     def test_consume_ack(self):
         yield self.store_outbound(message_id='123')
         ack_event = yield self.publish_event(user_message_id='123',

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -100,19 +100,15 @@ class TestBulkMessageApplication(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_start_with_deduplication(self):
-        user_account = yield self.account_store.new_user(u'testuser')
-        user_api = VumiUserApi(user_account.key, {
-                'redis_cls': lambda **kw: self._fake_redis,
-                'riak_manager': {'bucket_prefix': 'test.'},
-                }, TxRiakManager)
-        user_api.api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
-        user_api.api.set_pool_metadata("pool", {
+        user_api = yield VumiUserApi.from_config_async(
+            self.user_account.key, self.config)
+        yield user_api.api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
+        yield user_api.api.set_pool_metadata("pool", {
             "transport_type": "sphex",
             })
         group = yield user_api.contact_store.new_group(u'test group')
 
-        # Create two contacts with the same to_addr, they should be deduped
-
+        # These contacts have the same to_addr and will be deduped
         contact1 = yield user_api.contact_store.new_contact(
             name=u'First', surname=u'Contact', msisdn=u'27831234567',
             groups=[group])
@@ -130,13 +126,9 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         yield conversation.start(dedupe=True)
         yield self._amqp.kick_delivery()
 
-        # assert that we've sent the message to the two contacts
-        msgs = yield self.get_dispatched_messages()
-        msgs.sort(key=lambda msg: msg['to_addr'])
-
         # Make sure only 1 message is sent, the rest were duplicates to the
         # same to_addr and were filtered out as a result.
-        [msg] = msgs
+        [msg] = yield self.get_dispatched_messages()
 
         # check that the right to_addr & from_addr are set and that the content
         # of the message equals conversation.message

--- a/go/apps/bulk_message/views.py
+++ b/go/apps/bulk_message/views.py
@@ -92,7 +92,7 @@ def send(request, conversation_key):
 
     if request.method == 'POST':
         try:
-            conversation.start()
+            conversation.start(dedupe=(request.POST.get('dedupe') == '1'))
         except ConversationSendError as error:
             messages.add_message(request, messages.ERROR, str(error))
             return redirect(reverse('bulk_message:send', kwargs={

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -37,6 +37,8 @@ class BulkMessageApplication(GoApplicationWorker):
         conv = yield self.get_conversation(batch_id, conversation_key)
 
         to_addresses = yield conv.get_opted_in_addresses()
+        if extra_params.get('dedupe') == True:
+            to_addresses = set(to_addresses)
         for to_addr in to_addresses:
             yield self.send_message(batch_id, to_addr,
                                     conv.message, msg_options)


### PR DESCRIPTION
By default it'll send a message to everyone in each group, regardless of
whether someone is in both groups. This option prevents people in both
groups receiving the text message twice.
