### PR TITLE
Use bytestrings when listing accounts with go_list_accounts

### DIFF
--- a/go/base/management/commands/go_list_accounts.py
+++ b/go/base/management/commands/go_list_accounts.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
 
     """
     args = "[optional username regex]"
+    encoding = 'utf-8'
 
     def handle(self, *usernames, **options):
         users = User.objects.all().order_by('date_joined')
@@ -32,5 +33,6 @@ class Command(BaseCommand):
             self.stderr.write('No accounts found.\n')
         for index, user in enumerate(users):
             profile = user.get_profile()
-            self.stdout.write('%s. %s <%s> [%s]\n' % (index, profile,
-                user.username, profile.user_account))
+            output = u'%s. %s <%s> [%s]\n' % (index, profile, user.username,
+                                                profile.user_account)
+            self.stdout.write(output.encode(self.encoding))

--- a/go/base/management/commands/go_list_accounts.py
+++ b/go/base/management/commands/go_list_accounts.py
@@ -33,6 +33,6 @@ class Command(BaseCommand):
             self.stderr.write('No accounts found.\n')
         for index, user in enumerate(users):
             profile = user.get_profile()
-            output = u'%s. %s <%s> [%s]\n' % (index, profile, user.username,
-                                                profile.user_account)
+            output = u'%s. %s %s <%s> [%s]\n' % (index, user.first_name,
+                user.last_name, user.username, profile.user_account)
             self.stdout.write(output.encode(self.encoding))

--- a/go/base/tests/test_go_list_accounts.py
+++ b/go/base/tests/test_go_list_accounts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from go.base.tests.utils import VumiGoDjangoTestCase
 from go.base.management.commands import go_list_accounts
 from StringIO import StringIO
@@ -21,6 +22,15 @@ class GoListAccountsCommandTestCase(VumiGoDjangoTestCase):
         self.assertEqual(self.command.stdout.getvalue(),
             '0. Test User <username> [%s]\n' % (
                 self.user.get_profile().user_account))
+
+    def test_unicode_account_listing(self):
+        self.user.first_name = u"Tëßt"
+        self.user.save()
+        self.command.handle()
+        profile = self.user.get_profile()
+        self.assertEqual(self.command.stdout.getvalue(),
+            '0. T\xc3\xab\xc3\x9ft User <username> [%s]\n' % (
+                str(profile.user_account)))
 
     def test_account_matching(self):
         self.command.handle('user')


### PR DESCRIPTION
Kotzé was causing ascii errors.
