### PR TITLE
Add ConversationConfigResource to allow the sandbox access to conversation config.

### DIFF
--- a/go/apps/jsbox/forms.py
+++ b/go/apps/jsbox/forms.py
@@ -72,8 +72,6 @@ class JsboxAppConfigFormset(BaseFormSet):
             metadata[submeta['key']] = submeta
             del submeta['key']
             del submeta['DELETE']  # remove formset deletion marker
-
-        print metadata
         return metadata
 
     @staticmethod

--- a/go/apps/jsbox/forms.py
+++ b/go/apps/jsbox/forms.py
@@ -7,6 +7,20 @@ from django.forms.formsets import BaseFormSet
 from bootstrap.forms import BootstrapForm
 
 
+def possibly_load_from_url(url, default_value, update):
+    """Possibly load a value from a URL.
+
+    Returns the body of the response from the URL if update is True
+    and the URL is non-empty and a request to the URL returns
+    successfully. Otherwise returns the default value.
+    """
+    if update and url:
+        response = requests.get(url)
+        if response.ok:
+            return response.text
+    return default_value
+
+
 class JavascriptField(forms.CharField):
     widget = widgets.Textarea
 
@@ -16,19 +30,20 @@ class JsboxForm(BootstrapForm):
     source_url = forms.URLField(required=False)
     update_from_source = forms.BooleanField(required=False)
 
-    def _update_from_source(self, url):
-        response = requests.get(url)
-        if response.ok:
-            return response.text
+    @staticmethod
+    def initial_from_metadata(metadata):
+        return metadata
 
     def to_metadata(self):
-        metadata = self.cleaned_data.copy()
-        if metadata['update_from_source']:
-            source = self._update_from_source(metadata['source_url'])
-            if source is not None:
-                metadata['javascript'] = source
-        del metadata['update_from_source']
-        return metadata
+        javascript = possibly_load_from_url(
+            self.cleaned_data['source_url'],
+            self.cleaned_data['javascript'],
+            self.cleaned_data['update_from_source'],
+        )
+        return {
+            'javascript': javascript,
+            'source_url': self.cleaned_data['source_url'],
+        }
 
 
 class ConfigValueField(forms.CharField):
@@ -41,19 +56,21 @@ class JsboxAppConfigForm(BootstrapForm):
     source_url = forms.URLField(required=False)
     update_from_source = forms.BooleanField(required=False)
 
-    def _update_from_source(self, url):
-        response = requests.get(url)
-        if response.ok:
-            return response.text
+    @staticmethod
+    def initial_from_metadata(metadata):
+        return metadata
 
     def to_metadata(self):
-        metadata = self.cleaned_data.copy()
-        if metadata['update_from_source']:
-            source = self._update_from_source(metadata['source_url'])
-            if source is not None:
-                metadata['value'] = source
-        del metadata['update_from_source']
-        return metadata
+        value = possibly_load_from_url(
+            self.cleaned_data['source_url'],
+            self.cleaned_data['value'],
+            self.cleaned_data['update_from_source'],
+        )
+        return {
+            'key': self.cleaned_data['key'],
+            'value': value,
+            'source_url': self.cleaned_data['source_url'],
+        }
 
 
 class JsboxAppConfigFormset(BaseFormSet):
@@ -71,14 +88,15 @@ class JsboxAppConfigFormset(BaseFormSet):
             submeta = form.to_metadata()
             metadata[submeta['key']] = submeta
             del submeta['key']
-            del submeta['DELETE']  # remove formset deletion marker
         return metadata
 
-    @staticmethod
-    def initial_from_metadata(metadata):
+    @classmethod
+    def initial_from_metadata(cls, metadata):
         initials = []
         for key in sorted(metadata):
             submeta = metadata[key].copy()
             submeta['key'] = key
+            if hasattr(cls.form, 'initial_from_metadata'):
+                submeta = getattr(cls.form, 'initial_from_metadata')(submeta)
             initials.append(submeta)
         return initials

--- a/go/apps/jsbox/forms.py
+++ b/go/apps/jsbox/forms.py
@@ -2,6 +2,7 @@ import requests
 
 from django import forms
 from django.forms import widgets
+from django.forms.formsets import BaseFormSet
 
 from bootstrap.forms import BootstrapForm
 
@@ -28,3 +29,58 @@ class JsboxForm(BootstrapForm):
                 metadata['javascript'] = source
         del metadata['update_from_source']
         return metadata
+
+
+class ConfigValueField(forms.CharField):
+    widget = widgets.Textarea
+
+
+class JsboxAppConfigForm(BootstrapForm):
+    key = forms.CharField()
+    value = ConfigValueField(required=False)
+    source_url = forms.URLField(required=False)
+    update_from_source = forms.BooleanField(required=False)
+
+    def _update_from_source(self, url):
+        response = requests.get(url)
+        if response.ok:
+            return response.text
+
+    def to_metadata(self):
+        metadata = self.cleaned_data.copy()
+        if metadata['update_from_source']:
+            source = self._update_from_source(metadata['source_url'])
+            if source is not None:
+                metadata['value'] = source
+        del metadata['update_from_source']
+        return metadata
+
+
+class JsboxAppConfigFormset(BaseFormSet):
+    form = JsboxAppConfigForm
+    extra = 1
+    can_order = False
+    can_delete = True
+    max_num = None
+
+    def to_metadata(self):
+        metadata = {}
+        for form in self.forms:
+            if not form.cleaned_data or form in self.deleted_forms:
+                continue
+            submeta = form.to_metadata()
+            metadata[submeta['key']] = submeta
+            del submeta['key']
+            del submeta['DELETE']  # remove formset deletion marker
+
+        print metadata
+        return metadata
+
+    @staticmethod
+    def initial_from_metadata(metadata):
+        initials = []
+        for key in sorted(metadata):
+            submeta = metadata[key].copy()
+            submeta['key'] = key
+            initials.append(submeta)
+        return initials

--- a/go/apps/jsbox/tests/test_forms.py
+++ b/go/apps/jsbox/tests/test_forms.py
@@ -2,10 +2,57 @@ import mock
 
 from django.test import TestCase
 
-from go.apps.jsbox.forms import JsboxForm, JsboxAppConfigForm
+from go.apps.jsbox.forms import (JsboxForm, JsboxAppConfigForm,
+                                 JsboxAppConfigFormset,
+                                 possibly_load_from_url)
+
+
+class PossiblyLoadFromUrlTestCase(TestCase):
+    def mock_response(self, status_code, text):
+        r = mock.Mock()
+        r.status_code = status_code
+        r.text = text
+        r.ok = status_code == 200
+        return r
+
+    @mock.patch('requests.get')
+    def test_blank_url(self, requests_get):
+        value = possibly_load_from_url('', 'foo', True)
+        self.assertEqual(value, 'foo')
+        self.assertEqual(requests_get.call_count, 0)
+
+    @mock.patch('requests.get')
+    def test_update_false(self, requests_get):
+        value = possibly_load_from_url('http://www.example.com', 'foo', False)
+        self.assertEqual(value, 'foo')
+        self.assertEqual(requests_get.call_count, 0)
+
+    @mock.patch('requests.get')
+    def test_successful_request(self, requests_get):
+        requests_get.return_value = self.mock_response(200, 'source text')
+        value = possibly_load_from_url('http://www.example.com', 'foo', True)
+        self.assertEqual(value, 'source text')
+        requests_get.assert_called_once_with('http://www.example.com')
+
+    @mock.patch('requests.get')
+    def test_failed_request(self, requests_get):
+        requests_get.return_value = self.mock_response(500, 'error text')
+        value = possibly_load_from_url('http://www.example.com', 'foo', True)
+        self.assertEqual(value, 'foo')
+        requests_get.assert_called_once_with('http://www.example.com')
 
 
 class JsboxFormTestCase(TestCase):
+    def test_initial_form_metadata(self):
+        initial = JsboxForm.initial_from_metadata({
+            'javascript': 'x = 1;',
+            'source_url': 'http://www.example.com',
+        })
+        self.assertEqual(initial, {
+            'javascript': 'x = 1;',
+            'source_url': 'http://www.example.com',
+        })
+
     def test_to_metadata(self):
         form = JsboxForm(data={
             'javascript': 'x = 1;',
@@ -17,17 +64,9 @@ class JsboxFormTestCase(TestCase):
             'source_url': '',
         })
 
-    def mock_response(self, status_code, text):
-        r = mock.Mock()
-        r.status_code = status_code
-        r.text = text
-        r.ok = status_code == 200
-        return r
-
-    @mock.patch('requests.get')
-    def test_update_from_source(self, requests_get):
-        requests_get.return_value = self.mock_response(
-            200, "custom javascript")
+    @mock.patch('go.apps.jsbox.forms.possibly_load_from_url')
+    def test_update_from_source(self, possibly_load):
+        possibly_load.return_value = "custom javascript"
         source_url = 'http://www.example.com/'
         form = JsboxForm(data={
             'javascript': '',
@@ -36,32 +75,25 @@ class JsboxFormTestCase(TestCase):
         })
         self.assertTrue(form.is_valid())
         metadata = form.to_metadata()
-        requests_get.assert_called_once_with(source_url)
+        possibly_load.assert_called_once_with(source_url, '', True)
         self.assertEqual(metadata, {
-            'javascript': requests_get.return_value.text,
-            'source_url': source_url,
-        })
-
-    @mock.patch('requests.get')
-    def test_update_from_source_404(self, requests_get):
-        requests_get.return_value = self.mock_response(
-            404, "Javascript not found")
-        source_url = 'http://www.example.com/'
-        form = JsboxForm(data={
-            'javascript': '',
-            'source_url': source_url,
-            'update_from_source': '1',
-        })
-        self.assertTrue(form.is_valid())
-        metadata = form.to_metadata()
-        requests_get.assert_called_once_with(source_url)
-        self.assertEqual(metadata, {
-            'javascript': '',
+            'javascript': possibly_load.return_value,
             'source_url': source_url,
         })
 
 
 class JsboxAppConfigFormTestCase(TestCase):
+    def test_initial_from_metadata(self):
+        initial = JsboxAppConfigForm.initial_from_metadata({
+            'key': 'foo',
+            'value': 'bar',
+            'source_url': 'http://www.example.com',
+        })
+        self.assertEqual(initial, {
+            'key': 'foo',
+            'value': 'bar',
+            'source_url': 'http://www.example.com',
+        })
 
     def test_to_metadata(self):
         form = JsboxAppConfigForm(data={
@@ -74,4 +106,51 @@ class JsboxAppConfigFormTestCase(TestCase):
             'key': 'foo',
             'value': 'bar',
             'source_url': '',
+        })
+
+    @mock.patch('go.apps.jsbox.forms.possibly_load_from_url')
+    def test_update_from_source(self, possibly_load):
+        possibly_load.return_value = "custom javascript"
+        source_url = 'http://www.example.com/'
+        form = JsboxAppConfigForm(data={
+            'key': 'bar',
+            'value': '',
+            'source_url': source_url,
+            'update_from_source': '1',
+        })
+        self.assertTrue(form.is_valid())
+        metadata = form.to_metadata()
+        possibly_load.assert_called_once_with(source_url, '', True)
+        self.assertEqual(metadata, {
+            'key': 'bar',
+            'value': possibly_load.return_value,
+            'source_url': source_url,
+        })
+
+
+class JsboxAppConfigFormsetTestCase(TestCase):
+    def test_initial_from_metadata(self):
+        initials = JsboxAppConfigFormset.initial_from_metadata({
+            'foo1': {'value': 'bar', 'source_url': 'http://example.com/1'},
+            'foo2': {'value': 'baz', 'source_url': 'http://example.com/2'},
+        })
+        self.assertEqual(initials, [
+           {'key': 'foo1', 'value': 'bar',
+            'source_url': 'http://example.com/1'},
+           {'key': 'foo2', 'value': 'baz',
+            'source_url': 'http://example.com/2'},
+        ])
+
+    def test_to_metadata(self):
+        formset = JsboxAppConfigFormset(data={
+            'form-TOTAL_FORMS': '1',
+            'form-INITIAL_FORMS': '0',
+            'form-MAX_NUM_FORMS': u'',
+            'form-0-key': 'foo1',
+            'form-0-value': 'bar',
+            'form-0-source_url': 'http://example.com/1',
+        })
+        self.assertTrue(formset.is_valid())
+        self.assertEqual(formset.to_metadata(), {
+            'foo1': {'value': 'bar', 'source_url': 'http://example.com/1'},
         })

--- a/go/apps/jsbox/tests/test_forms.py
+++ b/go/apps/jsbox/tests/test_forms.py
@@ -2,11 +2,11 @@ import mock
 
 from django.test import TestCase
 
-from go.apps.jsbox.forms import JsboxForm
+from go.apps.jsbox.forms import JsboxForm, JsboxAppConfigForm
 
 
 class JsboxFormTestCase(TestCase):
-    def test_to_metdata(self):
+    def test_to_metadata(self):
         form = JsboxForm(data={
             'javascript': 'x = 1;',
         })
@@ -58,4 +58,20 @@ class JsboxFormTestCase(TestCase):
         self.assertEqual(metadata, {
             'javascript': '',
             'source_url': source_url,
+        })
+
+
+class JsboxAppConfigFormTestCase(TestCase):
+
+    def test_to_metadata(self):
+        form = JsboxAppConfigForm(data={
+            'key': 'foo',
+            'value': 'bar',
+        })
+        self.assertTrue(form.is_valid())
+        metadata = form.to_metadata()
+        self.assertEqual(metadata, {
+            'key': 'foo',
+            'value': 'bar',
+            'source_url': '',
         })

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -129,11 +129,11 @@ class TestConversationConfigResource(TestCase):
         self.app_worker.conversation_for_api = mock.Mock(
             return_value=self.conversation)
 
-    def set_app_config(self, app_config):
+    def set_app_config(self, key_values):
+        app_config = dict((k, {"value": v}) for k, v
+                          in key_values.iteritems())
         self.conversation.metadata = {
-            "jsbox": {
-                "app_config": app_config,
-            },
+            "jsbox_app_config": app_config,
         }
 
     def check_reply(self, reply, cmd, value):

--- a/go/apps/jsbox/views.py
+++ b/go/apps/jsbox/views.py
@@ -1,5 +1,5 @@
 from go.conversation.base import ConversationViews
-from go.apps.jsbox.forms import JsboxForm
+from go.apps.jsbox.forms import JsboxForm, JsboxAppConfigFormset
 
 
 class JsboxConversationViews(ConversationViews):
@@ -8,4 +8,5 @@ class JsboxConversationViews(ConversationViews):
     conversation_initiator = None
     edit_conversation_forms = (
         ('jsbox', JsboxForm),
+        ('jsbox_app_config', JsboxAppConfigFormset),
         )

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -15,14 +15,14 @@ from go.vumitools.app_worker import GoApplicationMixin
 class ConversationConfigResource(SandboxResource):
     """Resource that provides access to conversation config."""
 
-    @inlineCallbacks
     def handle_get(self, api, command):
         key = command.get("key")
         if key is None:
             return self.reply(command, success=False)
         conversation = self.app_worker.conversation_for_api(api)
-        jsbox_config = conversation.metadata.get("jsbox_config", {})
-        value = jsbox_config.get(key)
+        jsbox = conversation.metadata.get("jsbox", {})
+        app_config = jsbox.get("app_config", {})
+        value = app_config.get(key)
         return self.reply(command, value=value, success=True)
 
 

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -20,9 +20,9 @@ class ConversationConfigResource(SandboxResource):
         if key is None:
             return self.reply(command, success=False)
         conversation = self.app_worker.conversation_for_api(api)
-        jsbox = conversation.metadata.get("jsbox", {})
-        app_config = jsbox.get("app_config", {})
-        value = app_config.get(key)
+        app_config = conversation.metadata.get("jsbox_app_config", {})
+        key_config = app_config.get(key, {})
+        value = key_config.get('value')
         return self.reply(command, value=value, success=True)
 
 


### PR DESCRIPTION
The use-case driving this is making JSON objects containing translations accessible to the JS code without having to doing something like make an HTTP call.

This ticket includes adding UI for updating config values from a URL.
