### PR TITLE
surveys/vumi_app.py is missing yields to super() calls

### DIFF
--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -281,3 +281,15 @@ class TestSurveyApplication(AppWorkerTestCase):
         self.create_survey(self.conversation)
         yield self.conversation.start()
         yield self.complete_survey(self.default_questions)
+
+    @inlineCallbacks
+    def test_ensure_participant_cleared_after_archiving(self):
+        contact = yield self.create_contact(u'First', u'Contact',
+            msisdn=u'+27831234567', groups=[self.group])
+        self.create_survey(self.conversation)
+        yield self.conversation.start()
+        yield self.complete_survey(self.default_questions)
+        # This participant should be empty
+        poll_id = 'poll-%s' % (self.conversation.key,)
+        participant = yield self.pm.get_participant(poll_id, contact.msisdn)
+        self.assertEqual(participant.labels, {})

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -80,7 +80,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
 
             yield self.pm.save_participant(poll_id, participant)
 
-        super(SurveyApplication, self).consume_user_message(message)
+        yield super(SurveyApplication, self).consume_user_message(message)
 
     def start_survey(self, to_addr, conversation, **msg_options):
         log.debug('Starting %r -> %s' % (conversation, to_addr))
@@ -119,7 +119,8 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             'transport_type': message['transport_type'],
             'participant': participant.dump(),
         })
-        super(SurveyApplication, self).end_session(participant, poll, message)
+        yield super(SurveyApplication, self).end_session(participant, poll,
+            message)
 
     @inlineCallbacks
     def get_conversation(self, batch_id, conversation_key):


### PR DESCRIPTION
The result is Deferreds firing out of order. This only happens when
runnin against real Redis (which PR #55 deals with). This is only the
fix for the SNA issue (which is already running in production)
