### PR TITLE
VUMIGO-251 TokenManager

### DIFF
--- a/go/base/tests/test_token_manager.py
+++ b/go/base/tests/test_token_manager.py
@@ -4,7 +4,7 @@ from django.test.client import Client
 from django.core.urlresolvers import reverse
 
 from go.apps.tests.base import DjangoGoApplicationTestCase
-from go.base.token_manager import TokenManager
+from go.base.token_manager import TokenManager, InvalidToken, MalformedToken
 
 
 class TokenManagerTestCase(DjangoGoApplicationTestCase):
@@ -71,9 +71,13 @@ class TokenManagerTestCase(DjangoGoApplicationTestCase):
         response = self.client.get(token_url)
         self.assertTrue(response.status_code, 404)
 
+    def test_malformed_token(self):
+        self.assertRaises(MalformedToken, self.tm.verify_get,
+                            'A-token-starting-with-a-digit')
+
     def test_token_verify(self):
         token = self.tm.generate('/foo/', token=('to', 'ken'))
-        self.assertEqual(self.tm.get(token, verify='bar'), None)
+        self.assertRaises(InvalidToken, self.tm.get, token, verify='bar')
         self.assertEqual(self.tm.get(token, verify='ken'), {
             'user_id': '',
             'system_token': 'ken',

--- a/go/base/tests/test_token_manager.py
+++ b/go/base/tests/test_token_manager.py
@@ -21,14 +21,16 @@ class TokenManagerTestCase(DjangoGoApplicationTestCase):
         token = self.tm.generate('/some/path/', lifetime=10)
         token_data = self.tm.get(token)
         self.assertEqual(len(token), 6)
-        self.assertEqual(token_data, {
-            'user_id': '',
-            'redirect_to': '/some/path/',
-            })
+        self.assertEqual(token_data['user_id'], '')
+        self.assertEqual(token_data['redirect_to'], '/some/path/')
+        self.assertTrue(token_data['system_token'])
 
     def test_token_provided(self):
-        token = self.tm.generate('/some/path/', lifetime=10, token='token!')
-        self.assertEqual(token, 'token!')
+        token = self.tm.generate('/some/path/', lifetime=10,
+                                    token=('to', 'ken'))
+        self.assertEqual(token, 'to')
+        token_data = self.tm.get(token)
+        self.assertEqual(token_data['system_token'], 'ken')
 
     def test_unknown_token(self):
         self.assertEqual(self.tm.get('foo'), {})
@@ -45,9 +47,12 @@ class TokenManagerTestCase(DjangoGoApplicationTestCase):
     def test_token_with_login(self):
         token = self.tm.generate('/path/', user_id=self.user.pk)
         token_url = reverse('token', kwargs={'token': token})
+        token_data = self.tm.get(token)
         self.client.login(username='username', password='password')
         response = self.client.get(token_url)
-        self.assertTrue(response['Location'].endswith('/path/'))
+        self.assertTrue(
+            response['Location'].endswith('/path/?token=%s%s%s' % (
+                len(token), token, token_data['system_token'])))
 
     def test_token_with_invalid_login(self):
         token = self.tm.generate('/path/', user_id=-1)
@@ -64,3 +69,18 @@ class TokenManagerTestCase(DjangoGoApplicationTestCase):
         token_url = reverse('token', kwargs={'token': token})
         response = self.client.get(token_url)
         self.assertTrue(response.status_code, 404)
+
+    def test_token_verify(self):
+        token = self.tm.generate('/foo/', token=('to', 'ken'))
+        self.assertEqual(self.tm.get(token, verify='bar'), {})
+        self.assertEqual(self.tm.get(token, verify='ken'), {
+            'user_id': '',
+            'system_token': 'ken',
+            'redirect_to': '/foo/',
+            })
+
+    def test_token_delete(self):
+        token = self.tm.generate('/foo/')
+        self.assertTrue(self.tm.get(token))
+        self.assertTrue(self.tm.delete(token))
+        self.assertFalse(self.tm.get(token))

--- a/go/base/tests/test_token_manager.py
+++ b/go/base/tests/test_token_manager.py
@@ -1,0 +1,66 @@
+import urllib
+
+from django.test.client import Client
+from django.core.urlresolvers import reverse
+
+from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.token_manager import TokenManager
+
+
+class TokenManagerTestCase(DjangoGoApplicationTestCase):
+    use_riak = False
+
+    def setUp(self):
+        super(TokenManagerTestCase, self).setUp()
+        self.client = Client()
+        self.redis = self.get_redis_manager()
+        self.tm = TokenManager(self.redis.sub_manager('token_manager'))
+        self.user = self.mk_django_user()
+
+    def test_token_generation(self):
+        token = self.tm.generate('/some/path/', lifetime=10)
+        token_data = self.tm.get(token)
+        self.assertEqual(len(token), 6)
+        self.assertEqual(token_data, {
+            'user_id': '',
+            'redirect_to': '/some/path/',
+            })
+
+    def test_token_provided(self):
+        token = self.tm.generate('/some/path/', lifetime=10, token='token!')
+        self.assertEqual(token, 'token!')
+
+    def test_unknown_token(self):
+        self.assertEqual(self.tm.get('foo'), {})
+
+    def test_token_require_login(self):
+        token = self.tm.generate('/path/', user_id=self.user.pk)
+        token_url = reverse('token', kwargs={'token': token})
+        response = self.client.get(token_url)
+        self.assertRedirects(response,
+            '%s?%s' % (reverse('auth_login'), urllib.urlencode({
+                        'next': reverse('token', kwargs={'token': token}),
+                        })))
+
+    def test_token_with_login(self):
+        token = self.tm.generate('/path/', user_id=self.user.pk)
+        token_url = reverse('token', kwargs={'token': token})
+        self.client.login(username='username', password='password')
+        response = self.client.get(token_url)
+        self.assertTrue(response['Location'].endswith('/path/'))
+
+    def test_token_with_invalid_login(self):
+        token = self.tm.generate('/path/', user_id=-1)
+        token_url = reverse('token', kwargs={'token': token})
+        self.client.login(username='username', password='password')
+        response = self.client.get(token_url)
+        self.assertRedirects(response,
+            '%s?%s' % (reverse('auth_login'), urllib.urlencode({
+                        'next': reverse('token', kwargs={'token': token}),
+                        })))
+
+    def test_invalid_token(self):
+        token = self.tm.generate('/foo/', user_id=self.user.pk)
+        token_url = reverse('token', kwargs={'token': token})
+        response = self.client.get(token_url)
+        self.assertTrue(response.status_code, 404)

--- a/go/base/token_manager.py
+++ b/go/base/token_manager.py
@@ -76,12 +76,11 @@ class TokenManager(object):
 
     def get(self, token, verify=None):
         """
-        Retrieve the data for the given token, it it doesn't exist it'll
-        return an empty dictionary.
+        Retrieve the data for the given token. If there is no match then `None`
+        will be returned.
 
         :param str verify:
-            Provide the system_token if matching needs to occur. If there
-            is no match then an empty dictionary will be returned.
+            Provide the system_token if matching needs to occur.
         """
         if not self.redis.exists(token):
             return None

--- a/go/base/token_manager.py
+++ b/go/base/token_manager.py
@@ -62,17 +62,30 @@ class TokenManager(object):
             data that can be encoded as JSON.
         """
         lifetime = lifetime or self.DEFAULT_LIFETIME
-        a = token or self.generate_token()
-        user_token, system_token = a
+        user_token, system_token = token or self.generate_token()
         extra_params = extra_params or {}
-        self.redis.hmset(user_token, {
-            'redirect_to': redirect_to,
-            'user_id': user_id or '',
-            'system_token': system_token,
-            'extra_params': json.dumps(extra_params),
-            })
-        self.redis.expire(user_token, lifetime)
-        return user_token
+
+        # This is to avoid a possible race condition which could occur in
+        # `generate_token()` if two identical user_tokens are generated before
+        # either is stored.
+        if self.redis.hsetnx(user_token, 'system_token', system_token):
+            self.redis.hmset(user_token, {
+                'redirect_to': redirect_to,
+                'user_id': user_id or '',
+                'extra_params': json.dumps(extra_params),
+                })
+            self.redis.expire(user_token, lifetime)
+            return user_token
+
+        # If we've been given a token then we need to raise an exception as
+        # that's not something we can recover from.
+        if token:
+            raise TokenManagerException('This token has already been issued.')
+
+        # If we end up here then we've hit the race condition and we need to
+        # retry.
+        return self.generate(redirect_to, user_id=user_id, lifetime=lifetime,
+            token=token, extra_params=extra_params)
 
     def get(self, token, verify=None):
         """

--- a/go/base/token_manager.py
+++ b/go/base/token_manager.py
@@ -1,0 +1,52 @@
+from uuid import uuid4
+
+
+class TokenManager(object):
+    """
+    A system for managing 1-time tokens that can expire.
+    """
+    # How long should tokens live by default in seconds
+    DEFAULT_LIFETIME = 60 * 60 * 4
+
+    def __init__(self, redis):
+        self.redis = redis
+
+    def generate_token(self, length=6):
+        """
+        Generate a token that doesn't exist yet but is also short enough
+        to not take up too much space in an SMS.
+        """
+        token_taken = True
+        while token_taken:
+            token = uuid4().hex[0:length]
+            token_taken = self.redis.exists(token)
+        return token
+
+    def generate(self, redirect_to, user_id=None, lifetime=None, token=None):
+        """
+        Generate a token that redirects to `redirect_to` for exactly
+        `lifetime` amount of seconds.
+
+        :param int lifetime:
+            How long should the token be valid for in seconds.
+        :param int user_id:
+            Django user id, if specified this URL is only valid for this user.
+        :param str token:
+            The token to use, if not specified then a unique one will be
+            automatically generated.
+        """
+        lifetime = lifetime or self.DEFAULT_LIFETIME
+        token = token or self.generate_token()
+        self.redis.hmset(token, {
+            'redirect_to': redirect_to,
+            'user_id': user_id or '',
+            })
+        self.redis.expire(token, lifetime)
+        return token
+
+    def get(self, token):
+        """
+        Retrieve the data for the given token, it it doesn't exist it'll
+        return an empty dictionary.
+        """
+        return self.redis.hgetall(token)

--- a/go/base/token_manager.py
+++ b/go/base/token_manager.py
@@ -11,16 +11,21 @@ class TokenManager(object):
     def __init__(self, redis):
         self.redis = redis
 
-    def generate_token(self, length=6):
+    def generate_token(self, user_token_size=6):
         """
         Generate a token that doesn't exist yet but is also short enough
         to not take up too much space in an SMS.
+
+        :param int user_token_size:
+            How big the token sent to the user should be. Defaults to 6.
         """
         token_taken = True
         while token_taken:
-            token = uuid4().hex[0:length]
-            token_taken = self.redis.exists(token)
-        return token
+            full_token = uuid4().hex
+            user_token = full_token[0:user_token_size]
+            system_token = full_token[user_token_size:]
+            token_taken = self.redis.exists(user_token)
+        return (user_token, system_token)
 
     def generate(self, redirect_to, user_id=None, lifetime=None, token=None):
         """
@@ -31,22 +36,52 @@ class TokenManager(object):
             How long should the token be valid for in seconds.
         :param int user_id:
             Django user id, if specified this URL is only valid for this user.
-        :param str token:
+        :param tuple token:
             The token to use, if not specified then a unique one will be
-            automatically generated.
+            automatically generated. The token is a tuple in the format
+            (user_token, system_token). The user token is submitted in the SMS
+            the system_token is used internally to ensure that only users
+            arriving at the `redirect_to` URL via the token url gain access.
         """
         lifetime = lifetime or self.DEFAULT_LIFETIME
-        token = token or self.generate_token()
-        self.redis.hmset(token, {
+        user_token, system_token = token or self.generate_token()
+        self.redis.hmset(user_token, {
             'redirect_to': redirect_to,
             'user_id': user_id or '',
+            'system_token': system_token,
             })
-        self.redis.expire(token, lifetime)
-        return token
+        self.redis.expire(user_token, lifetime)
+        return user_token
 
-    def get(self, token):
+    def get(self, token, verify=None):
         """
         Retrieve the data for the given token, it it doesn't exist it'll
         return an empty dictionary.
+
+        :param str verify:
+            Provide the system_token if matching needs to occur. If there
+            is no match then an empty dictionary will be returned.
         """
-        return self.redis.hgetall(token)
+        token_data = self.redis.hgetall(token)
+        if verify is not None and verify != token_data['system_token']:
+            return {}
+        return token_data
+
+    def verify_get(self, full_token):
+        """
+        Retrieve the data for a full token as supplied to the `redirect_to`
+        URL.
+        """
+        user_token_length, _, token = full_token.partition('-')
+        user_token = token[0:int(user_token_length)]
+        system_token = token[int(user_token_length):]
+        return self.get(user_token, verify=system_token)
+
+    def delete(self, token):
+        """
+        Remove a token
+
+        :param str token:
+            The token to expire.
+        """
+        return self.redis.delete(token)

--- a/go/base/views.py
+++ b/go/base/views.py
@@ -1,4 +1,5 @@
 import urllib
+import urlparse
 
 from django.conf import settings
 from django.shortcuts import render, Http404, redirect
@@ -24,11 +25,18 @@ def token(request, token):
         raise Http404
     user_id = int(token_data['user_id'])
     redirect_to = token_data['redirect_to']
+    system_token = token_data['system_token']
 
     # If we're authorized and we're the same user_id then redirect to
     # where we need to be
     if not user_id or request.user.id == user_id:
-        return redirect(redirect_to)
+        path, _, qs = redirect_to.partition('?')
+        params = urlparse.parse_qs(qs)
+        # since the token can be custom we prepend the size of the user_token
+        # to the token being forwarded so the view handling the `redirect_to`
+        # can lookup the token and verify the system token.
+        params.update({'token': '%s-%s%s' % (len(token), token, system_token)})
+        return redirect('%s?%s' % (path, urllib.urlencode(params)))
 
     # If we got here then we need authentication and the user's either not
     # logged in or is logged in with a wrong account.

--- a/go/base/views.py
+++ b/go/base/views.py
@@ -1,6 +1,40 @@
-from django.shortcuts import render
+import urllib
+
+from django.conf import settings
+from django.shortcuts import render, Http404, redirect
+from django.contrib.auth.views import logout
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+
+from vumi.persist.redis_manager import RedisManager
+
+from go.base.token_manager import TokenManager
 
 
 def todo(request):  # pragma: no cover
     return render(request, 'base/todo.html', {
     })
+
+
+def token(request, token):
+    redis = RedisManager.from_config(settings.VUMI_API_CONFIG['redis_manager'])
+    tm = TokenManager(redis.sub_manager('token_manager'))
+    token_data = tm.get(token)
+    if not token_data:
+        raise Http404
+    user_id = int(token_data['user_id'])
+    redirect_to = token_data['redirect_to']
+
+    # If we're authorized and we're the same user_id then redirect to
+    # where we need to be
+    if not user_id or request.user.id == user_id:
+        return redirect(redirect_to)
+
+    # If we got here then we need authentication and the user's either not
+    # logged in or is logged in with a wrong account.
+    if request.user.is_authenticated():
+        logout(request)
+        messages.info(request, 'Wrong account for this token.')
+    return redirect('%s?%s' % (reverse('auth_login'), urllib.urlencode({
+        'next': reverse('token', kwargs={'token': token}),
+        })))

--- a/go/urls.py
+++ b/go/urls.py
@@ -27,6 +27,7 @@ urlpatterns = patterns('',
 
     # simple todo view for stuff that's not completed yet
     url(r'^todo/.*$', 'go.base.views.todo', name='todo'),
+    url(r'^t/(?P<token>\w+)/$', 'go.base.views.token', name='token'),
 
     # vumi go!
     url(r'^$', RedirectView.as_view(url='/conversations/', permanent=False,


### PR DESCRIPTION
TokenManager for managing once-off auto-expiring tokens to Vumi Go. Used
for SMS confirmations.

Generates a token consisting of two parts. First part is submitted to
the user, the second part is looked up serverside and then redirected
to the specified `redirect_to` URL. That URL is responsible for ensuring
that the two parts are present and valid, it is the only way we have to
ensure that a user has actually arrived via the token.

Undecided on whether or not a token needs to be deleted when a
conversation is started or whether we should just leave that to Redis to
expire.
