### PR TITLE
Reduce GoApplicationRouter verbose logging.

### DIFF
--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -379,6 +379,7 @@ class GoApplicationRouter(BaseDispatchRouter):
         message = yield self.vumi_api.mdb.get_outbound_message(user_message_id)
         if message is None:
             log.error('Unable to find message for event: %s' % (event,))
+            return
 
         application = yield self.find_application_for_msg(message)
         returnValue(application)
@@ -395,7 +396,10 @@ class GoApplicationRouter(BaseDispatchRouter):
                 publisher = self.dispatcher.exposed_publisher[application]
                 yield publisher.publish_message(msg)
             else:
-                log.error('No application setup for inbound message '
+                # This often happens when we have a USSD code like *123*4#
+                # and some random person dials *123*4*1# when that isn't
+                # actually configured to route somewhere.
+                log.warning('No application setup for inbound message '
                             'type: %s' % (msg,))
 
     @inlineCallbacks

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -354,8 +354,6 @@ class GoApplicationRouter(BaseDispatchRouter):
         self.conversation_mappings = self.config['conversation_mappings']
         self.upstream_transport = self.config['upstream_transport']
         self.optout_transport = self.config['optout_transport']
-
-        # TODO: Fix this madness.
         self.vumi_api = yield VumiApi.from_config_async(self.config)
 
     @inlineCallbacks


### PR DESCRIPTION
Fixes some small issues:
1. The code didn't return from a situation where it couldn't continue
   anyway and as a result a second error was logged.
2. When we received an unroutable message we now log a warning and not
   an error since this almost exclusively happens with USSD.
