### PR TITLE
Middleware for generating metrics for Vumi Go

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -1,10 +1,15 @@
 # -*- test-case-name: go.vumitools.tests.test_middleware -*-
 import sys
+import time
+
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.middleware.tagger import TaggingMiddleware
 from vumi.middleware.base import TransportMiddleware, BaseMiddleware
 from vumi.utils import normalize_msisdn
 from vumi.components.tagpool import TagpoolManager
+from vumi.blinkenlights.metrics import MetricManager, Count, Metric
+from vumi.persist.txredis_manager import TxRedisManager
 
 from go.vumitools.credit import CreditManager
 
@@ -151,3 +156,110 @@ class DebitAccountMiddleware(TransportMiddleware):
                                      " to debit %r." %
                                      (user_account_key, credits_per_message))
         return msg
+
+class MetricsMiddleware(BaseMiddleware):
+    """
+    Middleware that publishes metrics on messages flowing through.
+    It tracks the number of messages sent & received on the various
+    transports and the average response times for messages received.
+
+    :param str manager_name:
+        The name of the metrics publisher, this is used for the MetricManager
+        publisher and all metric names will be prefixed with it.
+    :param str count_suffix:
+        Defaults to 'count'. This is the suffix appended to all `transport_name`
+        based counters. If a message is received on endpoint 'foo', counters
+        are published on '<manager_name>.foo.inbound.<count_suffix>'
+    :param str response_time_suffix:
+        Defaults to 'response_time'. This is the suffix appended to all
+        `transport_name` based average response time metrics. If a message is
+        received its `message_id` is stored and when a reply for the given
+        `message_id` is sent out, the timestamps are compared and a averaged
+        metric is published.
+    :param dict redis_manager:
+        Connection configuration details for Redis.
+    """
+
+    def validate_config(self):
+        self.manager_name = self.config['manager_name']
+        self.count_suffix = self.config.get('count_suffix', 'count')
+        self.response_time_suffix = self.config.get('response_time_suffix',
+            'response_time')
+
+    @inlineCallbacks
+    def setup_middleware(self):
+        self.validate_config()
+        self.redis = yield TxRedisManager.from_config(
+            self.config['redis_manager'])
+        self.metric_manager = yield self.worker.start_publisher(MetricManager,
+            "%s." % (self.manager_name,))
+
+    def teardown_middleware(self):
+        self.metric_manager.stop()
+
+    def get_or_create_metric(self, name, metric_class, *args, **kwargs):
+        """
+        Get the metric for `name`, create it with
+        `metric_class(*args, **kwargs)` if it doesn't exist yet.
+        """
+        if name not in self.metric_manager:
+            self.metric_manager.register(metric_class(name, *args, **kwargs))
+        return self.metric_manager[name]
+
+    def get_counter_metric(self, name):
+        metric_name = '%s.%s' % (name, self.count_suffix)
+        return self.get_or_create_metric(metric_name, Count)
+
+    def increment_counter(self, transport_name, message_type):
+        metric = self.get_counter_metric('%s.%s' % (transport_name,
+            message_type))
+        metric.inc()
+
+    def get_response_time_metric(self, name):
+        metric_name = '%s.%s' % (name, self.response_time_suffix)
+        return self.get_or_create_metric(metric_name, Metric)
+
+    def set_response_time(self, transport_name, time):
+        metric = self.get_response_time_metric(transport_name)
+        metric.set(time)
+
+    def key(self, transport_name, message_id):
+        return '%s:%s' % (transport_name, message_id)
+
+    def set_inbound_timestamp(self, transport_name, message):
+        key = self.key(transport_name, message['message_id'])
+        return self.redis.set(key, repr(time.time()))
+
+    @inlineCallbacks
+    def get_outbound_timestamp(self, transport_name, message):
+        key = self.key(transport_name, message['in_reply_to'])
+        timestamp = yield self.redis.get(key)
+        if timestamp:
+            returnValue(float(timestamp))
+
+    @inlineCallbacks
+    def compare_timestamps(self, transport_name, message):
+        timestamp = yield self.get_outbound_timestamp(transport_name, message)
+        if timestamp:
+            self.set_response_time(transport_name, time.time() - timestamp)
+
+    @inlineCallbacks
+    def handle_inbound(self, message, endpoint):
+        self.increment_counter(message['transport_name'], 'inbound')
+        yield self.set_inbound_timestamp(message['transport_name'], message)
+        returnValue(message)
+
+    @inlineCallbacks
+    def handle_outbound(self, message, endpoint):
+        self.increment_counter(message['transport_name'], 'outbound')
+        yield self.compare_timestamps(message['transport_name'], message)
+        returnValue(message)
+
+    def handle_event(self, event, endpoint):
+        self.increment_counter(event['transport_name'], 'event')
+        return event
+
+    def handle_failure(self, failure, endpoint):
+        self.increment_counter(failure['transport_name'], 'failure')
+        return failure
+

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -391,15 +391,6 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
                 u'bulk_message', u'subject', u'message'))
 
     @inlineCallbacks
-    def tearDown(self):
-        # These aren't ready until we use the dispatcher, so we add them here
-        # instead of in setUp()
-        vumi_api = yield self.dispatcher._router.get_vumi_api()
-        self._persist_riak_managers.append(vumi_api.manager)
-        self._persist_redis_managers.append(vumi_api.redis)
-        yield super(GoApplicationRouterTestCase, self).tearDown()
-
-    @inlineCallbacks
     def test_tag_retrieval_and_message_dispatching(self):
         msg = self.mkmsg_in(transport_type='xmpp',
                                 transport_name=self.transport_name)

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -24,6 +24,7 @@ class MiddlewareTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def tearDown(self):
+        yield super(MiddlewareTestCase, self).tearDown()
         for mw in self._middlewares:
             yield maybeDeferred(mw.teardown_middleware)
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -1,32 +1,43 @@
 """Tests for go.vumitools.middleware"""
+import time
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.message import TransportUserMessage
+from vumi.application.tests.test_base import DummyApplicationWorker
 
 from go.vumitools.tests.utils import AppWorkerTestCase
-from go.vumitools.middleware import NormalizeMsisdnMiddleware, OptOutMiddleware
+from go.vumitools.middleware import (NormalizeMsisdnMiddleware,
+    OptOutMiddleware, MetricsMiddleware)
 
 
 class MiddlewareTestCase(AppWorkerTestCase):
+
+    application_class = DummyApplicationWorker
 
     @inlineCallbacks
     def setUp(self):
         yield super(MiddlewareTestCase, self).setUp()
         self.default_config = self.mk_config({})
 
+    @inlineCallbacks
     def create_middleware(self, middleware_class, name='dummy_middleware',
                             config=None):
-        dummy_worker = object()
+        dummy_worker = yield self.get_application({})
         mw = middleware_class(name, config or self.default_config,
                                 dummy_worker)
         mw.setup_middleware()
-        return mw
+        returnValue(mw)
 
-    def mk_msg(self, to_addr, from_addr):
-        return TransportUserMessage(to_addr=to_addr, from_addr=from_addr,
-                                   transport_name="dummy_endpoint",
-                                   transport_type="dummy_transport_type")
+    def mk_msg(self, **kwargs):
+        defaults = {
+            'to_addr': 'to@addr.com',
+            'from_addr': 'from@addr.com',
+            'transport_name': 'dummy_endpoint',
+            'transport_type': 'dummy_transport_type',
+        }
+        defaults.update(kwargs)
+        return TransportUserMessage(**defaults)
 
 
 class NormalizeMisdnMiddlewareTestCase(MiddlewareTestCase):
@@ -34,9 +45,8 @@ class NormalizeMisdnMiddlewareTestCase(MiddlewareTestCase):
     @inlineCallbacks
     def setUp(self):
         yield super(NormalizeMisdnMiddlewareTestCase, self).setUp()
-        self.mw = self.create_middleware(NormalizeMsisdnMiddleware, config={
-            'country_code': '256'
-        })
+        self.mw = yield self.create_middleware(NormalizeMsisdnMiddleware,
+            config={'country_code': '256'})
 
     def test_normalization(self):
         msg = self.mk_msg(to_addr='8007', from_addr='256123456789')
@@ -54,7 +64,8 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
             'keyword_separator': '-',
             'optout_keywords': ['STOP', 'HALT', 'QUIT']
         })
-        self.mw = self.create_middleware(OptOutMiddleware, config=self.config)
+        self.mw = yield self.create_middleware(OptOutMiddleware,
+            config=self.config)
 
     def send_keyword(self, mw, word, expected_response):
         msg = self.mk_msg('to@domain.org', 'from@domain.org')
@@ -88,7 +99,7 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         config.update({
             'case_sensitive': True,
         })
-        mw = self.create_middleware(OptOutMiddleware, config=config)
+        mw = yield self.create_middleware(OptOutMiddleware, config=config)
 
         yield self.send_keyword(mw, 'STOP', {
             'optout': {
@@ -102,3 +113,79 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
                 'optout': False,
             }
         })
+
+class MetricsMiddlewareTestCase(MiddlewareTestCase):
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(MetricsMiddlewareTestCase, self).setUp()
+        self.config = self.default_config.copy()
+        self.config.update({
+            'manager_name': 'metrics_manager',
+            'count_suffix': 'counter',
+            'response_time_suffix': 'timer',
+            'redis_manager': {
+                'FAKE_REDIS': 'yes please',
+            }
+        })
+        self.mw = yield self.create_middleware(MetricsMiddleware,
+            config=self.config)
+
+    def tearDown(self):
+        self.mw.teardown_middleware()
+
+    @inlineCallbacks
+    def test_inbound_counters(self):
+        msg1 = self.mk_msg(transport_name='endpoint_0')
+        msg2 = self.mk_msg(transport_name='endpoint_1')
+        msg3 = self.mk_msg(transport_name='endpoint_1')
+        # The middleware inspects the message's transport_name value, not
+        # the dispatcher endpoint it was received on.
+        yield self.mw.handle_inbound(msg1, 'dummy_endpoint')
+        yield self.mw.handle_inbound(msg2, 'dummy_endpoint')
+        yield self.mw.handle_inbound(msg3, 'dummy_endpoint')
+        endpoint0_metric = self.mw.metric_manager['endpoint_0.inbound.counter']
+        endpoint0_values = endpoint0_metric.poll()
+        endpoint1_metric = self.mw.metric_manager['endpoint_1.inbound.counter']
+        endpoint1_values = endpoint1_metric.poll()
+        self.assertEqual(sum([m[1] for m in endpoint0_values]), 1)
+        self.assertEqual(sum([m[1] for m in endpoint1_values]), 2)
+
+    @inlineCallbacks
+    def test_outbound_counters(self):
+        msg1 = self.mk_msg(transport_name='endpoint_0')
+        msg2 = self.mk_msg(transport_name='endpoint_1')
+        msg3 = self.mk_msg(transport_name='endpoint_1')
+        # The middleware inspects the message's transport_name value, not
+        # the dispatcher endpoint it was received on.
+        yield self.mw.handle_outbound(msg1, 'dummy_endpoint')
+        yield self.mw.handle_outbound(msg2, 'dummy_endpoint')
+        yield self.mw.handle_outbound(msg3, 'dummy_endpoint')
+        endpoint0_metric = self.mw.metric_manager['endpoint_0.outbound.counter']
+        endpoint0_values = endpoint0_metric.poll()
+        endpoint1_metric = self.mw.metric_manager['endpoint_1.outbound.counter']
+        endpoint1_values = endpoint1_metric.poll()
+        self.assertEqual(sum([m[1] for m in endpoint0_values]), 1)
+        self.assertEqual(sum([m[1] for m in endpoint1_values]), 2)
+
+    @inlineCallbacks
+    def test_response_time_inbound(self):
+        msg = self.mk_msg(transport_name='endpoint_0')
+        yield self.mw.handle_inbound(msg, 'dummy_endpoint')
+        key = self.mw.key('endpoint_0', msg['message_id'])
+        timestamp = yield self.mw.redis.get(key)
+        self.assertTrue(timestamp)
+
+    @inlineCallbacks
+    def test_response_time_comparison_on_outbound(self):
+        inbound_msg = self.mk_msg(transport_name='endpoint_0')
+        key = self.mw.key('endpoint_0', inbound_msg['message_id'])
+        # Fake it to be 10 seconds in the past
+        timestamp = time.time() - 10
+        yield self.mw.redis.set(key, repr(timestamp))
+        outbound_msg = self.mk_msg(transport_name='endpoint_0',
+            in_reply_to=inbound_msg['message_id'])
+        yield self.mw.handle_outbound(outbound_msg, 'dummy_endpoint')
+        [timer_metric] = self.mw.metric_manager['endpoint_0.timer'].poll()
+        [timestamp, value] = timer_metric
+        self.assertTrue(value > 10)


### PR DESCRIPTION
It inspects all inbound & outbound messages, maintains counters and
calculates response times for messages.

Not quite sure what to do about events and failures at this point since
they're not guaranteed to have a transport_name.
