### PR TITLE
Filter contacts on surname using mapreduce and not in-memory python.

### DIFF
--- a/go/contacts/templates/contacts/people.html
+++ b/go/contacts/templates/contacts/people.html
@@ -54,11 +54,10 @@
             {% empty %}
                 <tr>
 					<td colspan="3">
-					{% if selected_letter %}
+                    {% if query %}
+                        No contact match <strong>{{query}}</strong>
+                    {% else %}
 					    No contact surnames start with the letter <strong>{{selected_letter|upper}}</strong>
-					{% endif %}
-					{% if query %}
-					    No contact match <strong>{{query}}</strong>
 					{% endif %}
 					</td>
                 </tr>

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -91,12 +91,6 @@ class ContactsTestCase(VumiGoDjangoTestCase):
         })
         self.assertContains(response, person_url(self.contact_key))
 
-        # test match surname
-        response = self.client.get(group_url(self.group_key), {
-            'q': TEST_CONTACT_SURNAME,
-        })
-        self.assertContains(response, person_url(self.contact_key))
-
     def test_group_contact_filter_by_letter(self):
         first_letter = TEST_CONTACT_SURNAME[0]
 

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -215,6 +215,10 @@ def _people(request):
 
     select_contact_group_form = SelectContactGroupForm(
         groups=contact_store.list_groups())
+
+    # TODO: A lot of this stuff is duplicated from the similar group search
+    #       in the groups() view. We need a function that does that to avoid
+    #       the duplication.
     selected_letter = request.GET.get('l', 'a')
     query = request.GET.get('q', '')
     if query:

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -21,28 +21,6 @@ def _query_to_kwargs(query):
     return dict([(t[0], t[1]) for t in tuples])
 
 
-def _filter_contacts(contacts, request_params):
-    contacts = [c for c in contacts if (c.name or c.surname)]
-    query = request_params.get('q', None)
-    selected_letter = None
-
-    if query:
-        ql = query.lower()
-        contacts = [c for c in contacts
-                    if (ql in c.name.lower()) or (ql in c.surname.lower())]
-    else:
-        selected_letter = request_params.get('l', 'a').lower()
-        contacts = [c for c in contacts
-                    if c.surname.lower().startswith(selected_letter)]
-
-    return {
-        'query': query,
-        'selected_letter': selected_letter,
-        'selected_contacts': sorted(contacts,
-                                    key=lambda c: c.name.lower()[0]),
-        }
-
-
 def _group_url(group_key):
     return reverse('contacts:group', kwargs={'group_key': group_key})
 
@@ -166,17 +144,24 @@ def _group(request, group_key):
         except ValueError:
             messages.error(request, 'Something is wrong with the file')
 
-    if ':' in request.GET.get('q', ''):
-        query = request.GET['q']
-        query_kwargs = _query_to_kwargs(query)
-        context.update({
-            'query': query,
-            'selected_contacts': [contact for contact in
-                            contact_store.contacts.search(**query_kwargs)],
-        })
+    selected_letter = request.GET.get('l', 'a')
+    query = request.GET.get('q', '')
+    if query:
+        if ':' in query:
+            query_kwargs = _query_to_kwargs(request.GET.get('q'))
+        else:
+            query_kwargs = _query_to_kwargs('name:%s' % query)
+        selected_contacts = contact_store.contacts.search(**query_kwargs)
     else:
-        context.update(_filter_contacts(group.backlinks.contacts(),
-                                            request.GET))
+        selected_contacts = contact_store.filter_contacts_on_surname(
+            selected_letter, group=group)
+
+    context.update({
+        'query': request.GET.get('q'),
+        'selected_letter': selected_letter,
+        'selected_contacts': selected_contacts,
+        })
+
     return render(request, 'contacts/group.html', context)
 
 
@@ -231,12 +216,17 @@ def _people(request):
     select_contact_group_form = SelectContactGroupForm(
         groups=contact_store.list_groups())
     selected_letter = request.GET.get('l', 'a')
-    if ':' in request.GET.get('q', ''):
-        query_kwargs = _query_to_kwargs(request.GET.get('q'))
+    query = request.GET.get('q', '')
+    if query:
+        if ':' in query:
+            query_kwargs = _query_to_kwargs(query)
+        else:
+            query_kwargs = _query_to_kwargs('name:%s' % query)
         selected_contacts = contact_store.contacts.search(**query_kwargs)
     else:
         selected_contacts = contact_store.filter_contacts_on_surname(
             selected_letter)
+
     return render(request, 'contacts/people.html', {
         'query': request.GET.get('q'),
         'selected_letter': selected_letter,

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -133,7 +133,7 @@ class ContactStore(PerAccountStore):
         js_function = """function(value, keyData, arg){
             var data = Riak.mapValuesJson(value)[0];
             var surname = data.surname.toLowerCase();
-            if(surname && surname.charAt(0) == arg){
+            if(surname && surname[0] === arg){
                 return [[value.key, value[0]]];
             } else {
                 return [];

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -125,6 +125,10 @@ class ContactStore(PerAccountStore):
 
     @Manager.calls_manager
     def filter_contacts_on_surname(self, letter, group=None):
+        # TODO: vumi.persist needs to have better ways of supporting
+        #       generic map reduce functions. There's a bunch of boilerplate
+        #       around getting bucket names and indexes that I'm doing
+        #       manually that could be automated.
         mr = self.manager.riak_map_reduce()
         bucket = self.manager.bucket_name(Contact)
         mr.add_bucket(bucket)


### PR DESCRIPTION
Adds a `filter_contacts_on_surname()` function which in time could be
made more generic to allow filtering on other fields. Resisting the
temptation to do that now because a) we don't need it yet and b) it
comes awfully close to what Riak search gives us anyway with the work
being done in VUMIGO-67
