### PR TITLE
SNA Event handler crashes, causing event backlog.

### DIFF
--- a/go/apps/sna/handlers.py
+++ b/go/apps/sna/handlers.py
@@ -56,7 +56,7 @@ class USSDOptOutHandler(EventHandler):
         contact = yield contact_store.contact_for_addr('ussd', from_addr)
         if contact:
             opted_out = contact.extra['opted_out']
-            if opted_out is not None:
+            if opted_out is not None and opted_out.isdigit():
                 if int(opted_out) > 1:
                     yield oo_store.new_opt_out('msisdn', from_addr, {
                         'message_id': message_id,

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -76,3 +76,25 @@ class USSDOptOutHandlerTestCase(EventHandlerTestCase):
 
         [opt_out] = yield self.oo_store.list_opt_outs()
         self.assertTrue(opt_out)
+
+    @inlineCallbacks
+    def test_opt_out_for_empty_outed_out_value(self):
+        msisdn = u'+2345'
+        message_id = u'message-id'
+        event = self.mkevent('survey_completed', {
+            'from_addr': msisdn,
+            'message_id': message_id,
+            'transport_type': 'ussd',
+            }, conv_key=self.conversation.key, account_key=self.account.key)
+
+        contact = yield self.contact_store.new_contact(msisdn=msisdn)
+        contact.extra['opted_out'] = u''
+        yield contact.save()
+
+        opt_outs = yield self.oo_store.list_opt_outs()
+        self.assertEqual(opt_outs, [])
+
+        yield self.publish_event(event)
+
+        opt_outs = yield self.oo_store.list_opt_outs()
+        self.assertEqual(opt_outs, [])


### PR DESCRIPTION
Because of how the contact import worked at one point, there are some
values in the `contact.extra` dict that are empty strings. When trying
to `int()` that value it spews an error.
