### PR TITLE
VUMIGO-247 reuse existing batch id for conversation.

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -417,10 +417,10 @@ class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):
         # because we `get_latest_batch_key()` depends on the cache being
         # populated which at this point it isn't yet.
         batch_keys = conversation.get_batch_keys()
-        self.assertEqual(len(batch_keys), 2)
-        [latest_batch_key] = [bk for bk in batch_keys if bk != batch_key]
+        self.assertEqual(len(batch_keys), 1)
+        self.assertEqual([batch_key], batch_keys)
 
-        batch = conversation.mdb.get_batch(latest_batch_key)
+        batch = conversation.mdb.get_batch(batch_key)
         [tag] = list(batch.tags)
         [cmd] = self.get_api_commands_sent()
 

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -279,7 +279,8 @@ class ConfirmConversationView(ConversationView):
         confirmation_form = ConfirmConversationForm(request.POST)
         if confirmation_form.is_valid():
             try:
-                conversation.start(acquire_tag=False, **params)
+                batch_id = conversation.get_latest_batch_key()
+                conversation.start(batch_id=batch_id, **params)
                 messages.info(request, '%s started succesfully!' % (
                                             self.conversation_display_name,))
                 return redirect('%s?%s' % (


### PR DESCRIPTION
After a sending an token via SMS we're re-using the already acquired
batch_id when starting the conversation after confirmation.
