### PR TITLE
Django management command to pull out simple stats per conversation.

### DIFF
--- a/go/base/management/commands/go_account_stats.py
+++ b/go/base/management/commands/go_account_stats.py
@@ -1,0 +1,136 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from go.base.utils import vumi_api_for_user
+
+
+def per_date(collection):
+    bucket = {}
+    for message in collection:
+        key = message['timestamp'].date()
+        bucket.setdefault(key, 0)
+        bucket[key] += 1
+    return bucket
+
+
+def print_dates(bucket, io):
+    items = sorted(bucket.items(), key=lambda t: t[0])
+    for item, count in items:
+        io.write('%s: %s\n' % (item.strftime('%Y-%m-%d'), count))
+
+
+def get_inbound(conversation):
+    batch_keys = conversation.get_batch_keys()
+    replies = []
+    for batch_id in batch_keys:
+        replies.extend(conversation.mdb.batch_replies(batch_id))
+    return replies
+
+
+def get_outbound(conversation):
+    batch_keys = conversation.get_batch_keys()
+    messages = []
+    for batch_id in batch_keys:
+        messages.extend(conversation.mdb.batch_messages(batch_id))
+    return messages
+
+
+def get_msisdns(key, collection):
+    uniques = set([])
+    for message in collection:
+        uniques.add(message[key])
+    return uniques
+
+
+class Command(BaseCommand):
+    help = """
+    Generate stats for a given Vumi Go account.
+
+    """
+    args = "<email-address> <command>"
+
+    def handle(self, *args, **options):
+
+        if len(args) == 0:
+            self.print_command_summary()
+            return
+        elif len(args) < 2:
+            self.stderr.write('Usage <email-address> <command>\n')
+            return
+
+        email_address = args[0]
+        command = args[1]
+
+        try:
+            user = User.objects.get(username=email_address)
+            api = self.get_api(user)
+        except User.DoesNotExist:
+            self.stderr.write('Account does not exist\n')
+
+        handler = getattr(self, 'handle_%s' % (command,), self.unknown_command)
+        handler(user, api, args[2:])
+
+    def get_api(self, user):
+        return vumi_api_for_user(user)
+
+    def print_command_summary(self):
+        self.stdout.write('Known commands:\n')
+        handlers = [func for func in dir(self)
+                        if func.startswith('handle_')]
+        for handler in sorted(handlers):
+            command = handler.split('_', 1)[1]
+            func = getattr(self, handler)
+            self.stdout.write('%s:' % (command,))
+            self.stdout.write('%s\n' % (func.__doc__,))
+        return
+
+    def unknown_command(self, *args, **kwargs):
+        self.stderr.write('Unknown command\n')
+
+    def handle_list_conversations(self, user, api, options):
+        """
+        List all conversations for the user.
+
+            go_account_stats <email-address> list_conversations
+            go_account_stats <email-address> list_conversations active
+
+        Appending 'active' limits the list to only active conversations.
+        """
+        conversations = sorted(map(api.wrap_conversation,
+                            api.conversation_store.list_conversations()),
+                            key=lambda c: c.created_at)
+        if 'active' in options:
+            conversations = [c for c in conversations if not c.ended()]
+        for index, conversation in enumerate(conversations):
+            self.stdout.write('%s. %s (%s) [%s]\n' % (index,
+                conversation.subject, conversation.created_at,
+                conversation.key))
+
+    def handle_stats(self, user, api, options):
+        """
+        Get stats for a given conversation key.
+
+            go_account_stats <email-address> stats <conversation-key>
+
+        """
+        if not len(options) == 1:
+            self.stderr.write('Provide a conversation key')
+            return
+        conv_key = options[0]
+        raw_conv = api.conversation_store.get_conversation_by_key(conv_key)
+        conversation = api.wrap_conversation(raw_conv)
+
+        self.stdout.write('Conversation: %s\n' % (conversation.subject,))
+
+        inbound = get_inbound(conversation)
+        outbound = get_outbound(conversation)
+        inbound_msisdns = get_msisdns('from_addr', inbound)
+        outbound_msisdns = get_msisdns('to_addr', outbound)
+        all_msisdns = inbound_msisdns.union(outbound_msisdns)
+
+        self.stdout.write('Total Received: %s\n' % (len(inbound),))
+        self.stdout.write('Total Sent: %s\n' % (len(outbound),))
+        self.stdout.write('Total Uniques: %s\n' % (len(all_msisdns),))
+        self.stdout.write('Received per date:\n')
+        print_dates(per_date(inbound), self.stdout)
+        self.stdout.write('Sent per date:\n')
+        print_dates(per_date(outbound), self.stdout)

--- a/go/base/management/commands/go_list_accounts.py
+++ b/go/base/management/commands/go_list_accounts.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from django.contrib.auth.models import User
+
+
+class Command(BaseCommand):
+    help = """
+    List known accounts on Vumi Go. Allows for optional searching on the
+    username.
+
+    Usage:
+
+    ./go-admin.sh go_list_accounts:
+
+        Lists all known accounts ordered by `date_joined`
+
+    ./go-admin.sh go_list_accounts <optional regex>:
+
+        Lists all known accounts order_by `date_joined` matching
+        the given regular expression.
+
+    """
+    args = "[optional username regex]"
+
+    def handle(self, *usernames, **options):
+        users = User.objects.all().order_by('date_joined')
+        if usernames:
+            or_statements = [Q(username__regex=un) for un in usernames]
+            or_query = reduce(lambda x, y: x | y, or_statements)
+            users = users.filter(or_query)
+        if not users.exists():
+            self.stderr.write('No accounts found.\n')
+        for index, user in enumerate(users):
+            profile = user.get_profile()
+            self.stdout.write('%s. %s <%s> [%s]\n' % (index, profile,
+                user.username, profile.user_account))

--- a/go/base/tests/test_go_account_stats.py
+++ b/go/base/tests/test_go_account_stats.py
@@ -1,0 +1,65 @@
+from StringIO import StringIO
+from datetime import datetime
+
+from django.contrib.auth.models import User
+
+from go.base.tests.utils import VumiGoDjangoTestCase
+from go.base.management.commands import go_account_stats
+from go.base.utils import vumi_api_for_user
+
+
+class GoAccountStatsCommandTestCase(VumiGoDjangoTestCase):
+
+    USE_RIAK = True
+
+    def setUp(self):
+        super(GoAccountStatsCommandTestCase, self).setUp()
+        self.user = User.objects.create(username='test@user.com',
+            first_name='Test', last_name='User', password='password',
+            email='test@user.com')
+
+        self.api = vumi_api_for_user(self.user)
+
+        def mkconv(*args, **kwargs):
+            return self.api.wrap_conversation(
+                self.api.conversation_store.new_conversation(*args, **kwargs))
+
+        self.active_conv = mkconv(u'bulk_message', u'active', u'content')
+        self.inactive_conv = mkconv(u'bulk_message', u'inactive', u'content',
+            end_timestamp=datetime.now())
+        self.assertTrue(self.inactive_conv.ended())
+
+        self.command = go_account_stats.Command()
+        self.command.stdout = StringIO()
+        self.command.stderr = StringIO()
+
+    def test_command_summary(self):
+        self.command.handle()
+        output = self.command.stdout.getvalue().split('\n')
+        self.assertEqual(output[0], 'Known commands:')
+        self.assertEqual(output[1], 'list_conversations:')
+
+    def test_list_conversations(self):
+        self.command.handle('test@user.com', 'list_conversations')
+        output = self.command.stdout.getvalue().strip().split('\n')
+        self.assertEqual(len(output), 2)
+        self.assertTrue(self.active_conv.key in output[0])
+        self.assertTrue(self.inactive_conv.key in output[1])
+
+    def test_list_conversations_active(self):
+        self.command.handle('test@user.com', 'list_conversations', 'active')
+        output = self.command.stdout.getvalue().strip().split('\n')
+        self.assertEqual(len(output), 1)
+        self.assertTrue(self.active_conv.key in output[0])
+
+    def test_stats(self):
+        self.command.handle('test@user.com', 'stats', self.active_conv.key)
+        output = self.command.stdout.getvalue().strip().split('\n')
+        self.assertEqual(output, [
+            u'Conversation: active',
+            u'Total Received: 0',
+            u'Total Sent: 0',
+            u'Total Uniques: 0',
+            u'Received per date:',
+            u'Sent per date:',
+        ])

--- a/go/base/tests/test_go_list_accounts.py
+++ b/go/base/tests/test_go_list_accounts.py
@@ -1,0 +1,37 @@
+from django.contrib.auth.models import User
+from go.base.tests.utils import VumiGoDjangoTestCase
+from go.base.management.commands import go_list_accounts
+from StringIO import StringIO
+
+
+class GoListAccountsCommandTestCase(VumiGoDjangoTestCase):
+
+    USE_RIAK = True
+
+    def setUp(self):
+        super(GoListAccountsCommandTestCase, self).setUp()
+        self.user = User.objects.create(username='test@user.com',
+            first_name='Test', last_name='User', password='password',
+            email='test@user.com')
+
+        self.command = go_list_accounts.Command()
+        self.command.stdout = StringIO()
+        self.command.stderr = StringIO()
+
+    def test_account_listing(self):
+        self.command.handle()
+        self.assertEqual(self.command.stdout.getvalue(),
+            '0. Test User <test@user.com> [%s]\n' % (
+                self.user.get_profile().user_account))
+
+    def test_account_matching(self):
+        self.command.handle('test')
+        self.assertEqual(self.command.stdout.getvalue(),
+            '0. Test User <test@user.com> [%s]\n' % (
+                self.user.get_profile().user_account))
+
+    def test_account_mismatching(self):
+        self.command.handle('foo')
+        self.assertEqual(self.command.stderr.getvalue(),
+            'No accounts found.\n')
+        self.assertEqual(self.command.stdout.getvalue(), '')


### PR DESCRIPTION
```
List command options:
  ./go-admin.sh go_account_stats 

List conversations (append active to exclude inactives):
  ./go-admin.sh go_account_stats <email-address> list_conversations 

Get stats:
  ./go-admin.sh go_account_status <email-address> stats <conv-key>
```
