### PR TITLE
Add setting for Google Analytics account

### DIFF
--- a/go/base/context_processors.py
+++ b/go/base/context_processors.py
@@ -1,5 +1,6 @@
 from go.contacts import forms
 from go.base.utils import vumi_api_for_user
+from django.conf import settings
 
 
 def user_profile(request):
@@ -31,3 +32,9 @@ def credit(request):
             'account_credits': api.cm.get_credit(profile.user_account) or 0,
         }
     return {}
+
+
+def google_analytics(request):
+    return {
+        'google_analytics_ua': getattr(settings, "GOOGLE_ANALYTICS_UA", None),
+    }

--- a/go/settings.py
+++ b/go/settings.py
@@ -171,6 +171,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "go.base.context_processors.user_profile",
     "go.base.context_processors.standard_forms",
     "go.base.context_processors.credit",
+    "go.base.context_processors.google_analytics",
 )
 
 # A sample logging configuration. The only tangible logging

--- a/go/settings.py
+++ b/go/settings.py
@@ -269,6 +269,9 @@ VUMI_INSTALLED_APPS = {
 VXPOLLS_REDIS_CONFIG = {}
 VXPOLLS_PREFIX = 'vumigo'
 
+# Set this to enable Google Analytics
+GOOGLE_ANALYTICS_UA = None
+
 try:
     from production_settings import *
 except ImportError:

--- a/go/templates/base.html
+++ b/go/templates/base.html
@@ -74,12 +74,14 @@
     <script src="{{ STATIC_URL }}js/libs/jquery-ui-1.8.17.custom.min.js"></script>
     <script src="{{ STATIC_URL }}js/libs/jquery.validate.js"></script>
     <script src="{{ STATIC_URL }}js/script.js"></script>
+    {% if google_analytics_ua  %}
     <script>
-    var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
+    var _gaq=[['_setAccount','{{ google_analytics_ua }}'],['_trackPageview']];
     (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
     g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
     s.parentNode.insertBefore(g,s)}(document,'script'));
     </script>
+    {% endif %}
     <script>
     $(document).ready(function(){
         $("#newConversationType").validate();


### PR DESCRIPTION
Currently Go has code for using Google Analytics in `go/templates/base.html` but no way to set the account token for it.
