### PR TITLE
SortedDict isn't safe to put on the wire as JSON

### DIFF
--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -174,10 +174,14 @@ class ContactFileParser(object):
         things like account details. Attributes that can be set are in the
         SETTABLE_ATTRIBUTES list, which defaults to the DEFAULT_HEADERS keys.
         """
-
+        # We receive the fields as list of tuples, not a dict because the
+        # order is important and needs to stay intact while being encoded
+        # and decoded as JSON
+        field_names = [field[0] for field in fields]
+        field_map = dict(fields)
         # We're expecting a generator so loop over it and save as contacts
         # in the contact_store, normalizing anything we need to
-        data_dictionaries = self.read_data_from_file(file_path, fields.keys(),
+        data_dictionaries = self.read_data_from_file(file_path, field_names,
             has_header)
         for data_dictionary in data_dictionaries:
 
@@ -185,7 +189,7 @@ class ContactFileParser(object):
             # contact to be saved
             contact_dictionary = {}
             for key, value in data_dictionary.items():
-                value = self.normalizer.normalize(fields[key], value)
+                value = self.normalizer.normalize(field_map[key], value)
                 if not isinstance(value, basestring):
                     value = unicode(str(value), self.ENCODING,
                         self.ENCODING_ERRORS)

--- a/go/contacts/parsers/test_parsers.py
+++ b/go/contacts/parsers/test_parsers.py
@@ -4,7 +4,6 @@ from django.test import TestCase
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
-from django.utils.datastructures import SortedDict
 
 from go.contacts.parsers.csv_parser import CSVFileParser
 from go.contacts.parsers.xls_parser import XLSFileParser
@@ -46,9 +45,9 @@ class CSVParserTestCase(ParserTestCase):
     def test_contacts_parsing(self):
         csv_file = self.fixture('sample-contacts-with-headers.csv')
         fp = default_storage.open(csv_file, 'rU')
-        contacts = list(self.parser.parse_file(fp, SortedDict(zip(
+        contacts = list(self.parser.parse_file(fp, zip(
             ['name', 'surname', 'msisdn'],
-            ['string', 'string', 'msisdn_za'])), has_header=True))
+            ['string', 'string', 'msisdn_za']), has_header=True))
         self.assertEqual(contacts, [
             {
                 'msisdn': '+27761234561',
@@ -89,9 +88,9 @@ class XLSParserTestCase(ParserTestCase):
 
     def test_contacts_parsing(self):
         xls_file = self.fixture('sample-contacts-with-headers.xlsx')
-        contacts = list(self.parser.parse_file(xls_file, SortedDict(zip(
+        contacts = list(self.parser.parse_file(xls_file, zip(
             ['name', 'surname', 'msisdn'],
-            ['string', 'integer', 'number'])), has_header=True))
+            ['string', 'integer', 'number']), has_header=True))
         self.assertEqual(contacts[0], {
                 'msisdn': '1.0',
                 'surname': '2',

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -8,7 +8,6 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.files.uploadhandler import TemporaryFileUploadHandler
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
-from django.utils.datastructures import SortedDict
 
 from go.contacts.forms import (
     ContactForm, ContactGroupForm, UploadContactsForm, SmartGroupForm,
@@ -136,7 +135,7 @@ def _static_group(request, contact_store, group):
                                 range(len(sample_row))]
                 normalizers = [request.POST.get('normalize-%s' % i, '')
                                 for i in range(len(sample_row))]
-                fields = SortedDict(zip(field_names, normalizers))
+                fields = zip(field_names, normalizers)
 
                 tasks.import_contacts_file.delay(
                     request.user_api.user_account_key, group.key, file_name,


### PR DESCRIPTION
When decoded it is in a different order. This change the relevant code
to use [(k, v), ...] instead
