### PR TITLE
The WindowManager should understand `nack` messages

### DIFF
--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -95,8 +95,8 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         nack = self.mkmsg_nack(user_message_id=msg2['message_id'],
             nack_reason='unknown')
 
-        yield self.dispatch(ack, rkey='%s.event' % (self.transport_name,))
-        yield self.dispatch(nack, rkey='%s.event' % (self.transport_name,))
+        yield self.dispatch_event(ack)
+        yield self.dispatch_event(nack)
 
         # Assert that the window's now empty because acks have been received
         self.assertEqual(

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -89,14 +89,14 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         msgs.sort(key=lambda msg: msg['to_addr'])
         [msg1, msg2] = msgs
 
-        # Create acks for messages
-        ack1 = self.mkmsg_ack(user_message_id=msg1['message_id'],
+        # Create an ack and a nack for the messages
+        ack = self.mkmsg_ack(user_message_id=msg1['message_id'],
             sent_message_id=msg1['message_id'])
-        ack2 = self.mkmsg_ack(user_message_id=msg2['message_id'],
-            sent_message_id=msg2['message_id'])
+        nack = self.mkmsg_nack(user_message_id=msg2['message_id'],
+            nack_reason='unknown')
 
-        yield self.dispatch(ack1, rkey='%s.event' % (self.transport_name,))
-        yield self.dispatch(ack2, rkey='%s.event' % (self.transport_name,))
+        yield self.dispatch(ack, rkey='%s.event' % (self.transport_name,))
+        yield self.dispatch(nack, rkey='%s.event' % (self.transport_name,))
 
         # Assert that the window's now empty because acks have been received
         self.assertEqual(

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -104,8 +104,14 @@ class BulkMessageApplication(GoApplicationWorker):
         tag = TaggingMiddleware.map_msg_to_tag(msg)
         return self.vumi_api.mdb.add_inbound_message(msg, tag=tag)
 
-    @inlineCallbacks
     def consume_ack(self, event):
+        return self.handle_event(event)
+
+    def consume_nack(self, event):
+        return self.handle_event(event)
+
+    @inlineCallbacks
+    def handle_event(self, event):
         yield self.vumi_api.mdb.add_event(event)
 
         message = yield self.find_message_for_event(event)


### PR DESCRIPTION
The WindowManager pops messages out of the flight window when an ack is
received. It should do the same for `nack` messages.

Wrote a `handle_event()` method at which we can throw any type of event,
would've liked to have called it `consume_event` but that's already
being used by the base class.
