### PR TITLE
Add delayed contact group member counting (for static and dynamic groups)

### DIFF
--- a/go/contacts/templates/contacts/group.html
+++ b/go/contacts/templates/contacts/group.html
@@ -43,7 +43,7 @@
 	               <a data-toggle="modal" href="#newConv">Message this group</a>
 	            </div>
 	        </div>
- -->            <h3>{{group.name}} <span class="label label-info">{{group.contact_set.count}} Members</span></h3><br />
+ -->            <h3>{{group.name}} <span class="label label-info">{{member_count}} Members</span></h3><br />
         </div>
     </div>
     <div class="row">

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -31,6 +31,7 @@ def _group_url(group_key):
 def index(request):
     return redirect(reverse('contacts:groups'))
 
+
 @login_required
 def groups(request):
     contact_store = request.user_api.contact_store
@@ -250,6 +251,7 @@ def _smart_group(request, contact_store, group):
         'group': group,
         'selected_contacts': selected_contacts,
         'group_form': smart_group_form,
+        'member_count': len(keys),
     })
 
 

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -210,6 +210,7 @@ def _static_group(request, contact_store, group):
         'query': request.GET.get('q'),
         'selected_letter': selected_letter,
         'selected_contacts': selected_contacts,
+        'member_count': contact_store.count_contacts_for_group(group),
         })
 
     return render(request, 'contacts/group.html', context)

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -161,6 +161,12 @@ class ContactStore(PerAccountStore):
         """
         return self.contacts.raw_search(group.query).get_keys()
 
+    def count_contacts_for_group(self, group):
+        if group.is_smart_group():
+            return self.contacts.raw_search(group.query).get_count()
+        else:
+            return self.contacts.index_lookup('groups', group.key).get_count()
+
     @Manager.calls_manager
     def filter_contacts_on_surname(self, letter, group=None):
         # FIXME: This does a mapreduce over a bucket, which means hitting every

--- a/go/vumitools/tests/test_contact.py
+++ b/go/vumitools/tests/test_contact.py
@@ -129,3 +129,24 @@ class TestContactStore(GoPersistenceMixin, TestCase):
 
         self.assertTrue((yield self.store.contact_has_opted_out(contact1)))
         self.assertFalse((yield self.store.contact_has_opted_out(contact2)))
+
+    @inlineCallbacks
+    def test_count_contacts_for_static_group(self):
+        group = yield self.store.new_group(u'test group')
+        for i in range(2):
+            yield self.store.new_contact(
+                name=u'Contact', surname=u'%d' % i, msisdn=u'12345',
+                groups=[group])
+        count = yield self.store.count_contacts_for_group(group)
+        self.assertEqual(count, 2)
+
+    @inlineCallbacks
+    def test_count_contacts_for_smart_group(self):
+        yield self.store.contacts.enable_search()
+        group = yield self.store.new_smart_group(u'test group',
+                                                 u'surname:"Foo 1"')
+        for i in range(2):
+            yield self.store.new_contact(
+                name=u'Contact', surname=u'Foo %d' % i, msisdn=u'12345')
+        count = yield self.store.count_contacts_for_group(group)
+        self.assertEqual(count, 1)


### PR DESCRIPTION
Required to avoid having to report these numbers manually every day while on leave. :)
