### PR TITLE
Vxpolls improved exporting of user data.

### DIFF
--- a/go/apps/surveys/templates/surveys/includes/download.html
+++ b/go/apps/surveys/templates/surveys/includes/download.html
@@ -7,10 +7,7 @@
     <div class="span12">
         <table>
             <tr>
-                <td>Download <a href="{% url dashboard:export_users poll_id=poll_id %}">User data</a></td>
-            </tr>
-            <tr>
-                <td>Download <a href="{% url dashboard:export_results poll_id=poll_id %}">Poll results</a></td>
+                <td>Download <a href="{% url survey:user_data conversation_key=conversation.key %}">User data</a></td>
             </tr>
         </table>
     </div>

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -29,6 +29,12 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         conv = self.conv_store.get_conversation_by_key(self.conv_key)
         return self.user_api.wrap_conversation(conv)
 
+    def create_poll(self, conversation, **kwargs):
+        poll_id = 'poll-%s' % (conversation.key,)
+        pm, config = get_poll_config(poll_id)
+        config.update(kwargs)
+        return pm, pm.register(poll_id, config)
+
     def run_new_conversation(self, selected_option, pool, tag):
         # render the form
         self.assertEqual(len(self.conv_store.list_conversations()), 1)
@@ -221,3 +227,29 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(question['valid_responses'], [
             'rock', 'jazz', 'techno'])
         self.assertEqual(question['label'], 'favorite music')
+
+    def test_export_user_data(self):
+        survey_url = reverse('survey:user_data', kwargs={
+            'conversation_key': self.conv_key,
+        })
+        pm, poll = self.create_poll(self.conversation, questions=[{
+                'copy': 'question-1',
+                'label': 'label-1',
+            }, {
+                'copy': 'question-2',
+                'label': 'label-2',
+            }])
+
+        participant = pm.get_participant(poll.poll_id, 'user-1')
+        participant.has_unanswered_question = True
+        participant.set_last_question_index(0)
+        poll.submit_answer(participant, 'answer 1')
+        participant.set_last_question_index(1)
+        poll.submit_answer(participant, 'answer 2')
+
+        response = self.client.get(survey_url)
+        self.assertEqual(response['Content-Type'], 'application/csv')
+        lines = response.content.split('\r\n')
+        self.assertEqual(lines[0], 'user_id,user_timestamp,label-1,label-2')
+        self.assertTrue(lines[1].startswith('user-1'))
+        self.assertTrue(lines[1].endswith(',answer 1,answer 2'))

--- a/go/apps/surveys/urls.py
+++ b/go/apps/surveys/urls.py
@@ -10,4 +10,6 @@ urlpatterns = patterns('',
     url(r'^(?P<conversation_key>\w+)/start/$', views.start, name='start'),
     url(r'^(?P<conversation_key>\w+)/end/$', views.end, name='end'),
     url(r'^(?P<conversation_key>\w+)/edit/$', views.edit, name='edit'),
+    url(r'^(?P<conversation_key>\w+)/users\.csv$', views.download_user_data,
+        name='user_data'),
 )

--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.conf import settings
+from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from django.contrib import messages
 from django.core.urlresolvers import reverse
@@ -285,3 +286,13 @@ def edit(request, conversation_key):
         'questions_formset': questions_formset,
         'completed_response_formset': completed_response_formset,
     })
+
+
+@login_required
+def download_user_data(request, conversation_key):
+    conversation = conversation_or_404(request.user_api, conversation_key)
+    poll_id = 'poll-%s' % (conversation.key,)
+    pm, poll_data = get_poll_config(poll_id)
+    poll = pm.get(poll_id)
+    csv_data = pm.export_user_data_as_csv(poll)
+    return HttpResponse(csv_data, content_type='application/csv')

--- a/go/urls.py
+++ b/go/urls.py
@@ -37,7 +37,6 @@ urlpatterns = patterns('',
         include('go.apps.urls')),
     url(r'^contacts/', include('go.contacts.urls', namespace='contacts')),
     url(r'^account/', include('go.account.urls', namespace='account')),
-    url(r'^', include('vxpolls.urls')),
 )
 
 urlpatterns += patterns('django.contrib.flatpages.views',


### PR DESCRIPTION
This makes use of that and removes vxpolls.urls which was a hacky way of
providing the same features but with messier data.

This requires praekelt/vxpolls#37 to land first.
