### PR TITLE
Allow for cache reconciliation

### DIFF
--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -256,16 +256,6 @@ class TestBulkMessageApplication(AppWorkerTestCase):
     def test_reconcile_cache(self):
         conv = yield self.create_conversation(
             delivery_tag_pool=u'pool', delivery_class=u'sms')
-        yield self.start_conversation(conv)
-        [batch_id] = conv.get_batch_keys()
-
-        mkid = TransportUserMessage.generate_id
-        yield self.user_api.api.mdb.add_outbound_message(
-            self.mkmsg_out("out 1", message_id=mkid()), batch_id=batch_id)
-        yield self.user_api.api.mdb.add_outbound_message(
-            self.mkmsg_out("out 2", message_id=mkid()), batch_id=batch_id)
-        yield self.user_api.api.mdb.add_inbound_message(
-            self.mkmsg_in("in 2", message_id=mkid()), batch_id=batch_id)
 
         with LogCatcher() as logger:
             yield self.dispatch_command(

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -6,6 +6,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import Clock
 
 from vumi.message import TransportUserMessage
+from vumi.tests.utils import LogCatcher
 
 from go.vumitools.tests.utils import AppWorkerTestCase
 from go.vumitools.window_manager import WindowManager
@@ -250,3 +251,33 @@ class TestBulkMessageApplication(AppWorkerTestCase):
                 u'messages_sent': [2],
                 u'messages_received': [1],
                 }, metrics)
+
+    @inlineCallbacks
+    def test_reconcile_cache(self):
+        conv = yield self.create_conversation(
+            delivery_tag_pool=u'pool', delivery_class=u'sms')
+        yield self.start_conversation(conv)
+        [batch_id] = conv.get_batch_keys()
+
+        mkid = TransportUserMessage.generate_id
+        yield self.user_api.api.mdb.add_outbound_message(
+            self.mkmsg_out("out 1", message_id=mkid()), batch_id=batch_id)
+        yield self.user_api.api.mdb.add_outbound_message(
+            self.mkmsg_out("out 2", message_id=mkid()), batch_id=batch_id)
+        yield self.user_api.api.mdb.add_inbound_message(
+            self.mkmsg_in("in 2", message_id=mkid()), batch_id=batch_id)
+
+        with LogCatcher() as logger:
+            yield self.dispatch_command(
+                'reconcile_cache', conversation_key='bogus key',
+                user_account_key=self.user_account.key)
+
+            yield self.dispatch_command(
+                'reconcile_cache', conversation_key=conv.key,
+                user_account_key=self.user_account.key)
+
+            [err] = logger.errors
+            [msg] = logger.messages()
+            self.assertTrue('Conversation does not exist: bogus key'
+                                in err['message'][0])
+            self.assertEqual('Reconciling cache for %s' % (conv.key,), msg)

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from go.vumitools.api import SyncMessageSender, VumiApiCommand
+
+
+class Command(BaseCommand):
+    help = "Send a VumiApi command to an application worker"
+    args = "<worker-name> <event-type> key1=value1 key2=value2"
+    sender_class = SyncMessageSender
+    # List of allowed commands
+    allowed_commands = [
+        'reconcile_cache',
+    ]
+
+    def handle(self, worker_name, command, parameters, **config):
+        self.sender = self.sender_class()
+        if command not in self.allowed_commands:
+            self.stderr.write('Unknown command %s' % (command,))
+
+        command_parameters = dict([parameter.strip().split('=', 1)
+                                    for parameter in parameters.split(' ')])
+
+        cmd = VumiApiCommand.command(worker_name, command,
+            **command_parameters)
+        self.sender.send_command(cmd)

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -11,14 +11,19 @@ class Command(BaseCommand):
         'reconcile_cache',
     ]
 
-    def handle(self, worker_name, command, parameters, **config):
+    def handle(self, worker_name, command, *parameters, **config):
         self.sender = self.sender_class()
         if command not in self.allowed_commands:
             self.stderr.write('Unknown command %s' % (command,))
 
-        command_parameters = dict([parameter.strip().split('=', 1)
-                                    for parameter in parameters.split(' ')])
+        args = []
+        kwargs = {}
+        for parameter in parameters:
+            parameter = parameter.strip()
+            if '=' in parameter:
+                kwargs.update(dict((parameter.split('=', 1),)))
+            else:
+                args.append(parameter)
 
-        cmd = VumiApiCommand.command(worker_name, command,
-            **command_parameters)
+        cmd = VumiApiCommand.command(worker_name, command, *args, **kwargs)
         self.sender.send_command(cmd)

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
             conversation = user_api.get_wrapped_conversation(conversation_key)
             if conversation is None:
-                raise Command('Conversation does not exist')
+                raise CommandError('Conversation does not exist')
 
             return VumiApiCommand.command(worker_name, command,
                 user_account_key=account_key,

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -1,5 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+
 from go.vumitools.api import SyncMessageSender, VumiApiCommand
+from go.base.utils import vumi_api_for_user
 
 
 class Command(BaseCommand):
@@ -27,5 +30,17 @@ class Command(BaseCommand):
 
     def handle_reconcile_cache(self, worker_name, command, account_key,
         conversation_key):
-        return VumiApiCommand.command(worker_name, command,
-            user_account_key=account_key, conversation_key=conversation_key)
+
+        try:
+            user = User.objects.get(userprofile__user_account=account_key)
+            user_api = vumi_api_for_user(user)
+
+            conversation = user_api.get_wrapped_conversation(conversation_key)
+            if conversation is None:
+                raise Command('Conversation does not exist')
+
+            return VumiApiCommand.command(worker_name, command,
+                user_account_key=account_key,
+                conversation_key=conversation_key)
+        except User.DoesNotExist:
+            raise CommandError('Account does not exist')

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -1,20 +1,17 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from go.vumitools.api import SyncMessageSender, VumiApiCommand
 
 
 class Command(BaseCommand):
     help = "Send a VumiApi command to an application worker"
-    args = "<worker-name> <event-type> key1=value1 key2=value2"
+    args = "<worker-name> <command> key1=value1 key2=value2"
     sender_class = SyncMessageSender
-    # List of allowed commands
-    allowed_commands = [
-        'reconcile_cache',
-    ]
 
     def handle(self, worker_name, command, *parameters, **config):
         self.sender = self.sender_class()
-        if command not in self.allowed_commands:
-            self.stderr.write('Unknown command %s' % (command,))
+        handler = getattr(self, 'handle_%s' % (command,), None)
+        if handler is None:
+            raise CommandError('Unknown command %s' % (command,))
 
         args = []
         kwargs = {}
@@ -25,5 +22,10 @@ class Command(BaseCommand):
             else:
                 args.append(parameter)
 
-        cmd = VumiApiCommand.command(worker_name, command, *args, **kwargs)
+        cmd = handler(worker_name, command, *args, **kwargs)
         self.sender.send_command(cmd)
+
+    def handle_reconcile_cache(self, worker_name, command, account_key,
+        conversation_key):
+        return VumiApiCommand.command(worker_name, command,
+            user_account_key=account_key, conversation_key=conversation_key)

--- a/go/base/tests/test_go_account_stats.py
+++ b/go/base/tests/test_go_account_stats.py
@@ -10,8 +10,6 @@ from go.base.utils import vumi_api_for_user
 
 class GoAccountStatsCommandTestCase(DjangoGoApplicationTestCase):
 
-    USE_RIAK = True
-
     def setUp(self):
         super(GoAccountStatsCommandTestCase, self).setUp()
         self.user = self.mk_django_user()

--- a/go/base/tests/test_go_send_app_worker_command.py
+++ b/go/base/tests/test_go_send_app_worker_command.py
@@ -29,17 +29,19 @@ class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
         self.command.stderr = StringIO()
 
     def test_invalid_command(self):
-        self.assertRaises(CommandError, self.command.handle, 'worker-name',
-            'bad_command', 'key=1', 'key=2')
+        self.assertRaisesRegexp(CommandError, 'Unknown command bad_command',
+            self.command.handle, 'worker-name', 'bad_command',
+            'key=1', 'key=2')
 
     def test_reconcile_cache_invalid_user(self):
-        self.assertRaises(CommandError, self.command.handle, 'worker-name',
-            'reconcile_command', 'account_key=foo', 'conversation_key=bar')
+        self.assertRaisesRegexp(CommandError, 'Account does not exist',
+            self.command.handle, 'worker-name', 'reconcile_cache',
+            'account_key=foo', 'conversation_key=bar')
 
     def test_reconcile_cache_invalid_conversation(self):
-        self.assertRaises(CommandError, self.command.handle, 'worker-name',
-            'reconcile_command', 'account_key=%s' % self.account_key,
-            'conversation_key=bar')
+        self.assertRaisesRegexp(CommandError, 'Conversation does not exist',
+            self.command.handle, 'worker-name', 'reconcile_cache',
+            'account_key=%s' % self.account_key, 'conversation_key=bar')
 
     def test_reconcile_cache(self):
         self.command.handle('worker-name', 'reconcile_cache',

--- a/go/base/tests/test_go_send_app_worker_command.py
+++ b/go/base/tests/test_go_send_app_worker_command.py
@@ -26,16 +26,27 @@ class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
         self.command.stderr = StringIO()
 
     def test_invalid_command(self):
-        self.command.handle('worker-name', 'bad_command', 'key=1 key=2')
+        self.command.handle('worker-name', 'bad_command', 'key=1', 'key=2')
         self.assertEqual(self.command.stderr.getvalue(),
             'Unknown command bad_command')
 
     def test_valid_command(self):
-        self.command.handle('worker-name', 'good_command', 'key=1 key=2')
+        self.command.handle('worker-name', 'good_command', 'key=1', 'key=2')
         self.assertEqual(self.command.stderr.getvalue(), '')
         self.assertEqual(self.command.stdout.getvalue(), '')
         [cmd] = self.command.sender.outbox
         self.assertEqual(cmd['worker_name'], 'worker-name')
         self.assertEqual(cmd['command'], 'good_command')
         self.assertEqual(cmd['args'], [])
+        self.assertEqual(cmd['kwargs'], {'key': '1', 'key': '2'})
+
+    def test_valid_command_with_args(self):
+        self.command.handle('worker-name', 'good_command', 'positional-arg',
+                            'key=1', 'key=2')
+        self.assertEqual(self.command.stderr.getvalue(), '')
+        self.assertEqual(self.command.stdout.getvalue(), '')
+        [cmd] = self.command.sender.outbox
+        self.assertEqual(cmd['worker_name'], 'worker-name')
+        self.assertEqual(cmd['command'], 'good_command')
+        self.assertEqual(cmd['args'], ['positional-arg'])
         self.assertEqual(cmd['kwargs'], {'key': '1', 'key': '2'})

--- a/go/base/tests/test_go_send_app_worker_command.py
+++ b/go/base/tests/test_go_send_app_worker_command.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from StringIO import StringIO
+
+from go.base.management.commands import go_send_app_worker_command
+from go.apps.tests.base import DjangoGoApplicationTestCase
+
+
+class DummyMessageSender(object):
+    def __init__(self):
+        self.outbox = []
+
+    def send_command(self, command):
+        self.outbox.append(command)
+
+
+class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
+
+    def setUp(self):
+        super(GoSendAppWorkerCommandTestCase, self).setUp()
+        self.user = self.mk_django_user()
+
+        self.command = go_send_app_worker_command.Command()
+        self.command.sender_class = DummyMessageSender
+        self.command.allowed_commands = ['good_command']
+        self.command.stdout = StringIO()
+        self.command.stderr = StringIO()
+
+    def test_invalid_command(self):
+        self.command.handle('worker-name', 'bad_command', 'key=1 key=2')
+        self.assertEqual(self.command.stderr.getvalue(),
+            'Unknown command bad_command')
+
+    def test_valid_command(self):
+        self.command.handle('worker-name', 'good_command', 'key=1 key=2')
+        self.assertEqual(self.command.stderr.getvalue(), '')
+        self.assertEqual(self.command.stdout.getvalue(), '')
+        [cmd] = self.command.sender.outbox
+        self.assertEqual(cmd['worker_name'], 'worker-name')
+        self.assertEqual(cmd['command'], 'good_command')
+        self.assertEqual(cmd['args'], [])
+        self.assertEqual(cmd['kwargs'], {'key': '1', 'key': '2'})

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -118,7 +118,8 @@ class VumiUserApi(object):
     def get_wrapped_conversation(self, conversation_key):
         conversation = yield self.conversation_store.get_conversation_by_key(
             conversation_key)
-        returnValue(self.wrap_conversation(conversation))
+        if conversation:
+            returnValue(self.wrap_conversation(conversation))
 
     def active_conversations(self):
         conversations = self.conversation_store.conversations

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -147,7 +147,7 @@ class GoApplicationMixin(object):
         message_store = user_api.api.mdb
         for batch_key in conv.get_batch_keys():
             if (yield message_store.needs_reconciliation(batch_key, delta)):
-                yield message_store.cache.reconcile(batch_key)
+                yield message_store.reconcile_cache(batch_key)
 
     @inlineCallbacks
     def get_contact_for_message(self, message):

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -92,6 +92,20 @@ class GoApplicationMixin(object):
     def process_command_collect_metrics(self, conversation_key,
                                         user_account_key):
         key_tuple = (conversation_key, user_account_key)
+        if key_tuple in self._cache_recon_conversations:
+            log.info("Ignoring conversation %s for user %s because the "
+                     "previous recon run is still going." % (
+                        conversation_key, user_account_key))
+            return
+        self._cache_recon_conversations.add(key_tuple)
+        user_api = self.get_user_api(user_account_key)
+        yield self.recon_cache(user_api, conversation_key)
+        self._cache_recon_conversations.remove(key_tuple)
+
+    @inlineCallbacks
+    def process_command_reconcile_cache(self, conversation_key,
+                                        user_account_key):
+        key_tuple = (conversation_key, user_account_key)
         if key_tuple in self._metrics_conversations:
             log.info("Ignoring conversation %s for user %s because the "
                      "previous collection run is still going." % (
@@ -99,7 +113,7 @@ class GoApplicationMixin(object):
             return
         self._metrics_conversations.add(key_tuple)
         user_api = self.get_user_api(user_account_key)
-        yield self.collect_metrics(user_api, conversation_key)
+        yield self.reconcile_cache(user_api, conversation_key)
         self._metrics_conversations.remove(key_tuple)
 
     def process_unknown_cmd(self, method_name, *args, **kwargs):
@@ -109,6 +123,31 @@ class GoApplicationMixin(object):
     def collect_metrics(self, user_api, conversation_key):
         # By default, we don't collect metrics.
         pass
+
+    @inlineCallbacks
+    def reconcile_cache(self, user_api, conversation_key, delta=0.01):
+        """Reconcile the cached values for the conversation.
+
+        Checks whether caches for a conversation are off by a given
+        delta and if so, initiates a full cache reconciliation.
+
+        :param VumiUserApi user_api:
+            The Api for this user
+        :param str conversation_key:
+            The key of the conversation to reconcile
+        :param float delta:
+            If the key count difference between the message_store and
+            the cache is bigger than the delta a reconciliation is initiated.
+        """
+        conv = yield user_api.get_wrapped_conversation(conversation_key)
+        if conv is None:
+            log.error('Conversation does not exist: %s' % (conversation_key,))
+            return
+
+        message_store = user_api.api.mdb
+        for batch_key in conv.get_batch_keys():
+            if (yield message_store.needs_reconciliation(batch_key, delta)):
+                yield message_store.cache.reconcile(batch_key)
 
     @inlineCallbacks
     def get_contact_for_message(self, message):


### PR DESCRIPTION
This PR adds the following:
1. A `go_send_app_worker_command` management command that sends commands
   to app workers.
2. The addition of `process_command_reconcile_cache()` which calls the
   cache recon stuff added in praekelt/vumi#405 and praekelt/vumi#406
