### PR TITLE
`yield` missing in a bunch of places, causes problems with real Redis.

### DIFF
--- a/go/apps/afropinions/test_handlers.py
+++ b/go/apps/afropinions/test_handlers.py
@@ -2,7 +2,7 @@ import base64
 
 from go.vumitools.tests.test_handler import EventHandlerTestCase
 
-from vumi.tests.utils import LogCatcher, MockHttpServer
+from vumi.tests.utils import MockHttpServer
 
 from twisted.internet.defer import inlineCallbacks
 

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -2,8 +2,7 @@ from go.vumitools.opt_out import OptOutStore
 from go.vumitools.tests.test_handler import EventHandlerTestCase
 
 from twisted.internet.defer import inlineCallbacks
-# from twisted.internet.base import DelayedCall
-# DelayedCall.debug = True
+
 from vxpolls.manager import PollManager
 
 

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -2,7 +2,8 @@ from go.vumitools.opt_out import OptOutStore
 from go.vumitools.tests.test_handler import EventHandlerTestCase
 
 from twisted.internet.defer import inlineCallbacks
-
+# from twisted.internet.base import DelayedCall
+# DelayedCall.debug = True
 from vxpolls.manager import PollManager
 
 

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -281,3 +281,15 @@ class TestSurveyApplication(AppWorkerTestCase):
         self.create_survey(self.conversation)
         yield self.conversation.start()
         yield self.complete_survey(self.default_questions)
+
+    @inlineCallbacks
+    def test_ensure_participant_cleared_after_archiving(self):
+        contact = yield self.create_contact(u'First', u'Contact',
+            msisdn=u'+27831234567', groups=[self.group])
+        self.create_survey(self.conversation)
+        yield self.conversation.start()
+        yield self.complete_survey(self.default_questions)
+        # This participant should be empty
+        poll_id = 'poll-%s' % (self.conversation.key,)
+        participant = yield self.pm.get_participant(poll_id, contact.msisdn)
+        self.assertEqual(participant.labels, {})

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -5,7 +5,7 @@
 import uuid
 import json
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
 
 from vumi.message import TransportUserMessage
 from vumi.tests.utils import LogCatcher
@@ -62,7 +62,6 @@ class TestSurveyApplication(AppWorkerTestCase):
 
         # Steal app's vumi_api
         self.vumi_api = self.app.vumi_api  # YOINK!
-        self._persist_riak_managers.append(self.vumi_api.manager)
 
         # Create a test user account
         self.user_account = yield self.vumi_api.account_store.new_user(
@@ -70,8 +69,8 @@ class TestSurveyApplication(AppWorkerTestCase):
         self.user_api = VumiUserApi(self.vumi_api, self.user_account.key)
 
         # Add tags
-        self.user_api.api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
-        self.user_api.api.set_pool_metadata("pool", {
+        self.vumi_api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
+        self.vumi_api.set_pool_metadata("pool", {
             "transport_type": self.transport_type,
             "msg_options": {
                 "transport_name": self.transport_name,
@@ -165,22 +164,26 @@ class TestSurveyApplication(AppWorkerTestCase):
         returnValue(msgs[-1 * nr_of_messages:])
 
     @inlineCallbacks
-    def tearDown(self):
-        self.pm.stop()
-        yield super(TestSurveyApplication, self).tearDown()
-
-    @inlineCallbacks
     def test_start(self):
+        # We need to wait for process_command_start() to finish completely.
+        # Since it runs in response to an async command, we need to wrap it in
+        # something that fires a deferred at the appropriate time.
+        pcs_d = Deferred()
+        pcs = self.app.process_command_start
+        pcs_wrapper = lambda *args, **kw: pcs(*args, **kw).chainDeferred(pcs_d)
+        self.app.process_command_start = pcs_wrapper
+
         self.contact1 = yield self.create_contact(name=u'First',
             surname=u'Contact', msisdn=u'+27831234567', groups=[self.group])
         self.contact2 = yield self.create_contact(name=u'Second',
             surname=u'Contact', msisdn=u'+27831234568', groups=[self.group])
-        self.create_survey(self.conversation)
+        yield self.create_survey(self.conversation)
         with LogCatcher() as log:
             yield self.conversation.start()
             self.assertEqual(log.errors, [])
 
-        [msg1, msg2] = (yield self.wait_for_dispatched_messages(2))
+        yield pcs_d
+        [msg1, msg2] = self.get_dispatched_messages()
         self.assertEqual(msg1['content'], self.default_questions[0]['copy'])
         self.assertEqual(msg2['content'], self.default_questions[0]['copy'])
 
@@ -266,7 +269,6 @@ class TestSurveyApplication(AppWorkerTestCase):
             self._reformat_participant_for_comparison(participant.dump()))
 
         returnValue(last_msg)
-
 
     @inlineCallbacks
     def submit_answers(self, questions, answers, start_at=0):

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -27,7 +27,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
 
     @inlineCallbacks
     def teardown_application(self):
-        self.pm.stop()
+        yield self.pm.stop()
         yield self._go_teardown_application()
 
     @inlineCallbacks
@@ -91,7 +91,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         gmt = self.get_go_metadata(msg)
         gmt.set_conversation_info(conversation)
 
-        self.consume_user_message(msg)
+        return self.consume_user_message(msg)
 
     @inlineCallbacks
     def end_session(self, participant, poll, message):

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -4,7 +4,6 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from vxpolls.example import PollApplication
 from vxpolls.manager import PollManager
 
-from vumi.persist.txredis_manager import TxRedisManager
 from vumi.message import TransportUserMessage
 from vumi import log
 
@@ -17,21 +16,19 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
 
     def validate_config(self):
         self._go_validate_config()
-        self.r_config = self.config.get('redis_manager', {})
         # vxpolls
         vxp_config = self.config.get('vxpolls', {})
         self.poll_prefix = vxp_config.get('prefix')
 
     @inlineCallbacks
     def setup_application(self):
-        r_server = yield TxRedisManager.from_config(self.r_config)
-        self.pm = PollManager(r_server, self.poll_prefix)
         yield self._go_setup_application()
+        self.pm = PollManager(self.redis, self.poll_prefix)
 
     @inlineCallbacks
     def teardown_application(self):
-        yield self._go_teardown_application()
         self.pm.stop()
+        yield self._go_teardown_application()
 
     @inlineCallbacks
     def consume_user_message(self, message):

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -80,7 +80,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
 
             yield self.pm.save_participant(poll_id, participant)
 
-        super(SurveyApplication, self).consume_user_message(message)
+        yield super(SurveyApplication, self).consume_user_message(message)
 
     def start_survey(self, to_addr, conversation, **msg_options):
         log.debug('Starting %r -> %s' % (conversation, to_addr))
@@ -119,7 +119,8 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             'transport_type': message['transport_type'],
             'participant': participant.dump(),
         })
-        super(SurveyApplication, self).end_session(participant, poll, message)
+        yield super(SurveyApplication, self).end_session(participant, poll,
+            message)
 
     @inlineCallbacks
     def get_conversation(self, batch_id, conversation_key):

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -38,7 +38,9 @@ class GoApplicationMixin(object):
 
     @inlineCallbacks
     def _go_teardown_application(self):
-        yield self.redis.close_manager()
+        # Sometimes something else closes our Redis connection.
+        if self.redis is not None:
+            yield self.redis.close_manager()
         if self.control_consumer is not None:
             yield self.control_consumer.stop()
             self.control_consumer = None

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -25,6 +25,8 @@ class TestTxVumiApi(AppWorkerTestCase):
     @inlineCallbacks
     def tearDown(self):
         self.restore_celery()
+        yield self.api.redis._purge_all()
+        yield self.api.redis.close_manager()
         yield self.api.manager.purge_all()
 
     @inlineCallbacks
@@ -89,13 +91,13 @@ class TestTxVumiApi(AppWorkerTestCase):
     @inlineCallbacks
     def test_declare_acquire_and_release_tags(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
-        self.api.declare_tags([tag1, tag2])
+        yield self.api.declare_tags([tag1, tag2])
         self.assertEqual((yield self.api.acquire_tag("poolA")), tag1)
         self.assertEqual((yield self.api.acquire_tag("poolA")), tag2)
         self.assertEqual((yield self.api.acquire_tag("poolA")), None)
         self.assertEqual((yield self.api.acquire_tag("poolB")), None)
 
-        self.api.release_tag(tag2)
+        yield self.api.release_tag(tag2)
         self.assertEqual((yield self.api.acquire_tag("poolA")), tag2)
         self.assertEqual((yield self.api.acquire_tag("poolA")), None)
 
@@ -148,6 +150,8 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     def tearDown(self):
         self.restore_celery()
         yield self.api.manager.purge_all()
+        yield self.api.redis._purge_all()
+        yield self.api.redis.close_manager()
 
     @inlineCallbacks
     def test_optout_filtering(self):

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -21,13 +21,8 @@ class TestTxVumiApi(AppWorkerTestCase):
             self.api = VumiApi.from_config(self._persist_config)
         else:
             self.api = yield VumiApi.from_config_async(self._persist_config)
-
-    @inlineCallbacks
-    def tearDown(self):
-        self.restore_celery()
-        yield self.api.redis._purge_all()
-        yield self.api.redis.close_manager()
-        yield self.api.manager.purge_all()
+        self._persist_riak_managers.append(self.api.manager)
+        self._persist_redis_managers.append(self.api.redis)
 
     @inlineCallbacks
     def test_batch_start(self):

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -354,7 +354,6 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
     @inlineCallbacks
     def setUp(self):
         yield super(GoApplicationRouterTestCase, self).setUp()
-        yield self._persist_setUp()
         self.dispatcher = yield self.get_dispatcher(self.mk_config({
             'router_class': 'go.vumitools.api_worker.GoApplicationRouter',
             'transport_names': [
@@ -382,6 +381,8 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
 
         # get the router to test
         self.vumi_api = yield VumiApi.from_config_async(self._persist_config)
+        self._persist_riak_managers.append(self.vumi_api.manager)
+        self._persist_redis_managers.append(self.vumi_api.redis)
 
         self.account = yield self.vumi_api.account_store.new_user(u'user')
         self.user_api = VumiUserApi(self.vumi_api, self.account.key)
@@ -398,7 +399,6 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
         self._persist_redis_managers.append(
             self.dispatcher._router.vumi_api.redis)
         yield super(GoApplicationRouterTestCase, self).tearDown()
-        yield self._persist_tearDown()
 
     @inlineCallbacks
     def test_tag_retrieval_and_dispatching(self):

--- a/go/vumitools/tests/test_handler.py
+++ b/go/vumitools/tests/test_handler.py
@@ -13,7 +13,6 @@ class EventHandlerTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def setUp(self):
         yield super(EventHandlerTestCase, self).setUp()
-        yield self._persist_setUp()
         app_config = self.mk_config({
             'event_handlers': {},
         })
@@ -29,12 +28,6 @@ class EventHandlerTestCase(AppWorkerTestCase):
             u'survey', u'subject', u'message',
             delivery_tag_pool=u'pool',
             delivery_class=u'sms')
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield super(EventHandlerTestCase, self).tearDown()
-        yield self._persist_tearDown()
-        yield self.vumi_api.redis.close_manager()
 
     def publish_event(self, event):
         return self.dispatch(event, rkey='vumi.event')

--- a/go/vumitools/tests/test_handler.py
+++ b/go/vumitools/tests/test_handler.py
@@ -13,10 +13,10 @@ class EventHandlerTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def setUp(self):
         yield super(EventHandlerTestCase, self).setUp()
-
-        app_config = {
+        yield self._persist_setUp()
+        app_config = self.mk_config({
             'event_handlers': {},
-        }
+        })
         for name, handler_class, config in self.handlers:
             app_config['event_handlers'][name] = handler_class
             app_config[name] = config
@@ -33,7 +33,8 @@ class EventHandlerTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def tearDown(self):
         yield super(EventHandlerTestCase, self).tearDown()
-        yield self.event_dispatcher.teardown_application()
+        yield self._persist_tearDown()
+        yield self.vumi_api.redis.close_manager()
 
     def publish_event(self, event):
         return self.dispatch(event, rkey='vumi.event')

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -243,8 +243,7 @@ class AppWorkerTestCase(GoPersistenceMixin, CeleryTestMixIn,
     def get_application(self, *args, **kw):
         worker = yield super(AppWorkerTestCase, self).get_application(
             *args, **kw)
-        if hasattr(worker, 'manager'):
-            self._persist_riak_managers.append(worker.manager)
-        if hasattr(worker, 'redis'):
-            self._persist_redis_managers.append(worker.redis)
+        if hasattr(worker, 'vumi_api'):
+            self._persist_riak_managers.append(worker.vumi_api.manager)
+            self._persist_redis_managers.append(worker.vumi_api.redis)
         returnValue(worker)

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import json
 
 from twisted.python.monkey import MonkeyPatcher
-from twisted.internet.defer import DeferredList, inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue
 from celery.app import app_or_default
 
 from vumi.persist.fields import ForeignKeyProxy, ManyToManyProxy, DynamicProxy
@@ -238,3 +238,13 @@ class AppWorkerTestCase(GoPersistenceMixin, CeleryTestMixIn,
         d = self.dispatch(event, rkey=self.rkey('event'))
         d.addCallback(lambda _result: event)
         return d
+
+    @inlineCallbacks
+    def get_application(self, *args, **kw):
+        worker = yield super(AppWorkerTestCase, self).get_application(
+            *args, **kw)
+        if hasattr(worker, 'manager'):
+            self._persist_riak_managers.append(worker.manager)
+        if hasattr(worker, 'redis'):
+            self._persist_redis_managers.append(worker.redis)
+        returnValue(worker)


### PR DESCRIPTION
Surfaced in SNA with Deferreds firing in the wrong order. All tests now
pass against real redis with the exception of `test_start` for
`surveys/vumi_app.py` which fails with 'Connection was closed cleanly`
which is a bit odd.

```
go.apps.surveys.tests.test_vumi_app
  TestSurveyApplication
    test_clearing_old_survey_data ...
[OK]
    test_ensure_participant_cleared_after_archiving ...
[OK]
    test_start ...
[ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
                                                     [ERROR]
    test_survey_completion ...
[OK]

===============================================================================
[ERROR]
Traceback (most recent call last):
Failure: twisted.internet.error.ConnectionDone: Connection was closed
cleanly.

go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
go.apps.surveys.tests.test_vumi_app.TestSurveyApplication.test_start
-------------------------------------------------------------------------------
Ran 4 tests in 9.925s

FAILED (errors=12, successes=3)
```

@Hodgestar @jerith @dmaclay please review
