### PR TITLE
Shaving some deprecation warnings

### DIFF
--- a/go/apps/multi_surveys/templates/multi_surveys/show.html
+++ b/go/apps/multi_surveys/templates/multi_surveys/show.html
@@ -1,5 +1,6 @@
 {% extends "app.html" %}
 {% load conversation_tags %}
+{% load url from future %}
 
 {% block extra_header %}
     <link type="text/css" href="{{STATIC_URL}}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />
@@ -10,7 +11,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url conversations:index %}">Multi Surveys</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url "conversations:index" %}">Multi Surveys</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/apps/multi_surveys/templates/multi_surveys/show.html
+++ b/go/apps/multi_surveys/templates/multi_surveys/show.html
@@ -11,7 +11,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "conversations:index" %}">Multi Surveys</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url 'conversations:index' %}">Multi Surveys</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/apps/multi_surveys/templates/multi_surveys/surveys.html
+++ b/go/apps/multi_surveys/templates/multi_surveys/surveys.html
@@ -47,7 +47,7 @@
                     {% for friendly_name, poll_id in polls.items %}
                         <tr>
                             <td>
-                                <a href="{% url "multi_survey:survey" conversation_key=conversation.key poll_name=friendly_name %}">
+                                <a href="{% url 'multi_survey:survey' conversation_key=conversation.key poll_name=friendly_name %}">
                                     {{conversation.subject}}, survey: {{friendly_name}}
                                 </a>
                             </td>
@@ -56,7 +56,7 @@
                         <tr>
                             <td>
                                 You don't have any polls defined yet. <br/>
-                                <a href="{% url "multi_survey:new_survey" conversation_key=conversation.key %}">Create your first here.</a>
+                                <a href="{% url 'multi_survey:new_survey' conversation_key=conversation.key %}">Create your first here.</a>
                             </td>
                         </tr>
                     {% endfor %}
@@ -64,8 +64,8 @@
                     </table>
                     {% if polls %}
                         <div class="btn-toolbar">
-                            <a class="btn btn-primary" href="{% url "multi_survey:new_survey" conversation_key=conversation.key %}">Add Another Survey</a>
-                            <a class="btn" href="{% url "multi_survey:people" conversation_key=conversation.key %}">
+                            <a class="btn btn-primary" href="{% url 'multi_survey:new_survey' conversation_key=conversation.key %}">Add Another Survey</a>
+                            <a class="btn" href="{% url 'multi_survey:people' conversation_key=conversation.key %}">
                                 Add Recipients &rarr;
                             </a>
                         </div>

--- a/go/apps/multi_surveys/templates/multi_surveys/surveys.html
+++ b/go/apps/multi_surveys/templates/multi_surveys/surveys.html
@@ -1,4 +1,5 @@
 {% extends "app.html" %}
+{% load url from future %}
 
 {% block extra_header %}
 <link type="text/css" href="{{STATIC_URL}}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />
@@ -46,7 +47,7 @@
                     {% for friendly_name, poll_id in polls.items %}
                         <tr>
                             <td>
-                                <a href="{% url multi_survey:survey conversation_key=conversation.key,poll_name=friendly_name %}">
+                                <a href="{% url "multi_survey:survey" conversation_key=conversation.key poll_name=friendly_name %}">
                                     {{conversation.subject}}, survey: {{friendly_name}}
                                 </a>
                             </td>
@@ -55,7 +56,7 @@
                         <tr>
                             <td>
                                 You don't have any polls defined yet. <br/>
-                                <a href="{% url multi_survey:new_survey conversation_key=conversation.key %}">Create your first here.</a>
+                                <a href="{% url "multi_survey:new_survey" conversation_key=conversation.key %}">Create your first here.</a>
                             </td>
                         </tr>
                     {% endfor %}
@@ -63,8 +64,8 @@
                     </table>
                     {% if polls %}
                         <div class="btn-toolbar">
-                            <a class="btn btn-primary" href="{% url multi_survey:new_survey conversation_key=conversation.key %}">Add Another Survey</a>
-                            <a class="btn" href="{% url multi_survey:people conversation_key=conversation.key %}">
+                            <a class="btn btn-primary" href="{% url "multi_survey:new_survey" conversation_key=conversation.key %}">Add Another Survey</a>
+                            <a class="btn" href="{% url "multi_survey:people" conversation_key=conversation.key %}">
                                 Add Recipients &rarr;
                             </a>
                         </div>

--- a/go/apps/surveys/templates/surveys/edit.html
+++ b/go/apps/surveys/templates/surveys/edit.html
@@ -10,7 +10,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "conversations:index" %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url 'conversations:index' %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/apps/surveys/templates/surveys/edit.html
+++ b/go/apps/surveys/templates/surveys/edit.html
@@ -1,4 +1,5 @@
 {% extends "app.html" %}
+{% load url from future %}
 
 {% block extra_header %}
     <link type="text/css" href="{{STATIC_URL}}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />
@@ -9,7 +10,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url conversations:index %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url "conversations:index" %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/apps/surveys/templates/surveys/includes/download.html
+++ b/go/apps/surveys/templates/surveys/includes/download.html
@@ -8,7 +8,7 @@
     <div class="span12">
         <table>
             <tr>
-                <td>Download <a href="{% url "survey:user_data" conversation_key=conversation.key %}">User data</a></td>
+                <td>Download <a href="{% url 'survey:user_data' conversation_key=conversation.key %}">User data</a></td>
             </tr>
         </table>
     </div>

--- a/go/apps/surveys/templates/surveys/includes/download.html
+++ b/go/apps/surveys/templates/surveys/includes/download.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <div class="row">
     <div class="span12">
         <h3>Download Survey Data</h3>
@@ -7,7 +8,7 @@
     <div class="span12">
         <table>
             <tr>
-                <td>Download <a href="{% url survey:user_data conversation_key=conversation.key %}">User data</a></td>
+                <td>Download <a href="{% url "survey:user_data" conversation_key=conversation.key %}">User data</a></td>
             </tr>
         </table>
     </div>

--- a/go/apps/surveys/templates/surveys/show.html
+++ b/go/apps/surveys/templates/surveys/show.html
@@ -1,5 +1,6 @@
 {% extends "app.html" %}
 {% load conversation_tags %}
+{% load url from future %}
 
 {% block extra_header %}
     <link type="text/css" href="{{STATIC_URL}}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />
@@ -10,7 +11,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url conversations:index %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url "conversations:index" %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/apps/surveys/templates/surveys/show.html
+++ b/go/apps/surveys/templates/surveys/show.html
@@ -11,7 +11,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "conversations:index" %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url 'conversations:index' %}">Surveys</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/contacts/templates/contacts/group.html
+++ b/go/contacts/templates/contacts/group.html
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "contacts:groups" %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
+                <h1><a href="{% url 'contacts:groups' %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
             </div>
         </div>
     </div>
@@ -18,8 +18,8 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li><a href="{% url "contacts:people" %}">People</a></li>
-                <li><a href="{% url "contacts:groups" %}">Groups</a></li>
+                <li><a href="{% url 'contacts:people' %}">People</a></li>
+                <li><a href="{% url 'contacts:groups' %}">Groups</a></li>
             </ul>
         </div>
     </div>
@@ -30,7 +30,7 @@
                     <a class="btn btn-success" href="#"><i class="icon-user white"></i> Group Actions</a>
 		            <a class="btn btn-success dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
 		            <ul class="dropdown-menu">
-                        <li><a href="{% url "contacts:new_person" %}"><i class="icon-user"></i> New Contact</a></li>
+                        <li><a href="{% url 'contacts:new_person' %}"><i class="icon-user"></i> New Contact</a></li>
                         <li><a data-toggle="modal" href="#uplContactFrm"><i class="icon-upload"></i> Upload Contacts</a></li>
                         <li><a data-toggle="modal" href="#editGroup"><i class="icon-edit"></i> Edit Group</a></li>
                         <li><a data-toggle="modal" href="#emptyGroup"><i class="icon-fire"></i> Delete Group's Contacts</a></li>
@@ -72,7 +72,7 @@
             <tbody>
             {% for contact in selected_contacts %}
                  <tr>
-                    <td colspan="3"><a href="{% url "contacts:person" person_key=contact.key %}">{{contact}}</a></td>
+                    <td colspan="3"><a href="{% url 'contacts:person' person_key=contact.key %}">{{contact}}</a></td>
                  </tr>
             {% empty %}
                 <tr>

--- a/go/contacts/templates/contacts/group.html
+++ b/go/contacts/templates/contacts/group.html
@@ -1,11 +1,12 @@
 {% extends "app.html" %}
 {% load go_tags %}
+{% load url from future %}
 
 {% block main %}
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url contacts:groups %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
+                <h1><a href="{% url "contacts:groups" %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
             </div>
         </div>
     </div>
@@ -17,8 +18,8 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li><a href="{% url contacts:people %}">People</a></li>
-                <li><a href="{% url contacts:groups %}">Groups</a></li>
+                <li><a href="{% url "contacts:people" %}">People</a></li>
+                <li><a href="{% url "contacts:groups" %}">Groups</a></li>
             </ul>
         </div>
     </div>
@@ -29,7 +30,7 @@
                     <a class="btn btn-success" href="#"><i class="icon-user white"></i> Group Actions</a>
 		            <a class="btn btn-success dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
 		            <ul class="dropdown-menu">
-                        <li><a href="{% url contacts:new_person %}"><i class="icon-user"></i> New Contact</a></li>
+                        <li><a href="{% url "contacts:new_person" %}"><i class="icon-user"></i> New Contact</a></li>
                         <li><a data-toggle="modal" href="#uplContactFrm"><i class="icon-upload"></i> Upload Contacts</a></li>
                         <li><a data-toggle="modal" href="#editGroup"><i class="icon-edit"></i> Edit Group</a></li>
                         <li><a data-toggle="modal" href="#emptyGroup"><i class="icon-fire"></i> Delete Group's Contacts</a></li>
@@ -71,7 +72,7 @@
             <tbody>
             {% for contact in selected_contacts %}
                  <tr>
-                    <td colspan="3"><a href="{% url contacts:person person_key=contact.key %}">{{contact}}</a></td>
+                    <td colspan="3"><a href="{% url "contacts:person" person_key=contact.key %}">{{contact}}</a></td>
                  </tr>
             {% empty %}
                 <tr>

--- a/go/contacts/templates/contacts/groups.html
+++ b/go/contacts/templates/contacts/groups.html
@@ -19,8 +19,8 @@
     <div class="row">
         <div class="span12">
       			<ul class="nav nav-tabs">
-      			    <li><a href="{% url "contacts:people" %}">People</a></li>
-      			    <li class="active"><a href="{% url "contacts:groups" %}"><strong>Groups</strong></a></li>
+      			    <li><a href="{% url 'contacts:people' %}">People</a></li>
+      			    <li class="active"><a href="{% url 'contacts:groups' %}"><strong>Groups</strong></a></li>
       			</ul>
       			<form id="search-filter" name="search-filter" action="" method="get" class="well form-search">
                 <input type="text" id="search-filter-input" name="q" value="{{query|default:''}}" placeholder="Find Groups..." class="input-large search-query">
@@ -36,7 +36,7 @@
             {% for group in page.object_list %}
                <tr>
                      <td>
-                        <a href="{% url "contacts:group" group_key=group.key %}">{{group.name}}</a>
+                        <a href="{% url 'contacts:group' group_key=group.key %}">{{group.name}}</a>
                         {% if group.is_smart_group %}
                             <span class="label label-info">Smart Group</span>
                         {% endif %}

--- a/go/contacts/templates/contacts/groups.html
+++ b/go/contacts/templates/contacts/groups.html
@@ -1,5 +1,6 @@
 {% extends "app.html" %}
 {% load go_tags %}
+{% load url from future %}
 
 {% block main %}
     <div class="row">
@@ -18,8 +19,8 @@
     <div class="row">
         <div class="span12">
       			<ul class="nav nav-tabs">
-      			    <li><a href="{% url contacts:people %}">People</a></li>
-      			    <li class="active"><a href="{% url contacts:groups %}"><strong>Groups</strong></a></li>
+      			    <li><a href="{% url "contacts:people" %}">People</a></li>
+      			    <li class="active"><a href="{% url "contacts:groups" %}"><strong>Groups</strong></a></li>
       			</ul>
       			<form id="search-filter" name="search-filter" action="" method="get" class="well form-search">
                 <input type="text" id="search-filter-input" name="q" value="{{query|default:''}}" placeholder="Find Groups..." class="input-large search-query">
@@ -35,7 +36,7 @@
             {% for group in page.object_list %}
                <tr>
                      <td>
-                        <a href="{% url contacts:group group_key=group.key %}">{{group.name}}</a>
+                        <a href="{% url "contacts:group" group_key=group.key %}">{{group.name}}</a>
                         {% if group.is_smart_group %}
                             <span class="label label-info">Smart Group</span>
                         {% endif %}

--- a/go/contacts/templates/contacts/includes/menu.html
+++ b/go/contacts/templates/contacts/includes/menu.html
@@ -4,7 +4,7 @@
         <a class="btn btn-success" href="#"><i class="icon-user white"></i> New</a>
         <a class="btn btn-success dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
         <ul class="dropdown-menu">
-            <li><a href="{% url "contacts:new_person" %}"><i class="icon-user"></i> New Contact</a></li>
+            <li><a href="{% url 'contacts:new_person' %}"><i class="icon-user"></i> New Contact</a></li>
             <li><a data-toggle="modal" href="#newGroup"><i class="icon-user"></i> New Group</a></li>
             <li><a data-toggle="modal" href="#uplContactFrm"><i class="icon-upload"></i> Upload Contacts</a></li>
         </ul>

--- a/go/contacts/templates/contacts/includes/menu.html
+++ b/go/contacts/templates/contacts/includes/menu.html
@@ -1,9 +1,10 @@
+{% load url from future %}
 <div class="pull-right padtop">
     <div class="btn-group">
         <a class="btn btn-success" href="#"><i class="icon-user white"></i> New</a>
         <a class="btn btn-success dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
         <ul class="dropdown-menu">
-            <li><a href="{% url contacts:new_person %}"><i class="icon-user"></i> New Contact</a></li>
+            <li><a href="{% url "contacts:new_person" %}"><i class="icon-user"></i> New Contact</a></li>
             <li><a data-toggle="modal" href="#newGroup"><i class="icon-user"></i> New Group</a></li>
             <li><a data-toggle="modal" href="#uplContactFrm"><i class="icon-upload"></i> Upload Contacts</a></li>
         </ul>

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 
 <div class="modal hide fade" id="uplContacts">
     <div class="modal-header">
@@ -61,7 +62,7 @@
         <a class="close" data-dismiss="modal">×</a>
         <h3>Please match the sample to the fields provided</h3>
     </div>
-    <form class="form-horizontal" action="{% url contacts:group group_key=group.key %}" method="POST">
+    <form class="form-horizontal" action="{% url "contacts:group" group_key=group.key %}" method="POST">
         <div class="modal-body">
             <fieldset>
               <table class="table table-bordered table-striped">
@@ -104,7 +105,7 @@
         <a class="close" data-dismiss="modal">×</a>
         <h3>New Group</h3>
     </div>
-    <form name="frm-new-group" id="frm-new-group" method="post" action="{% url contacts:groups %}" class="form-horizontal">
+    <form name="frm-new-group" id="frm-new-group" method="post" action="{% url "contacts:groups" %}" class="form-horizontal">
     {% csrf_token %}
     <div class="modal-body">
 	    <fieldset>
@@ -145,7 +146,7 @@
 	  <a class="close" data-dismiss="modal">×</a>
 	  <h3>Remove Group</h3>
 	</div>
-	<form class="form-horizontal" method="POST" action="{% url contacts:group group_key=group.key %}">
+	<form class="form-horizontal" method="POST" action="{% url "contacts:group" group_key=group.key %}">
 	<div class="modal-body">
 	      <fieldset>
 	        <p><strong>Are you sure you want to remove this group?</strong>
@@ -165,7 +166,7 @@
 	  <a class="close" data-dismiss="modal">×</a>
 	  <h3>Delete Group's Contacts</h3>
 	</div>
-    <form class="form-horizontal" method="POST" action="{% url contacts:group group_key=group.key %}">
+    <form class="form-horizontal" method="POST" action="{% url "contacts:group" group_key=group.key %}">
       {% csrf_token %}
     <div class="modal-body">
         <div class="alert alert-error">
@@ -196,7 +197,7 @@
       <pre>{{smart_group_form.query.value}}</pre>
     </p>
   </div>
-  <form class="form-horizontal" method="POST" action="{% url contacts:groups %}">
+  <form class="form-horizontal" method="POST" action="{% url "contacts:groups" %}">
     {% csrf_token %}
     {{smart_group_form}}
     <div class="modal-footer">

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -62,7 +62,7 @@
         <a class="close" data-dismiss="modal">×</a>
         <h3>Please match the sample to the fields provided</h3>
     </div>
-    <form class="form-horizontal" action="{% url "contacts:group" group_key=group.key %}" method="POST">
+    <form class="form-horizontal" action="{% url 'contacts:group' group_key=group.key %}" method="POST">
         <div class="modal-body">
             <fieldset>
               <table class="table table-bordered table-striped">
@@ -105,7 +105,7 @@
         <a class="close" data-dismiss="modal">×</a>
         <h3>New Group</h3>
     </div>
-    <form name="frm-new-group" id="frm-new-group" method="post" action="{% url "contacts:groups" %}" class="form-horizontal">
+    <form name="frm-new-group" id="frm-new-group" method="post" action="{% url 'contacts:groups' %}" class="form-horizontal">
     {% csrf_token %}
     <div class="modal-body">
 	    <fieldset>
@@ -146,7 +146,7 @@
 	  <a class="close" data-dismiss="modal">×</a>
 	  <h3>Remove Group</h3>
 	</div>
-	<form class="form-horizontal" method="POST" action="{% url "contacts:group" group_key=group.key %}">
+	<form class="form-horizontal" method="POST" action="{% url 'contacts:group' group_key=group.key %}">
 	<div class="modal-body">
 	      <fieldset>
 	        <p><strong>Are you sure you want to remove this group?</strong>
@@ -166,7 +166,7 @@
 	  <a class="close" data-dismiss="modal">×</a>
 	  <h3>Delete Group's Contacts</h3>
 	</div>
-    <form class="form-horizontal" method="POST" action="{% url "contacts:group" group_key=group.key %}">
+    <form class="form-horizontal" method="POST" action="{% url 'contacts:group' group_key=group.key %}">
       {% csrf_token %}
     <div class="modal-body">
         <div class="alert alert-error">
@@ -197,7 +197,7 @@
       <pre>{{smart_group_form.query.value}}</pre>
     </p>
   </div>
-  <form class="form-horizontal" method="POST" action="{% url "contacts:groups" %}">
+  <form class="form-horizontal" method="POST" action="{% url 'contacts:groups' %}">
     {% csrf_token %}
     {{smart_group_form}}
     <div class="modal-footer">

--- a/go/contacts/templates/contacts/new_person.html
+++ b/go/contacts/templates/contacts/new_person.html
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "contacts:people" %}">People &amp; Groups</a> &raquo; New Contact</h1>
+                <h1><a href="{% url 'contacts:people' %}">People &amp; Groups</a> &raquo; New Contact</h1>
             </div>
         </div>
     </div>

--- a/go/contacts/templates/contacts/new_person.html
+++ b/go/contacts/templates/contacts/new_person.html
@@ -1,11 +1,12 @@
 {% extends "app.html" %}
+{% load url from future %}
 
 {% block main %}
 
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url contacts:people %}">People &amp; Groups</a> &raquo; New Contact</h1>
+                <h1><a href="{% url "contacts:people" %}">People &amp; Groups</a> &raquo; New Contact</h1>
             </div>
         </div>
     </div>

--- a/go/contacts/templates/contacts/people.html
+++ b/go/contacts/templates/contacts/people.html
@@ -19,8 +19,8 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li class="active"><a href="{% url "contacts:people" %}"><strong>People</strong></a></li>
-                <li><a href="{% url "contacts:groups" %}">Groups</a></li>
+                <li class="active"><a href="{% url 'contacts:people' %}"><strong>People</strong></a></li>
+                <li><a href="{% url 'contacts:groups' %}">Groups</a></li>
             </ul>
             <form id="search-filter" name="search-filter" action="" method="get" class="well form-search">
                 <input type="text" id="search-filter-input" name="q" value="{{query|default:''}}" placeholder="Find people..." class="input-large search-query">
@@ -55,7 +55,7 @@
             <tbody>
             {% for contact in selected_contacts %}
                  <tr>
-                    <td colspan="3"><a href="{% url "contacts:person" person_key=contact.key %}">{{contact}}</a></td>
+                    <td colspan="3"><a href="{% url 'contacts:person' person_key=contact.key %}">{{contact}}</a></td>
                  </tr>
             {% empty %}
                 <tr>

--- a/go/contacts/templates/contacts/people.html
+++ b/go/contacts/templates/contacts/people.html
@@ -1,5 +1,6 @@
 {% extends "app.html" %}
 {% load go_tags %}
+{% load url from future %}
 
 {% block main %}
     <div class="row">
@@ -18,8 +19,8 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li class="active"><a href="{% url contacts:people %}"><strong>People</strong></a></li>
-                <li><a href="{% url contacts:groups %}">Groups</a></li>
+                <li class="active"><a href="{% url "contacts:people" %}"><strong>People</strong></a></li>
+                <li><a href="{% url "contacts:groups" %}">Groups</a></li>
             </ul>
             <form id="search-filter" name="search-filter" action="" method="get" class="well form-search">
                 <input type="text" id="search-filter-input" name="q" value="{{query|default:''}}" placeholder="Find people..." class="input-large search-query">
@@ -54,7 +55,7 @@
             <tbody>
             {% for contact in selected_contacts %}
                  <tr>
-                    <td colspan="3"><a href="{% url contacts:person person_key=contact.key %}">{{contact}}</a></td>
+                    <td colspan="3"><a href="{% url "contacts:person" person_key=contact.key %}">{{contact}}</a></td>
                  </tr>
             {% empty %}
                 <tr>

--- a/go/contacts/templates/contacts/person.html
+++ b/go/contacts/templates/contacts/person.html
@@ -5,7 +5,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "contacts:people" %}">People &amp; Groups</a> &raquo; {{contact}}</h1>
+                <h1><a href="{% url 'contacts:people' %}">People &amp; Groups</a> &raquo; {{contact}}</h1>
             </div>
         </div>
     </div>

--- a/go/contacts/templates/contacts/person.html
+++ b/go/contacts/templates/contacts/person.html
@@ -1,10 +1,11 @@
 {% extends "app.html" %}
+{% load url from future %}
 
 {% block main %}
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url contacts:people %}">People &amp; Groups</a> &raquo; {{contact}}</h1>
+                <h1><a href="{% url "contacts:people" %}">People &amp; Groups</a> &raquo; {{contact}}</h1>
             </div>
         </div>
     </div>

--- a/go/contacts/templates/contacts/smart_group.html
+++ b/go/contacts/templates/contacts/smart_group.html
@@ -1,11 +1,12 @@
 {% extends "app.html" %}
 {% load go_tags %}
+{% load url from future %}
 
 {% block main %}
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url contacts:groups %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
+                <h1><a href="{% url "contacts:groups" %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
             </div>
         </div>
     </div>
@@ -17,8 +18,8 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li><a href="{% url contacts:people %}">People</a></li>
-                <li><a href="{% url contacts:groups %}">Groups</a></li>
+                <li><a href="{% url "contacts:people" %}">People</a></li>
+                <li><a href="{% url "contacts:groups" %}">Groups</a></li>
             </ul>
         </div>
     </div>
@@ -29,7 +30,7 @@
                     <a class="btn btn-success" href="#"><i class="icon-user white"></i> Group Actions</a>
 		            <a class="btn btn-success dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
 		            <ul class="dropdown-menu">
-                        <li><a href="{% url contacts:new_person %}"><i class="icon-user"></i> New Contact</a></li>
+                        <li><a href="{% url "contacts:new_person" %}"><i class="icon-user"></i> New Contact</a></li>
                         <li><a data-toggle="modal" href="#uplContactFrm"><i class="icon-upload"></i> Upload Contacts</a></li>
                         <li><a data-toggle="modal" href="#editGroup"><i class="icon-edit"></i> Edit Group</a></li>
                         <li><a data-toggle="modal" href="#emptyGroup"><i class="icon-fire"></i> Delete Group's Contacts</a></li>
@@ -61,7 +62,7 @@
             <tbody>
             {% for contact in selected_contacts %}
                  <tr>
-                    <td colspan="3"><a href="{% url contacts:person person_key=contact.key %}">{{contact}}</a></td>
+                    <td colspan="3"><a href="{% url "contacts:person" person_key=contact.key %}">{{contact}}</a></td>
                  </tr>
             {% empty %}
                 <tr>

--- a/go/contacts/templates/contacts/smart_group.html
+++ b/go/contacts/templates/contacts/smart_group.html
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "contacts:groups" %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
+                <h1><a href="{% url 'contacts:groups' %}">People &amp; Groups</a> &raquo; {{group.name}}</h1>
             </div>
         </div>
     </div>
@@ -18,8 +18,8 @@
     <div class="row">
         <div class="span12">
             <ul class="nav nav-tabs">
-                <li><a href="{% url "contacts:people" %}">People</a></li>
-                <li><a href="{% url "contacts:groups" %}">Groups</a></li>
+                <li><a href="{% url 'contacts:people' %}">People</a></li>
+                <li><a href="{% url 'contacts:groups' %}">Groups</a></li>
             </ul>
         </div>
     </div>
@@ -30,7 +30,7 @@
                     <a class="btn btn-success" href="#"><i class="icon-user white"></i> Group Actions</a>
 		            <a class="btn btn-success dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
 		            <ul class="dropdown-menu">
-                        <li><a href="{% url "contacts:new_person" %}"><i class="icon-user"></i> New Contact</a></li>
+                        <li><a href="{% url 'contacts:new_person' %}"><i class="icon-user"></i> New Contact</a></li>
                         <li><a data-toggle="modal" href="#uplContactFrm"><i class="icon-upload"></i> Upload Contacts</a></li>
                         <li><a data-toggle="modal" href="#editGroup"><i class="icon-edit"></i> Edit Group</a></li>
                         <li><a data-toggle="modal" href="#emptyGroup"><i class="icon-fire"></i> Delete Group's Contacts</a></li>
@@ -62,7 +62,7 @@
             <tbody>
             {% for contact in selected_contacts %}
                  <tr>
-                    <td colspan="3"><a href="{% url "contacts:person" person_key=contact.key %}">{{contact}}</a></td>
+                    <td colspan="3"><a href="{% url 'contacts:person' person_key=contact.key %}">{{contact}}</a></td>
                  </tr>
             {% empty %}
                 <tr>

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.views.generic.base import TemplateView
+from django.views.generic import TemplateView
 
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.views.generic import TemplateView
+from django.views.generic.base import TemplateView
 
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required

--- a/go/conversation/templates/conversation/includes/groups-selected.html
+++ b/go/conversation/templates/conversation/includes/groups-selected.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <fieldset>
     <label class="control-label" for="input01">Select which contact(s) you'd like to message:</label>
     <table class="table table-condensed">
@@ -16,7 +17,7 @@
     {% empty %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url contacts:people %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endfor %}

--- a/go/conversation/templates/conversation/includes/groups-selected.html
+++ b/go/conversation/templates/conversation/includes/groups-selected.html
@@ -17,7 +17,7 @@
     {% empty %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url 'contacts:people' %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endfor %}

--- a/go/conversation/templates/conversation/includes/groups.html
+++ b/go/conversation/templates/conversation/includes/groups.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <fieldset>
     <label class="control-label" for="input01">Select which contact(s) you'd like to message:</label>
     <table class="table table-condensed">
@@ -16,7 +17,7 @@
     {% empty %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url contacts:people %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endfor %}

--- a/go/conversation/templates/conversation/includes/groups.html
+++ b/go/conversation/templates/conversation/includes/groups.html
@@ -17,7 +17,7 @@
     {% empty %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url 'contacts:people' %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endfor %}

--- a/go/conversation/templates/conversation/inclusion_tags/show_conversation_messages.html
+++ b/go/conversation/templates/conversation/inclusion_tags/show_conversation_messages.html
@@ -40,7 +40,7 @@
                     <tr>
                         <td><i class="icon-repeat"></i> {{reply.type}}</td>
                         <td>
-                            <h6><a href="{% url "contacts:person" person_key=reply.contact.key %}">{{reply.contact}}</a> via {{reply.source}} - {{reply.time}}</h6>
+                            <h6><a href="{% url 'contacts:person' person_key=reply.contact.key %}">{{reply.contact}}</a> via {{reply.source}} - {{reply.time}}</h6>
                             <p>{{reply.content}}</p></td>
                         <td><a href="#" class="btn" title="Reply"><i class="icon-repeat"></i> Reply</a></td>
                     </tr>

--- a/go/conversation/templates/conversation/inclusion_tags/show_conversation_messages.html
+++ b/go/conversation/templates/conversation/inclusion_tags/show_conversation_messages.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <div class="row">
     <div class="span12">
         <h3>Messages from {{inbound_uniques_count}} unique people.</h3>
@@ -39,7 +40,7 @@
                     <tr>
                         <td><i class="icon-repeat"></i> {{reply.type}}</td>
                         <td>
-                            <h6><a href="{% url contacts:person person_key=reply.contact.key %}">{{reply.contact}}</a> via {{reply.source}} - {{reply.time}}</h6>
+                            <h6><a href="{% url "contacts:person" person_key=reply.contact.key %}">{{reply.contact}}</a> via {{reply.source}} - {{reply.time}}</h6>
                             <p>{{reply.content}}</p></td>
                         <td><a href="#" class="btn" title="Reply"><i class="icon-repeat"></i> Reply</a></td>
                     </tr>

--- a/go/conversation/templates/generic/includes/conversation-box.html
+++ b/go/conversation/templates/generic/includes/conversation-box.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% if conversation %}
 	<div class="span4">
 	    <div class="convos shadow">
@@ -7,7 +8,7 @@
 	        {% else %}
 	        	<span class="label label-success"><i class="icon-ok-circle icon-white"></i> {{conversation.get_status|title}}</span>
 	        {% endif %}
-	        <h3><a href="{% url conversations:show conversation_key=conversation.key %}">{{conversation.subject}}</a></h3>
+	        <h3><a href="{% url "conversations:show" conversation_key=conversation.key %}">{{conversation.subject}}</a></h3>
 	        <p>{{conversation.message}}</p>
 	        <div><span class="label">{{conversation.delivery_class_description}}</span>  
 	        <span class="label"><i class="icon-user icon-white"></i> {{conversation.people.count}}</span> 

--- a/go/conversation/templates/generic/includes/conversation-box.html
+++ b/go/conversation/templates/generic/includes/conversation-box.html
@@ -2,16 +2,16 @@
 {% if conversation %}
 	<div class="span4">
 	    <div class="convos shadow">
-	        <span class="label label-info">{{conversation.start_date}} {{conversation.start_time}}</span> 
+	        <span class="label label-info">{{conversation.start_date}} {{conversation.start_time}}</span>
 	        {% if conversation.ended %}
 	        	<span class="label label-important"><i class="icon-ok-circle icon-white"></i> Finished</span>
 	        {% else %}
 	        	<span class="label label-success"><i class="icon-ok-circle icon-white"></i> {{conversation.get_status|title}}</span>
 	        {% endif %}
-	        <h3><a href="{% url "conversations:show" conversation_key=conversation.key %}">{{conversation.subject}}</a></h3>
+	        <h3><a href="{% url 'conversations:show' conversation_key=conversation.key %}">{{conversation.subject}}</a></h3>
 	        <p>{{conversation.message}}</p>
-	        <div><span class="label">{{conversation.delivery_class_description}}</span>  
-	        <span class="label"><i class="icon-user icon-white"></i> {{conversation.people.count}}</span> 
+	        <div><span class="label">{{conversation.delivery_class_description}}</span>
+	        <span class="label"><i class="icon-user icon-white"></i> {{conversation.people.count}}</span>
 	        <span class="label"><i class="icon-repeat icon-white"></i> {{conversation.replies.count|default:"0"}}</span></div>
 	    </div>
 	</div>

--- a/go/conversation/templates/generic/includes/groups-selected.html
+++ b/go/conversation/templates/generic/includes/groups-selected.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <fieldset>
     <label class="control-label" for="input01">Select which contact(s) you'd like to message:</label>
     <table class="table table-condensed">
@@ -16,7 +17,7 @@
     {% else %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url contacts:people %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endif %}

--- a/go/conversation/templates/generic/includes/groups-selected.html
+++ b/go/conversation/templates/generic/includes/groups-selected.html
@@ -17,7 +17,7 @@
     {% else %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url 'contacts:people' %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endif %}

--- a/go/conversation/templates/generic/includes/groups.html
+++ b/go/conversation/templates/generic/includes/groups.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <fieldset>
     <label class="control-label" for="input01">Select which contact(s) you'd like to message:</label>
     <table class="table table-condensed">
@@ -16,7 +17,7 @@
     {% else %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url contacts:people %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endif %}

--- a/go/conversation/templates/generic/includes/groups.html
+++ b/go/conversation/templates/generic/includes/groups.html
@@ -17,7 +17,7 @@
     {% else %}
         <tr>
         <td>
-            You don't have any groups defined yet. <a href="{% url "contacts:people" %}">Upload a set of contacts</a> to create your first group.
+            You don't have any groups defined yet. <a href="{% url 'contacts:people' %}">Upload a set of contacts</a> to create your first group.
         </td>
         </tr>
     {% endif %}

--- a/go/conversation/templates/generic/show.html
+++ b/go/conversation/templates/generic/show.html
@@ -1,5 +1,6 @@
 {% extends "app.html" %}
 {% load conversation_tags %}
+{% load url from future %}
 
 {% block extra_header %}
     <link type="text/css" href="{{STATIC_URL}}css/smoothness/jquery-ui-1.8.11.custom.css" rel="stylesheet" />
@@ -10,7 +11,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url conversations:index %}">Conversations</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url "conversations:index" %}">Conversations</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/conversation/templates/generic/show.html
+++ b/go/conversation/templates/generic/show.html
@@ -11,7 +11,7 @@
     <div class="row">
         <div class="span12">
             <div id="welcome">
-                <h1><a href="{% url "conversations:index" %}">Conversations</a> &raquo; {{conversation.subject}}</h1>
+                <h1><a href="{% url 'conversations:index' %}">Conversations</a> &raquo; {{conversation.subject}}</h1>
             </div>
         </div>
     </div>

--- a/go/templates/app.html
+++ b/go/templates/app.html
@@ -10,38 +10,38 @@
 	       <span class="icon-bar"></span>
 	       <span class="icon-bar"></span>
 	    </a>
-	    <a class="brand" href="{% url "home" %}"><img src="{{ STATIC_URL }}img/logo.png"></a>
+	    <a class="brand" href="{% url 'home' %}"><img src="{{ STATIC_URL }}img/logo.png"></a>
 	    <div class="nav-collapse">
 	        <ul class="nav">
-	            <li><a href="{% url "conversations:index" %}">Conversations</a></li>
-	            <li><a href="{% url "contacts:people" %}">People</a></li>
+	            <li><a href="{% url 'conversations:index' %}">Conversations</a></li>
+	            <li><a href="{% url 'contacts:people' %}">People</a></li>
 	            <li><a href="#newConv" class="start" data-toggle="modal">New Conversation</a></li>
 	        </ul>
-	        <form id="search-form" name="search-form" action="{% url "conversations:index" %}" method="get" class="navbar-search pull-right">
+	        <form id="search-form" name="search-form" action="{% url 'conversations:index' %}" method="get" class="navbar-search pull-right">
 	            <input type="text" placeholder="Search" name="query" class="search-query" />
 	        </form>
 	        <ul class="nav pull-right">
-	            <li><a href="{% url "help" %}">Help</a></li>
+	            <li><a href="{% url 'help' %}">Help</a></li>
 	            <li class="divider-vertical"></li>
 	            <li class="dropdown">
 	               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Credits <b class="caret"></b></a>
 	               <ul class="dropdown-menu">
-	                   <li><a href="{% url "credits" %}#Balance"><strong>Balance: {{account_credits}} Credits</strong></a></li>
+	                   <li><a href="{% url 'credits' %}#Balance"><strong>Balance: {{account_credits}} Credits</strong></a></li>
 	                   <li class="divider"></li>
-	                   <li><a href="{% url "credits" %}#Buy"><i class="icon-shopping-cart"></i> Buy More Credits</a></li>
-	                   <li><a href="{% url "credits" %}#FAQ"><i class="icon-info-sign"></i> Credits FAQ</a></li>
+	                   <li><a href="{% url 'credits' %}#Buy"><i class="icon-shopping-cart"></i> Buy More Credits</a></li>
+	                   <li><a href="{% url 'credits' %}#FAQ"><i class="icon-info-sign"></i> Credits FAQ</a></li>
 	               </ul>
 	            </li>
 	            <li class="divider-vertical"></li>
 	            <li class="dropdown">
 	               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Settings <b class="caret"></b></a>
 	               <ul class="dropdown-menu">
-	                   <li><a href="{% url "account:index" %}#account"><i class="icon-list-alt"></i> Account Information</a></li>
-	                   <li><a href="{% url "account:index" %}#social"><i class="icon-heart"></i> Social Networks</a></li>
-	                   <li><a href="{% url "account:index" %}#im"><i class="icon-comment"></i> IM Accounts</a></li>
-	                   <li><a href="{% url "account:index" %}#contact"><i class="icon-envelope"></i> Contact Us</a></li>
+	                   <li><a href="{% url 'account:index' %}#account"><i class="icon-list-alt"></i> Account Information</a></li>
+	                   <li><a href="{% url 'account:index' %}#social"><i class="icon-heart"></i> Social Networks</a></li>
+	                   <li><a href="{% url 'account:index' %}#im"><i class="icon-comment"></i> IM Accounts</a></li>
+	                   <li><a href="{% url 'account:index' %}#contact"><i class="icon-envelope"></i> Contact Us</a></li>
 	                   <li class="divider"></li>
-	                   <li><a href="{% url "auth_logout" %}"><i class="icon-off"></i> <strong>Sign Out</strong></a></li>
+	                   <li><a href="{% url 'auth_logout' %}"><i class="icon-off"></i> <strong>Sign Out</strong></a></li>
 	              </ul>
 	        </li>
 	        <li class="divider-vertical"></li>
@@ -60,6 +60,6 @@
 	<hr>
 	<footer class="footer">
 	    <p class="pull-right"><a href="#">Back to top</a></p>
-	    <p>&copy; 2012 <a href="http://praekeltfoundation.org">Praekelt Foundation</a>. <a href="{% url "account:index" %}#contact">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
+	    <p>&copy; 2012 <a href="http://praekeltfoundation.org">Praekelt Foundation</a>. <a href="{% url 'account:index' %}#contact">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
 	</footer>
 {% endblock %}

--- a/go/templates/app.html
+++ b/go/templates/app.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block header %}
 	<div class="navbar navbar-fixed-top">
@@ -9,38 +10,38 @@
 	       <span class="icon-bar"></span>
 	       <span class="icon-bar"></span>
 	    </a>
-	    <a class="brand" href="{% url home %}"><img src="{{ STATIC_URL }}img/logo.png"></a>
+	    <a class="brand" href="{% url "home" %}"><img src="{{ STATIC_URL }}img/logo.png"></a>
 	    <div class="nav-collapse">
 	        <ul class="nav">
-	            <li><a href="{% url conversations:index %}">Conversations</a></li>
-	            <li><a href="{% url contacts:people %}">People</a></li>
+	            <li><a href="{% url "conversations:index" %}">Conversations</a></li>
+	            <li><a href="{% url "contacts:people" %}">People</a></li>
 	            <li><a href="#newConv" class="start" data-toggle="modal">New Conversation</a></li>
 	        </ul>
-	        <form id="search-form" name="search-form" action="{% url conversations:index %}" method="get" class="navbar-search pull-right">
+	        <form id="search-form" name="search-form" action="{% url "conversations:index" %}" method="get" class="navbar-search pull-right">
 	            <input type="text" placeholder="Search" name="query" class="search-query" />
 	        </form>
 	        <ul class="nav pull-right">
-	            <li><a href="{% url help %}">Help</a></li>
+	            <li><a href="{% url "help" %}">Help</a></li>
 	            <li class="divider-vertical"></li>
 	            <li class="dropdown">
 	               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Credits <b class="caret"></b></a>
 	               <ul class="dropdown-menu">
-	                   <li><a href="{% url credits %}#Balance"><strong>Balance: {{account_credits}} Credits</strong></a></li>
+	                   <li><a href="{% url "credits" %}#Balance"><strong>Balance: {{account_credits}} Credits</strong></a></li>
 	                   <li class="divider"></li>
-	                   <li><a href="{% url credits %}#Buy"><i class="icon-shopping-cart"></i> Buy More Credits</a></li>
-	                   <li><a href="{% url credits %}#FAQ"><i class="icon-info-sign"></i> Credits FAQ</a></li>
+	                   <li><a href="{% url "credits" %}#Buy"><i class="icon-shopping-cart"></i> Buy More Credits</a></li>
+	                   <li><a href="{% url "credits" %}#FAQ"><i class="icon-info-sign"></i> Credits FAQ</a></li>
 	               </ul>
 	            </li>
 	            <li class="divider-vertical"></li>
 	            <li class="dropdown">
 	               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Settings <b class="caret"></b></a>
 	               <ul class="dropdown-menu">
-	                   <li><a href="{% url account:index %}#account"><i class="icon-list-alt"></i> Account Information</a></li>
-	                   <li><a href="{% url account:index %}#social"><i class="icon-heart"></i> Social Networks</a></li>
-	                   <li><a href="{% url account:index %}#im"><i class="icon-comment"></i> IM Accounts</a></li>
-	                   <li><a href="{% url account:index %}#contact"><i class="icon-envelope"></i> Contact Us</a></li>
+	                   <li><a href="{% url "account:index" %}#account"><i class="icon-list-alt"></i> Account Information</a></li>
+	                   <li><a href="{% url "account:index" %}#social"><i class="icon-heart"></i> Social Networks</a></li>
+	                   <li><a href="{% url "account:index" %}#im"><i class="icon-comment"></i> IM Accounts</a></li>
+	                   <li><a href="{% url "account:index" %}#contact"><i class="icon-envelope"></i> Contact Us</a></li>
 	                   <li class="divider"></li>
-	                   <li><a href="{% url auth_logout %}"><i class="icon-off"></i> <strong>Sign Out</strong></a></li>
+	                   <li><a href="{% url "auth_logout" %}"><i class="icon-off"></i> <strong>Sign Out</strong></a></li>
 	              </ul>
 	        </li>
 	        <li class="divider-vertical"></li>
@@ -59,6 +60,6 @@
 	<hr>
 	<footer class="footer">
 	    <p class="pull-right"><a href="#">Back to top</a></p>
-	    <p>&copy; 2012 <a href="http://praekeltfoundation.org">Praekelt Foundation</a>. <a href="{% url account:index %}#contact">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
+	    <p>&copy; 2012 <a href="http://praekeltfoundation.org">Praekelt Foundation</a>. <a href="{% url "account:index" %}#contact">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
 	</footer>
 {% endblock %}

--- a/go/templates/registration/activation_complete.html
+++ b/go/templates/registration/activation_complete.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block content %}
     <div class="row">
@@ -7,7 +8,7 @@
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
                 <p> 
                     Thanks for confirming your email-address!
-                    You can now log in to your <a href="{% url home %}">Go account</a>.
+                    You can now log in to your <a href="{% url "home" %}">Go account</a>.
                 </p>
                 <p>&copy; 2012 <a href="http://praekelt.com">Praekelt Group</a>. <a href="mailto:hello@vumi.org">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
             </div>

--- a/go/templates/registration/activation_complete.html
+++ b/go/templates/registration/activation_complete.html
@@ -8,7 +8,7 @@
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
                 <p> 
                     Thanks for confirming your email-address!
-                    You can now log in to your <a href="{% url "home" %}">Go account</a>.
+                    You can now log in to your <a href="{% url 'home' %}">Go account</a>.
                 </p>
                 <p>&copy; 2012 <a href="http://praekelt.com">Praekelt Group</a>. <a href="mailto:hello@vumi.org">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
             </div>

--- a/go/templates/registration/activation_email.txt
+++ b/go/templates/registration/activation_email.txt
@@ -1,3 +1,3 @@
-Welcome to Vumi Go!
+{% load url from future %}Welcome to Vumi Go!
 
-Go to http://{{ site.domain }}{% url registration_activate activation_key=activation_key %}
+Go to http://{{ site.domain }}{% url "registration_activate" activation_key=activation_key %}

--- a/go/templates/registration/activation_email.txt
+++ b/go/templates/registration/activation_email.txt
@@ -1,3 +1,3 @@
 {% load url from future %}Welcome to Vumi Go!
 
-Go to http://{{ site.domain }}{% url "registration_activate" activation_key=activation_key %}
+Go to http://{{ site.domain }}{% url 'registration_activate' activation_key=activation_key %}

--- a/go/templates/registration/login.html
+++ b/go/templates/registration/login.html
@@ -6,7 +6,7 @@
 	    <div class="span12">
 	        <div id="login">
 	            <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
-	            <form id="signin-form" name="signin-form" action="{% url "auth_login" %}" method="post" class="form-horizontal">
+	            <form id="signin-form" name="signin-form" action="{% url 'auth_login' %}" method="post" class="form-horizontal">
 	               {% csrf_token %}
 	               <input type="hidden" name="next" value="{{next}}">
 	               <fieldset>
@@ -14,7 +14,7 @@
 		               <div class="control-group"><input type="password" class="input-large required" id="signin-input-password" name="password" placeholder="Password"></div>
 		               <div class="control-group">
 		                   <input type="submit" class="btn" name="submit" value="sign in">
-		                   <p><a href="{% url "auth_password_reset" %}">Forgot your password?</a></p>
+		                   <p><a href="{% url 'auth_password_reset' %}">Forgot your password?</a></p>
 		               </div>
 	               </fieldset>
 	               <p>&copy; 2012 <a href="http://praekelt.com">Praekelt Group</a>. <a href="mailto:hello@vumi.org">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>

--- a/go/templates/registration/login.html
+++ b/go/templates/registration/login.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block content %}
 	<div class="row">
 	    <div class="span12">
 	        <div id="login">
 	            <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
-	            <form id="signin-form" name="signin-form" action="{% url auth_login %}" method="post" class="form-horizontal">
+	            <form id="signin-form" name="signin-form" action="{% url "auth_login" %}" method="post" class="form-horizontal">
 	               {% csrf_token %}
 	               <input type="hidden" name="next" value="{{next}}">
 	               <fieldset>
@@ -13,7 +14,7 @@
 		               <div class="control-group"><input type="password" class="input-large required" id="signin-input-password" name="password" placeholder="Password"></div>
 		               <div class="control-group">
 		                   <input type="submit" class="btn" name="submit" value="sign in">
-		                   <p><a href="{% url auth_password_reset %}">Forgot your password?</a></p>
+		                   <p><a href="{% url "auth_password_reset" %}">Forgot your password?</a></p>
 		               </div>
 	               </fieldset>
 	               <p>&copy; 2012 <a href="http://praekelt.com">Praekelt Group</a>. <a href="mailto:hello@vumi.org">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>

--- a/go/templates/registration/logout.html
+++ b/go/templates/registration/logout.html
@@ -7,7 +7,7 @@
             <div id="login">
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
                 <strong>You've been logged out.</strong>
-                <p>You will need to <a href="{% url "home" %}">log in again</a> if you want to access your account.</p>
+                <p>You will need to <a href="{% url 'home' %}">log in again</a> if you want to access your account.</p>
                 <p>&copy; 2012 <a href="http://praekelt.com">Praekelt Group</a>. <a href="mailto:hello@vumi.org">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
             </div>
         </div>

--- a/go/templates/registration/logout.html
+++ b/go/templates/registration/logout.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block content %}
     <div class="row">
@@ -6,7 +7,7 @@
             <div id="login">
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
                 <strong>You've been logged out.</strong>
-                <p>You will need to <a href="{% url home %}">log in again</a> if you want to access your account.</p>
+                <p>You will need to <a href="{% url "home" %}">log in again</a> if you want to access your account.</p>
                 <p>&copy; 2012 <a href="http://praekelt.com">Praekelt Group</a>. <a href="mailto:hello@vumi.org">Contact</a>. <a href="https://github.com/praekelt/vumi">Github</a></p>
             </div>
         </div>

--- a/go/templates/registration/password_reset_form.html
+++ b/go/templates/registration/password_reset_form.html
@@ -6,7 +6,7 @@
         <div class="span12">
             <div id="login">
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
-                <form id="registration-form" name="registration-form" action="{% url "auth_password_reset" %}" method="post" class="form-horizontal">
+                <form id="registration-form" name="registration-form" action="{% url 'auth_password_reset' %}" method="post" class="form-horizontal">
                     {% csrf_token %}
                     <fieldset>
                         {{ form.as_p }}

--- a/go/templates/registration/password_reset_form.html
+++ b/go/templates/registration/password_reset_form.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block content %}
     <div class="row">
         <div class="span12">
             <div id="login">
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
-                <form id="registration-form" name="registration-form" action="{% url auth_password_reset %}" method="post" class="form-horizontal">
+                <form id="registration-form" name="registration-form" action="{% url "auth_password_reset" %}" method="post" class="form-horizontal">
                     {% csrf_token %}
                     <fieldset>
                         {{ form.as_p }}

--- a/go/templates/registration/registration_form.html
+++ b/go/templates/registration/registration_form.html
@@ -6,7 +6,7 @@
         <div class="span12">
             <div id="login">
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
-                <form id="registration-form" name="registration-form" action="{% url "registration_register" %}" method="post" class="form-horizontal">
+                <form id="registration-form" name="registration-form" action="{% url 'registration_register' %}" method="post" class="form-horizontal">
                     {% csrf_token %}
                     <fieldset>
                         {{ form.as_p }}

--- a/go/templates/registration/registration_form.html
+++ b/go/templates/registration/registration_form.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block content %}
     <div class="row">
         <div class="span12">
             <div id="login">
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go">
-                <form id="registration-form" name="registration-form" action="{% url registration_register %}" method="post" class="form-horizontal">
+                <form id="registration-form" name="registration-form" action="{% url "registration_register" %}" method="post" class="form-horizontal">
                     {% csrf_token %}
                     <fieldset>
                         {{ form.as_p }}

--- a/go/urls.py
+++ b/go/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls.defaults import patterns, include, url
 from django.contrib import admin
 from django.http import HttpResponse
-from django.views.generic.base import RedirectView
+from django.views.generic import RedirectView
 
 from registration.views import register
 from go.account.forms import RegistrationForm

--- a/go/urls.py
+++ b/go/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls.defaults import patterns, include, url
 from django.contrib import admin
 from django.http import HttpResponse
-from django.views.generic import RedirectView
+from django.views.generic.base import RedirectView
 
 from registration.views import register
 from go.account.forms import RegistrationForm


### PR DESCRIPTION
In Django 1.5 the behaviour of {% url ... %} will change, since Django
1.3 it gives a deprecation warning. This changes loads the new url tag
from future and gets us ready for 1.5 (and removes the deprecation
warning).

There is still a warning about the function based generic views being
deprecated. That is caused by a 3rd party library (django-registration) 
using the deprecated `django.views.generic.simple`.
