### PR TITLE
VUMIGO-205 less celery

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -219,7 +219,6 @@ SEND_FROM_EMAIL_ADDRESS = 'no-reply-vumigo@praekeltfoundation.org'
 #       configuration file so that configuration values aren't
 #       duplicated
 VUMI_API_CONFIG = {
-    'message_sender': {},
     'redis_manager': {'key_prefix': 'vumigo'},
     'riak_manager': {'bucket_prefix': 'vumigo.'},
     }

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -411,6 +411,7 @@ class AsyncMessageSender(object):
         self.publisher.publish_message(command)
 
     def make_publisher(self):
+        "Build a Publisher class with the right attributes on it."
         return type("VumiApiCommandPublisher", (Publisher,),
                     self.publisher_config.copy())
 

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -180,31 +180,30 @@ class VumiApi(object):
 
         # message sending API
         if sender is None:
-            sender = MessageSender({})
+            sender = MessageSender()
         self.mapi = sender
 
     @staticmethod
     def _parse_config(config):
         riak_config = config.get('riak_manager', {})
         redis_config = config.get('redis_manager', {})
-        sender_config = config.get('message_sender', {})
-        return riak_config, redis_config, sender_config
+        return riak_config, redis_config
 
     @classmethod
     def from_config(cls, config):
-        riak_config, redis_config, sender_config = cls._parse_config(config)
+        riak_config, redis_config = cls._parse_config(config)
         manager = RiakManager.from_config(riak_config)
         redis = RedisManager.from_config(redis_config)
-        sender = MessageSender(sender_config)
+        sender = MessageSender()
         return cls(manager, redis, sender)
 
     @classmethod
     @inlineCallbacks
     def from_config_async(cls, config):
-        riak_config, redis_config, sender_config = cls._parse_config(config)
+        riak_config, redis_config = cls._parse_config(config)
         manager = TxRiakManager.from_config(riak_config)
         redis = yield TxRedisManager.from_config(redis_config)
-        sender = MessageSender(sender_config)
+        sender = MessageSender()
         returnValue(cls(manager, redis, sender))
 
     def batch_start(self, tags):
@@ -382,9 +381,8 @@ class VumiApi(object):
 
 
 class MessageSender(object):
-    def __init__(self, config):
+    def __init__(self):
         from go.vumitools import api_celery
-        self.config = config
         self.sender_api = api_celery
         self.publisher_config = VumiApiCommand.default_routing_config()
 

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -247,34 +247,6 @@ class VumiApi(object):
         self.mapi.send_command(
             VumiApiCommand.command(worker_name, command, *args, **kwargs))
 
-    def batch_send(self, batch_id, msg, msg_options, addresses):
-        """Send a batch of text message to a list of addresses.
-
-        Use multiple calls to :meth:`batch_send` if you have *lots* of
-        addresses and don't want to pass them all in one API
-        call. Messages passed to multiple calls to :meth:`batch_send`
-        do not have to be the same.
-
-        :type batch_id: str
-        :param batch_id:
-            batch to append the messages too
-        :type msg: unicode
-        :param msg:
-            text to send
-        :type msg_options: dict
-        :param msg_options:
-            additional paramters for the outgoing Vumi message, usually
-            something like {'from_addr': '+1234'} or {}.
-        :type addresses:
-        :param msg:
-            list of addresses to send messages to
-        :rtype:
-            None.
-        """
-        for address in addresses:
-            command = VumiApiCommand.send(batch_id, msg, msg_options, address)
-            self.mapi.send_command(command)
-
     def batch_status(self, batch_id):
         """Check the status of a batch of messages.
 
@@ -442,13 +414,6 @@ class VumiApiCommand(Message):
                                  # JSON.
             'kwargs': kwargs,
         })
-
-    @classmethod
-    def send(cls, batch_id, msg, msg_options, address):
-        options = msg_options.copy()
-        worker_name = options.pop('worker_name')
-        return cls.command(worker_name, 'send', batch_id=batch_id,
-            content=msg, to_addr=address, msg_options=options)
 
 
 class VumiApiEvent(Message):

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
+from vumi.errors import VumiError
 from vumi.message import Message
 from vumi.components.tagpool import TagpoolManager
 from vumi.components.message_store import MessageStore
@@ -177,10 +178,6 @@ class VumiApi(object):
         self.mdb = MessageStore(self.manager,
                                 self.redis.sub_manager('message_store'))
         self.account_store = AccountStore(self.manager)
-
-        # message sending API
-        if sender is None:
-            sender = MessageSender()
         self.mapi = sender
 
     @staticmethod
@@ -243,6 +240,8 @@ class VumiApi(object):
         :param *args: Positional args for command.
         :param **kwargs: Keyword args for command.
         """
+        if self.mapi is None:
+            raise VumiError("No message sender on API object.")
         self.mapi.send_command(
             VumiApiCommand.command(worker_name, command, *args, **kwargs))
 

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -269,7 +269,8 @@ class EventDispatcher(ApplicationWorker):
         self.handlers = {}
 
         self.api_command_publisher = yield self.publish_to('vumi.api')
-        self.vumi_api = yield VumiApi.from_config_async(self.config)
+        self.vumi_api = yield VumiApi.from_config_async(
+            self.config, self._amqp_client)
         self.account_config = {}
 
         for name, handler_class in self.handler_config.items():

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -20,7 +20,8 @@ class GoApplicationMixin(object):
 
     @inlineCallbacks
     def _go_setup_application(self):
-        self.vumi_api = yield VumiApi.from_config_async(self.config)
+        self.vumi_api = yield VumiApi.from_config_async(
+            self.config, self._amqp_client)
 
         # In case we need these.
         self.redis = self.vumi_api.redis

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -172,7 +172,7 @@ class TestVumiUserApi(TestTxVumiUserApi):
 class TestMessageSender(TestCase, CeleryTestMixIn):
     def setUp(self):
         self.setup_celery_for_tests()
-        self.mapi = MessageSender({})
+        self.mapi = MessageSender()
 
     def tearDown(self):
         self.restore_celery()

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -210,6 +210,8 @@ class AppWorkerTestCase(GoPersistenceMixin, CeleryTestMixIn,
     def setUp(self):
         yield super(AppWorkerTestCase, self).setUp()
         if self.override_dummy_consumer:
+            # Set up the vumi exchange, in case we don't have one.
+            self._amqp.exchange_declare('vumi', 'direct')
             self.VUMI_COMMANDS_CONSUMER = (
                 dummy_consumer_factory_factory_factory(self.publish_command))
         self.setup_celery_for_tests()


### PR DESCRIPTION
This was actually easier to fix than I had expected. We now differentiate between sync and async message senders and require an AMQP client object to be passed into `VumiApi.from_config_async()` for the latter.
