### PR TITLE
Tiny UI change

### DIFF
--- a/go/base/context_processors.py
+++ b/go/base/context_processors.py
@@ -28,6 +28,6 @@ def credit(request):
         profile = request.user.get_profile()
         api = request.user_api.api
         return {
-            'account_credits': api.cm.get_credit(profile.user_account),
+            'account_credits': api.cm.get_credit(profile.user_account) or 0,
         }
     return {}


### PR DESCRIPTION
the CreditManager returns `None` if there's no set credit. Which is
think is correct since `None` is not the same as `0` credit.

The change is in the context_processor to display 0 nonetheless.
