### PR TITLE
Fix event routing for when a tag has been released.

### DIFF
--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -408,7 +408,7 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
                          self.conversation.key)
 
     @inlineCallbacks
-    def test_tag_retrieval_and_event_dispatching(self):
+    def test_batch_id_retrieval_and_event_dispatching(self):
         # first create an outbound message and then publish an inbound
         # event for it.
         msg = self.mkmsg_out(transport_type='xmpp',

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -436,6 +436,37 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
         self.assertEqual(event['user_message_id'], msg['message_id'])
 
     @inlineCallbacks
+    def test_batch_id_retrieval_and_event_dispatching_after_conv_close(self):
+        # first create an outbound message and then publish an inbound
+        # event for it.
+        msg = self.mkmsg_out(transport_type='xmpp',
+                                transport_name=self.transport_name)
+
+        # Make sure stuff is tagged properly so it can be routed.
+        tag = ('xmpp', 'test1@xmpp.org')
+        batch_id = yield self.vumi_api.mdb.batch_start([tag],
+            user_account=unicode(self.account.key))
+        self.conversation.batches.add_key(batch_id)
+        yield self.conversation.save()
+        TaggingMiddleware.add_tag_to_msg(msg, tag)
+
+        # Fake that it has been sent by storing it as a sent message
+        yield self.vumi_api.mdb.add_outbound_message(msg, tag=tag,
+            batch_id=batch_id)
+        # mark the batch as done which is what happens when a conversation
+        # is closed
+        yield self.vumi_api.mdb.batch_done(batch_id)
+
+        ack = self.mkmsg_ack(
+            user_message_id=msg['message_id'],
+            transport_name=self.transport_name)
+
+        yield self.dispatch(ack, self.transport_name, 'event')
+
+        [event] = self.get_dispatched_messages('app_1', direction='event')
+        self.assertEqual(event['user_message_id'], msg['message_id'])
+
+    @inlineCallbacks
     def test_no_tag(self):
         msg = self.mkmsg_in(transport_type='xmpp',
                                 transport_name='xmpp_transport')


### PR DESCRIPTION
Currently if a tag is released (to be re-used or returned to the pool)
has the side effect of events not being able to be routed to the
appropriate application worker any more since we are using the tag to
find the conversation.

This changes that to use the batch_id instead which doesn't change after
a conversation is closed and/or a tag is reassigned.
