### PR TITLE
Deal with MSISDNs in float notation somewhat sanely.

### DIFF
--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -61,7 +61,8 @@ class FieldNormalizer(object):
     def is_numeric(self, value):
         str_value = self.normalize_string(value)
         try:
-            return float(str_value)
+            float(str_value)
+            return True
         except ValueError:
             return False
 

--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -6,8 +6,10 @@ from vumi.utils import load_class, normalize_msisdn
 class ContactParserException(Exception):
     pass
 
+
 class FieldNormalizerException(Exception):
     pass
+
 
 class FieldNormalizer(object):
     """
@@ -73,7 +75,7 @@ class FieldNormalizer(object):
             return float(value)
         return value
 
-    def lchop(self, chops, string):
+    def lchop(self, string, chops):
         string = self.normalize_string(string)
         for chop in chops:
             if string.startswith(chop):
@@ -82,13 +84,13 @@ class FieldNormalizer(object):
 
     def do_msisdn(self, value, country_code):
         value = self.normalize_string(value)
-        value = self.lchop(['+'], value)
+        value = self.lchop(value, ['+'])
         float_value = self.normalize_float(value)
         if not (self.is_numeric(value) and float_value.is_integer()):
             raise FieldNormalizerException('Invalid MSISDN: %s' % (value,))
 
         msisdn = self.normalize_string(self.normalize_integer(float_value))
-        msisdn = self.lchop([country_code], msisdn)
+        msisdn = self.lchop(msisdn, [country_code])
         msisdn = '0%s' % (msisdn,)
         return self.normalize_string(normalize_msisdn(msisdn, country_code))
 
@@ -112,7 +114,7 @@ class FieldNormalizer(object):
 
     def normalize_msisdn_int(self, value):
         value = self.normalize_string(value)
-        value = self.lchop(['+', '00'], value)
+        value = self.lchop(value, ['+', '00'])
         float_value = self.normalize_float(value)
         if not (self.is_numeric(value) and float_value.is_integer()):
             raise FieldNormalizerException('Invalid MSISDN: %s' % (value,))
@@ -120,6 +122,7 @@ class FieldNormalizer(object):
         msisdn = self.normalize_string(self.normalize_integer(float_value))
         country_code = msisdn[:3]
         return self.normalize_string(normalize_msisdn(msisdn, country_code))
+
 
 class ContactFileParser(object):
 

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -682,6 +682,8 @@ class TestFieldNormalizer(TestCase):
         self.assertNormalizedMsisdn('27', 761234567, '+27761234567')
         self.assertNormalizedMsisdn('27', 761234567.0, '+27761234567')
         self.assertNormalizedMsisdn('27', 27761234567, '+27761234567')
+        self.assertNormalizedMsisdn('27', 2.74727E+10, '+27472700000')
+        self.assertNormalizedMsisdn('27', '2.74727E+10', '+27472700000')
 
     def test_internationalized_msisdn(self):
         self.assertNormalized('msisdn_int', '0027761234567', '+27761234567',
@@ -692,6 +694,7 @@ class TestFieldNormalizer(TestCase):
             unicode)
         self.assertNormalized('msisdn_int', '+27761234567', '+27761234567',
             unicode)
+        self.assertNormalized('msisdn_int', '2.74727E+10', '+27472700000')
 
     def test_integer(self):
         self.assertNormalized('integer', '0.1', 0, int)

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -695,6 +695,7 @@ class TestFieldNormalizer(TestCase):
         self.assertNormalized('msisdn_int', '+27761234567', '+27761234567',
             unicode)
         self.assertNormalized('msisdn_int', '2.74727E+10', '+27472700000')
+        self.assertNormalized('msisdn_int', 2.74727E+10, '+27472700000')
 
     def test_integer(self):
         self.assertNormalized('integer', '0.1', 0, int)


### PR DESCRIPTION
We can get floats from Excel or floats as strings from CSV.
It makes sure the float is really an integer, otherwise it raises and
error. This'll break for masked shortcodes (like GUINNESS) obviously
but I'm fine with that since those aren't likely to be uploaded into the
contact database.
