### PR TITLE
Tiny change in settings.py

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -201,7 +201,7 @@ BROKER_HOST = "localhost"
 BROKER_PORT = 5672
 BROKER_USER = "vumi"
 BROKER_PASSWORD = "vumi"
-BROKER_VHOST = "/go"
+BROKER_VHOST = "/develop"
 
 # If we're running in DEBUG mode then skip RabbitMQ and execute tasks
 # immediate instead of deferring them to the queue / workers.


### PR DESCRIPTION
Our dev setup assumes '/develop' and our production setup uses '/go' --
which is a good distinction. Our `go/settings.py` had '/go' for celery,
I've moved that to `production_settings.py` in praekelt-machines and
defaulted it to `/develop` instead.
