### PR TITLE
App Msg Dispatcher should also route events

### DIFF
--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -35,6 +35,10 @@ class BulkMessageApplication(GoApplicationWorker):
             return
 
         conv = yield self.get_conversation(batch_id, conversation_key)
+        if conv is None:
+            log.warning('Cannot find conversation for batch_id: %s '
+                'and conversation_key: %s' % (batch_id, conversation_key))
+            return
 
         to_addresses = yield conv.get_opted_in_addresses()
         if extra_params.get('dedupe'):

--- a/go/conversation/templates/generic/includes/overview.html
+++ b/go/conversation/templates/generic/includes/overview.html
@@ -18,6 +18,8 @@
          <h3>{{conversation.subject}}</h3>
          <p>{{conversation.message}}</p>
     </div>
+</div>
+<div class="row">
     <div class="span12">
         <table class="table table-bordered table-striped">
             <tr>
@@ -33,13 +35,45 @@
                 </td>
                 <td width="50%">
                     {% if not conversation.get_progress_percentage %}
-                        <div class="progress progress-striped active">
+                        <div class="progress progress-info progress-striped active">
                             <div class="bar" style="width: 100%;"/>
                         </div>
                     {% else %}
-                        <div class="progress progress-striped">
-                            <div class="bar" style="width: {{conversation.get_progress_percentage}}%"/>
+                        {% with conversation.get_progress_status as status %}
+                        <div class="progress progress-primary">
+                          <div class="bar" style="width: {% widthratio status.sent status.sent 100 %}%;">
+                            <span>{{ status.sent }} sent for delivery to the networks.</span>
+                            </div>
                         </div>
+                        {% if status.ack %}
+                        <div class="progress progress-info">
+                          <div class="bar" style="width: {% widthratio status.ack status.sent 100 %}%;">
+                            <span>{{ status.ack }} accepted for delivery by the networks.</span>
+                            </div>
+                        </div>
+                        {% endif %}
+                        {% if status.delivery_report_delivered %}
+                        <div class="progress progress-success">
+                          <div class="bar" style="width: {% widthratio status.delivery_report_delivered status.sent 100 %}%;">
+                            <span>{{ status.delivery_report_delivered }} delivered.</span>
+                          </div>
+                        </div>
+                        {% endif %}
+                        {% if status.delivery_report_failed %}
+                        <div class="progress progress-danger">
+                          <div class="bar" style="width: {% widthratio status.delivery_report_failed status.sent 100 %}%;">
+                            <span>{{ status.delivery_report_failed }} delivery unsuccessful.</span>
+                          </div>
+                        </div>
+                        {% endif %}
+                        {% if status.delivery_report_pending %}
+                        <div class="progress progress-warning active">
+                          <div class="bar" style="width: {% widthratio status.delivery_report_pending status.sent 100 %}%;">
+                            <span>{{status.delivery_report_pending}} delivery status unknown.</span>
+                          </div>
+                        </div>
+                        {% endif %}
+                        {% endwith %}
                     {% endif %}
                 </td>
                 <td>

--- a/go/conversation/templates/generic/show.html
+++ b/go/conversation/templates/generic/show.html
@@ -28,5 +28,5 @@
 {% endblock %}
 
 {% block extra_js %}
-    {% include "conversation/includes/charts.html" %}
+    {# {% include "conversation/includes/charts.html" %} #}
 {% endblock %}

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -394,14 +394,13 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
     def tearDown(self):
         # These aren't ready until we use the dispatcher, so we add them here
         # instead of in setUp()
-        self._persist_riak_managers.append(
-            self.dispatcher._router.vumi_api.manager)
-        self._persist_redis_managers.append(
-            self.dispatcher._router.vumi_api.redis)
+        vumi_api = yield self.dispatcher._router.get_vumi_api()
+        self._persist_riak_managers.append(vumi_api.manager)
+        self._persist_redis_managers.append(vumi_api.redis)
         yield super(GoApplicationRouterTestCase, self).tearDown()
 
     @inlineCallbacks
-    def test_tag_retrieval_and_dispatching(self):
+    def test_tag_retrieval_and_message_dispatching(self):
         msg = self.mkmsg_in(transport_type='xmpp',
                                 transport_name=self.transport_name)
 
@@ -422,6 +421,34 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
                          self.conversation.conversation_type)
         self.assertEqual(go_metadata['conversation_key'],
                          self.conversation.key)
+
+    @inlineCallbacks
+    def test_tag_retrieval_and_event_dispatching(self):
+        # first create an outbound message and then publish an inbound
+        # event for it.
+        msg = self.mkmsg_out(transport_type='xmpp',
+                                transport_name=self.transport_name)
+
+        # Make sure stuff is tagged properly so it can be routed.
+        tag = ('xmpp', 'test1@xmpp.org')
+        batch_id = yield self.vumi_api.mdb.batch_start([tag],
+            user_account=unicode(self.account.key))
+        self.conversation.batches.add_key(batch_id)
+        yield self.conversation.save()
+        TaggingMiddleware.add_tag_to_msg(msg, tag)
+
+        # Fake that it has been sent by storing it as a sent message
+        yield self.vumi_api.mdb.add_outbound_message(msg, tag=tag,
+            batch_id=batch_id)
+
+        ack = self.mkmsg_ack(event_type='ack',
+            user_message_id=msg['message_id'],
+            transport_name=self.transport_name)
+
+        yield self.dispatch(ack, self.transport_name, 'event')
+
+        [event] = self.get_dispatched_messages('app_1', direction='event')
+        self.assertEqual(event['user_message_id'], msg['message_id'])
 
     @inlineCallbacks
     def test_no_tag(self):


### PR DESCRIPTION
It was already trying to but was failing because it was looking for tags
in event messages. This changes looks up the message for the event and
then uses that message to route the event to the appropriate
application.
