### PR TITLE
contact_for_addr fixes for twitter and tests

### DIFF
--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -385,6 +385,26 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
             'q': 'name:%s' % (self.contact.name,)
         })
 
+    def test_contact_for_addr(self):
+        sms_contact = self.mkcontact(msisdn=u'+270000000')
+        twitter_contact = self.mkcontact(twitter_handle=u'@someone')
+        gtalk_contact = self.mkcontact(gtalk_id=u'gtalk@host.com')
+
+        self.assertEqual(
+            self.contact_store.contact_for_addr('sms', '+270000000').key,
+            sms_contact.key)
+        self.assertEqual(
+            self.contact_store.contact_for_addr('ussd', '+270000000').key,
+            sms_contact.key)
+        self.assertEqual(
+            self.contact_store.contact_for_addr('twitter', '@someone').key,
+            twitter_contact.key)
+        self.assertEqual(
+            self.contact_store.contact_for_addr('gtalk', 'gtalk@host.com').key,
+            gtalk_contact.key)
+        self.assertRaisesRegexp(RuntimeError, 'Unsupported transport_type',
+            self.contact_store.contact_for_addr, 'unknown', 'unknown')
+
 
 class GroupsTestCase(DjangoGoApplicationTestCase):
 

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -250,9 +250,10 @@ class ContactStore(PerAccountStore):
                                     gtalk_id=addr, msisdn=u'unknown')
             returnValue(contact)
         elif delivery_class == 'twitter':
-            contacts = yield self.contacts.search(twitter_handle=addr)
-            if contacts:
-                returnValue(contacts[0])
+            keys = yield self.contacts.search(twitter_handle=addr).get_keys()
+            if keys:
+                contact = yield self.contacts.load(keys[0])
+                returnValue(contact)
             contact_id = uuid4().get_hex()
             contact = self.contacts(contact_id,
                                     user_account=self.user_account_key,


### PR DESCRIPTION
contact_for_addr was updated to work with twitter addresses &
delivery_classes. The merge didn't apply the stuff that now works with
keys and so things broke. Tests didn't tell us this because there were
no tests.
