### PR TITLE
Displaying groups for a conversation in show.html was broken.

### DIFF
--- a/go/apps/surveys/templates/surveys/includes/overview.html
+++ b/go/apps/surveys/templates/surveys/includes/overview.html
@@ -14,7 +14,7 @@
         <span class="label label-info">{{conversation.start_timestamp|date:"d F Y"}}</span> 
         <span class="label">{{conversation.delivery_class_description}}</span> 
 
-        {% for group in conversation.groups.get_all %}
+        {% for group in conversation.get_groups %}
         <span class="label label-inverse">{{group.name}}</span>
         {% endfor %}
          <h3>{{conversation.subject}}</h3>

--- a/go/conversation/templates/generic/includes/overview.html
+++ b/go/conversation/templates/generic/includes/overview.html
@@ -12,7 +12,7 @@
         <span class="label label-info">{{conversation.start_timestamp|date:"d F Y"}}</span>
         <span class="label">{{conversation.delivery_class_description}}</span>
 
-        {% for group in conversation.groups.get_all %}
+        {% for group in conversation.get_groups %}
         <span class="label label-inverse">{{group.name}}</span>
         {% endfor %}
          <h3>{{conversation.subject}}</h3>

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -178,9 +178,10 @@ class VumiUserApi(object):
                         for application in sorted(applications)
                         if application in app_settings]))
 
+    @Manager.calls_manager
     def list_groups(self):
-        return sorted(self.contact_store.list_groups(),
-            key=lambda group: group.name)
+        returnValue(sorted((yield self.contact_store.list_groups()),
+            key=lambda group: group.name))
 
     def new_conversation(self, *args, **kw):
         return self.conversation_store.new_conversation(*args, **kw)

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -386,3 +386,12 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
                 for i in range(9, -1, -1)])
         for bucket in buckets:
             self.assertEqual(bucket, 2)
+
+    @inlineCallbacks
+    def test_get_groups(self):
+        groups = yield self.user_api.list_groups()
+        self.assertEqual([], groups)
+        group = yield self.user_api.contact_store.new_group(u'test group')
+        self.conv.groups.add_key(group.key)
+        [found_group] = yield self.conv.get_groups()
+        self.assertEqual(found_group.key, group.key)

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -136,6 +136,16 @@ class ConversationWrapper(object):
         returnValue(int(status['ack'] / float(status['sent']) * 100))
 
     @Manager.calls_manager
+    def get_groups(self):
+        """
+        Convenience method for loading all groups linked to this conversation.
+        """
+        groups = []
+        for bunch in self.groups.load_all_bunches():
+            groups.extend((yield bunch))
+        returnValue(groups)
+
+    @Manager.calls_manager
     def make_message_options(self, tag):
         msg_options = {}
         # TODO: transport_type is probably irrelevant


### PR DESCRIPTION
This was because it was directly calling `conv.groups.get_all()` which
no longer works since we're working with keys.

This fixes that by adding `conv.get_groups()`.
Also uncovered a bit where we weren't using `@Manager.calls_manager` & `yield` where we should've been doing so.
