### PR TITLE
Update the survey_completed event to include participant data

### DIFF
--- a/go/apps/afropinions/handlers.py
+++ b/go/apps/afropinions/handlers.py
@@ -40,9 +40,12 @@ class YoPaymentHandler(EventHandler):
 
         """
 
+        participant = event['content']['participant']
+        interactions = int(participant['interactions'])
+        amount = interactions * int(self.amount)
         request_params = {
             'msisdn': event['content']['from_addr'],
-            'amount': self.amount,
+            'amount': amount,
             'reason': self.reason,
         }
 

--- a/go/apps/afropinions/test_handlers.py
+++ b/go/apps/afropinions/test_handlers.py
@@ -35,7 +35,9 @@ class YoPaymentHandlerTestCase(EventHandlerTestCase):
             'from_addr': msisdn,
             'message_id': message_id,
             'transport_type': 'ussd',
-            }, conv_key=self.conversation.key, account_key=self.account.key)
+            'participant': {
+                'interactions': 2,
+            }}, conv_key=self.conversation.key, account_key=self.account.key)
 
 
         self.mock_server = MockHttpServer()
@@ -47,7 +49,7 @@ class YoPaymentHandlerTestCase(EventHandlerTestCase):
         yield self.publish_event(event)
         received_request = yield self.mock_server.queue.get()
         self.assertEqual(received_request.args['msisdn'][0], msisdn)
-        self.assertEqual(received_request.args['amount'][0], '1000')
+        self.assertEqual(received_request.args['amount'][0], '2000')
         self.assertEqual(received_request.args['reason'][0], 'foo')
 
         headers = received_request.requestHeaders

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -117,6 +117,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             'from_addr': message['from_addr'],
             'message_id': message['message_id'],
             'transport_type': message['transport_type'],
+            'participant': participant.dump(),
         })
         super(SurveyApplication, self).end_session(participant, poll, message)
 


### PR DESCRIPTION
Participant data is passed along with the event. The number of
interactions (and other information) might be relevant to the event
handler. This allows us to update the Afrop handler to refund users with
airtime for the number of messages sent.
