### PR TITLE
Fix stats script errors

### DIFF
--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 from django.contrib.auth.models import User
 
@@ -5,6 +7,8 @@ from go.base.tests.utils import VumiGoDjangoTestCase, declare_longcode_tags
 from go.vumitools.tests.utils import CeleryTestMixIn
 from go.vumitools.api import VumiApi
 from go.base.utils import vumi_api_for_user
+
+from vumi.message import TransportUserMessage
 
 
 class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
@@ -17,6 +21,10 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
     TEST_CONVERSATION_PARAMS = None
     TEST_START_PARAMS = None
     VIEWS_CLASS = None
+
+    # These are used for the mkmsg_in and mkmsg_out helper methods
+    transport_name = 'sphex'
+    transport_type = 'sms'
 
     def setUp(self):
         super(DjangoGoApplicationTestCase, self).setUp()
@@ -69,6 +77,62 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
         }
         defaults.update(kwargs)
         return self.conv_store.new_conversation(**defaults)
+
+    def mkmsg_in(self, content='hello world', message_id='abc',
+                 to_addr='9292', from_addr='+41791234567', group=None,
+                 session_event=None, transport_type=None,
+                 helper_metadata=None, transport_metadata=None,
+                 transport_name=None):
+        if transport_type is None:
+            transport_type = self.transport_type
+        if helper_metadata is None:
+            helper_metadata = {}
+        if transport_metadata is None:
+            transport_metadata = {}
+        if transport_name is None:
+            transport_name = self.transport_name
+        return TransportUserMessage(
+            from_addr=from_addr,
+            to_addr=to_addr,
+            group=group,
+            message_id=message_id,
+            transport_name=transport_name,
+            transport_type=transport_type,
+            transport_metadata=transport_metadata,
+            helper_metadata=helper_metadata,
+            content=content,
+            session_event=session_event,
+            timestamp=datetime.now(),
+            )
+
+    def mkmsg_out(self, content='hello world', message_id='1',
+                  to_addr='+41791234567', from_addr='9292', group=None,
+                  session_event=None, in_reply_to=None,
+                  transport_type=None, transport_metadata=None,
+                  transport_name=None, helper_metadata=None,
+                  ):
+        if transport_type is None:
+            transport_type = self.transport_type
+        if transport_metadata is None:
+            transport_metadata = {}
+        if transport_name is None:
+            transport_name = self.transport_name
+        if helper_metadata is None:
+            helper_metadata = {}
+        params = dict(
+            to_addr=to_addr,
+            from_addr=from_addr,
+            group=group,
+            message_id=message_id,
+            transport_name=transport_name,
+            transport_type=transport_type,
+            transport_metadata=transport_metadata,
+            content=content,
+            session_event=session_event,
+            in_reply_to=in_reply_to,
+            helper_metadata=helper_metadata,
+            )
+        return TransportUserMessage(**params)
 
     def mkcontact(self, name=None, surname=None, msisdn=u'+1234567890',
                   **kwargs):

--- a/go/base/management/commands/go_account_stats.py
+++ b/go/base/management/commands/go_account_stats.py
@@ -117,9 +117,7 @@ class Command(BaseCommand):
             self.err(u'Provide a conversation key')
             return
         conv_key = options[0]
-        raw_conv = api.conversation_store.get_conversation_by_key(conv_key)
-
-        conversation = api.wrap_conversation(raw_conv)
+        conversation = api.get_wrapped_conversation(conv_key)
         message_store = api.api.mdb
         self.out(u'Conversation: %s\n' % (conversation.subject,))
 

--- a/go/base/management/commands/go_account_stats.py
+++ b/go/base/management/commands/go_account_stats.py
@@ -6,7 +6,7 @@ from go.base.utils import vumi_api_for_user
 def per_date(collection):
     bucket = {}
     for message in collection:
-        key = message['timestamp'].date()
+        key = message.msg['timestamp'].date()
         bucket.setdefault(key, 0)
         bucket[key] += 1
     return bucket
@@ -18,26 +18,20 @@ def print_dates(bucket, io):
         io.write('%s: %s\n' % (item.strftime('%Y-%m-%d'), count))
 
 
-def get_inbound(conversation):
-    batch_keys = conversation.get_batch_keys()
-    replies = []
-    for batch_id in batch_keys:
-        replies.extend(conversation.mdb.batch_replies(batch_id))
-    return replies
+def get_inbound(message_store, keys):
+    for key in keys:
+        yield message_store.inbound_messages.load(key)
 
 
-def get_outbound(conversation):
-    batch_keys = conversation.get_batch_keys()
-    messages = []
-    for batch_id in batch_keys:
-        messages.extend(conversation.mdb.batch_messages(batch_id))
-    return messages
+def get_outbound(message_store, keys):
+    for key in keys:
+        yield message_store.outbound_messages.load(key)
 
 
 def get_msisdns(key, collection):
     uniques = set([])
     for message in collection:
-        uniques.add(message[key])
+        uniques.add(message.msg[key])
     return uniques
 
 
@@ -124,18 +118,34 @@ class Command(BaseCommand):
             return
         conv_key = options[0]
         raw_conv = api.conversation_store.get_conversation_by_key(conv_key)
-        conversation = api.wrap_conversation(raw_conv)
 
+        conversation = api.wrap_conversation(raw_conv)
+        message_store = api.api.mdb
         self.out(u'Conversation: %s\n' % (conversation.subject,))
 
-        inbound = get_inbound(conversation)
-        outbound = get_outbound(conversation)
+        for batch_key in conversation.batches.keys():
+            self.handle_batch_key(message_store, batch_key)
+            self.handle_batch_key_breakdown(message_store, batch_key)
+
+    def handle_batch_key(self, message_store, batch_key):
+        self.out(u'Total Received in batch %s: %s\n' % (
+            batch_key, message_store.batch_inbound_count(batch_key),))
+        self.out(u'Total Sent in batch %s: %s\n' % (
+            batch_key, message_store.batch_outbound_count(batch_key),))
+
+    def handle_batch_key_breakdown(self, message_store, batch_key):
+        inbound_keys = message_store.inbound_messages.by_index(
+            return_keys=True, batch=batch_key)
+
+        outbound_keys = message_store.outbound_messages.by_index(
+            return_keys=True, batch=batch_key)
+
+        inbound = list(get_inbound(message_store, inbound_keys))
+        outbound = list(get_outbound(message_store, outbound_keys))
         inbound_msisdns = get_msisdns('from_addr', inbound)
         outbound_msisdns = get_msisdns('to_addr', outbound)
         all_msisdns = inbound_msisdns.union(outbound_msisdns)
 
-        self.out(u'Total Received: %s\n' % (len(inbound),))
-        self.out(u'Total Sent: %s\n' % (len(outbound),))
         self.out(u'Total Uniques: %s\n' % (len(all_msisdns),))
         self.out(u'Received per date:\n')
         print_dates(per_date(inbound), self.stdout)


### PR DESCRIPTION
The stats script is making Riak unhappy because we're pulling out all
objects. This change has the stats script use the new `by_index_count`
stuff to get the totals and then pulling all keys one by one to get the
per date breakdown. It's slower but unlikely to create problems for
Riak.
