### PR TITLE
Removing go/settings.py reliance on poll.yaml

### DIFF
--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -25,8 +25,6 @@ def get_poll_config(poll_id):
     config = pm.get_config(poll_id)
     config.update({
         'poll_id': poll_id,
-        'transport_name': settings.VXPOLLS_TRANSPORT_NAME,
-        'worker_name': settings.VXPOLLS_WORKER_NAME,
     })
 
     config.setdefault('repeatable', True)

--- a/go/settings.py
+++ b/go/settings.py
@@ -245,13 +245,7 @@ VUMI_INSTALLED_APPS = {
 }
 
 VXPOLLS_REDIS_CONFIG = {}
-VXPOLLS_PREFIX = 'vumigo.'
-VXPOLLS_CONFIG_PATH = join(PROJECT_ROOT, '..', 'config', 'poll.yaml')
-VXPOLLS_CONFIG = yaml.load(open(VXPOLLS_CONFIG_PATH, 'r'))
-VXPOLLS_QUESTIONS = VXPOLLS_CONFIG.get('questions', [])
-VXPOLLS_POLL_ID = VXPOLLS_CONFIG.get('poll_id')
-VXPOLLS_TRANSPORT_NAME = 'vxpolls_transport'
-VXPOLLS_WORKER_NAME = 'vxpolls_worker'
+VXPOLLS_PREFIX = 'vumigo'
 
 try:
     from production_settings import *


### PR DESCRIPTION
poll.yaml was being read by the Django webapp but it is not longer
necesary. This removes that.
