### PR TITLE
Add resource for sending to other tags from JS sandbox

### DIFF
--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -17,8 +17,7 @@ class GoOutboundResource(OutboundResource):
         tag = (command.get('tagpool'), command.get('tag'))
         content = command.get('content')
         to_addr = command.get('to_addr')
-        if (tag[0] is None or tag[1] is None or content is None or
-                to_addr is None):
+        if None in (tag[0], tag[1], content, to_addr):
             returnValue(self.reply(
                 command, success=False,
                 reason="Tag, content or to_addr not specified"))

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -1,0 +1,26 @@
+# -*- test-case-name: go.apps.jsbox.tests.test_outbound -*-
+# -*- coding: utf-8 -*-
+
+"""Outbound message resource for JS Box sandboxes"""
+
+from vumi.application.sandbox import OutboundResource
+from vumi import log
+
+
+class GoOutboundResource(OutboundResource):
+    """Resource that provides outbound message support for Go."""
+
+    def handle_send_to_tag(self, api, command):
+        tagpool = command.get('tagpool')
+        tag = command.get('tag')
+        content = command['content']
+        to_addr = command['to_addr']
+        # TODO: check tagpool / tag is owned by an active conversation
+        # TODO: fetch tagpool metadata for tagpool
+        msg_options = {}
+        self.app_worker.send_to(to_addr, content, **msg_options)
+
+    def handle_send_to(self, api, command):
+        # Generic sending is not supported in Vumi Go sandboxes
+        return self.reply(command, success=False,
+                          reason="Generic sending not supported in Vumi Go")

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -3,6 +3,8 @@
 
 """Outbound message resource for JS Box sandboxes"""
 
+from twisted.internet.defer import inlineCallbacks, returnValue
+
 from vumi.application.sandbox import OutboundResource
 from vumi import log
 
@@ -10,15 +12,29 @@ from vumi import log
 class GoOutboundResource(OutboundResource):
     """Resource that provides outbound message support for Go."""
 
+    @inlineCallbacks
     def handle_send_to_tag(self, api, command):
-        tagpool = command.get('tagpool')
-        tag = command.get('tag')
-        content = command['content']
-        to_addr = command['to_addr']
-        # TODO: check tagpool / tag is owned by an active conversation
-        # TODO: fetch tagpool metadata for tagpool
-        msg_options = {}
-        self.app_worker.send_to(to_addr, content, **msg_options)
+        tag = (command.get('tagpool'), command.get('tag'))
+        content = command.get('content')
+        to_addr = command.get('to_addr')
+        if (tag[0] is None or tag[1] is None or content is None or
+                to_addr is None):
+            returnValue(self.reply(
+                command, success=False,
+                reason="Tag, content or to_addr not specified"))
+        log.info("Sending outbound message to %r via tag %r, content: %r" %
+                 (to_addr, tag, content))
+
+        user_api = self.app_worker.user_api_for_api(api)
+        tags = yield user_api.list_endpoints()
+        if tag not in tags:
+            returnValue(self.reply(command, success=False,
+                                   reason="Tag %r not held by account"
+                                   % (tag,)))
+        msg_options = yield user_api.msg_options(tag)
+        yield self.app_worker.send_to(to_addr, content, **msg_options)
+
+        returnValue(self.reply(command, success=True))
 
     def handle_send_to(self, api, command):
         # Generic sending is not supported in Vumi Go sandboxes

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -1,0 +1,26 @@
+"""Tests for go.apps.jsbox.outbound."""
+
+import mock
+
+from twisted.trial.unittest import TestCase
+
+from vumi.application.sandbox import SandboxCommand
+from vumi.tests.utils import LogCatcher
+
+from go.apps.jsbox.outbound import GoOutboundResource
+
+
+class TestGoOutboundResource(TestCase):
+
+    def setUp(self):
+        self.conversation = mock.Mock()
+        self.app_worker = mock.Mock()
+        self.dummy_api = object()
+        self.resource = GoOutboundResource("test", self.app_worker, {})
+        self.app_worker.conversation_for_api = mock.Mock(
+            return_value=self.conversation)
+
+    def check_reply(self, reply, cmd, success):
+        self.assertEqual(reply['reply'], True)
+        self.assertEqual(reply['cmd_id'], cmd['cmd_id'])
+        self.assertEqual(reply['success'], success)

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -33,7 +33,7 @@ class TestGoOutboundResource(TestCase):
         self.assertEqual(reply['cmd_id'], cmd['cmd_id'])
         self.assertEqual(reply['success'], success)
 
-    def assert_sent(self, to_addr, content, **msg_options):
+    def assert_sent(self, to_addr, content, msg_options):
         self.app_worker.send_to.assert_called_once_with(
             to_addr, content, **msg_options)
 
@@ -66,7 +66,7 @@ class TestGoOutboundResource(TestCase):
                 "Sending outbound message to '6789' via tag ('pool1', '1234'),"
                 " content: 'bar'"])
         self.assert_reply(reply, cmd, True)
-        self.assert_sent('6789', 'bar', **{'opt1': 'bar'})
+        self.assert_sent('6789', 'bar', {'opt1': 'bar'})
 
     def test_send_to_tag_unacquired(self):
         return self.assert_fails("Tag ('foo', '12345') not held by account",

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -3,6 +3,7 @@
 import mock
 
 from twisted.trial.unittest import TestCase
+from twisted.internet.defer import inlineCallbacks
 
 from vumi.application.sandbox import SandboxCommand
 from vumi.tests.utils import LogCatcher
@@ -14,13 +15,74 @@ class TestGoOutboundResource(TestCase):
 
     def setUp(self):
         self.conversation = mock.Mock()
+        self.user_api = mock.Mock()
         self.app_worker = mock.Mock()
         self.dummy_api = object()
         self.resource = GoOutboundResource("test", self.app_worker, {})
         self.app_worker.conversation_for_api = mock.Mock(
             return_value=self.conversation)
+        self.app_worker.user_api_for_api = mock.Mock(
+            return_value=self.user_api)
+        self.user_api.list_endpoints = mock.Mock(
+            return_value=set([('pool1', '1234'), ('pool2', '1234')]))
+        self.user_api.msg_options = mock.Mock(
+            return_value={'opt1': 'bar'})
 
     def check_reply(self, reply, cmd, success):
         self.assertEqual(reply['reply'], True)
         self.assertEqual(reply['cmd_id'], cmd['cmd_id'])
         self.assertEqual(reply['success'], success)
+
+    def check_sent(self, to_addr, content, **msg_options):
+        self.app_worker.send_to.assert_called_once_with(
+            to_addr, content, **msg_options)
+
+    def check_not_sent(self):
+        self.assertFalse(self.app_worker.send_to.called)
+
+    @inlineCallbacks
+    def check_fails(self, reason, handler=None, **cmd_args):
+        if handler is None:
+            handler = self.resource.handle_send_to_tag
+        cmd = SandboxCommand(**cmd_args)
+        reply = yield handler(self.dummy_api, cmd)
+        self.check_reply(reply, cmd, False)
+        self.check_not_sent()
+        self.assertEqual(reply['reason'], reason)
+
+    def test_send_to_fails(self):
+        return self.check_fails("Generic sending not supported in Vumi Go",
+                                handler=self.resource.handle_send_to)
+
+    @inlineCallbacks
+    def test_send_to_tag(self):
+        cmd = SandboxCommand(tagpool='pool1', tag='1234', to_addr='6789',
+                             content='bar')
+        with LogCatcher() as lc:
+            reply = yield self.resource.handle_send_to_tag(self.dummy_api, cmd)
+            self.assertEqual(lc.messages(), [
+                "Sending outbound message to '6789' via tag ('pool1', '1234'),"
+                " content: 'bar'"])
+        self.check_reply(reply, cmd, True)
+        self.check_sent('6789', 'bar', **{'opt1': 'bar'})
+
+    def test_send_to_tag_unacquired(self):
+        return self.check_fails("Tag ('foo', '12345') not held by account",
+                                tagpool='foo', tag='12345', to_addr='6789',
+                                content='bar')
+
+    def test_send_to_tag_missing_tagpool(self):
+        return self.check_fails("Tag, content or to_addr not specified",
+                                tag='12345', to_addr='6789', content='bar')
+
+    def test_send_to_tag_missing_tag(self):
+        return self.check_fails("Tag, content or to_addr not specified",
+                                tagpool='foo', to_addr='6789', content='bar')
+
+    def test_send_to_tag_missing_to_addr(self):
+        return self.check_fails("Tag, content or to_addr not specified",
+                                tagpool='foo', tag='12345', content='bar')
+
+    def test_send_to_tag_missing_content(self):
+        return self.check_fails("Tag, content or to_addr not specified",
+                                tagpool='foo', tag='12345', to_addr='6789')

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -51,6 +51,8 @@ class TestGoOutboundResource(TestCase):
         self.assertEqual(reply['reason'], reason)
 
     def test_send_to_fails(self):
+        # check that send_to is overridden to return the expected
+        # failure message by calling send_to without arguments
         return self.assert_fails("Generic sending not supported in Vumi Go",
                                  handler=self.resource.handle_send_to)
 

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -28,31 +28,31 @@ class TestGoOutboundResource(TestCase):
         self.user_api.msg_options = mock.Mock(
             return_value={'opt1': 'bar'})
 
-    def check_reply(self, reply, cmd, success):
+    def assert_reply(self, reply, cmd, success):
         self.assertEqual(reply['reply'], True)
         self.assertEqual(reply['cmd_id'], cmd['cmd_id'])
         self.assertEqual(reply['success'], success)
 
-    def check_sent(self, to_addr, content, **msg_options):
+    def assert_sent(self, to_addr, content, **msg_options):
         self.app_worker.send_to.assert_called_once_with(
             to_addr, content, **msg_options)
 
-    def check_not_sent(self):
+    def assert_not_sent(self):
         self.assertFalse(self.app_worker.send_to.called)
 
     @inlineCallbacks
-    def check_fails(self, reason, handler=None, **cmd_args):
+    def assert_fails(self, reason, handler=None, **cmd_args):
         if handler is None:
             handler = self.resource.handle_send_to_tag
         cmd = SandboxCommand(**cmd_args)
         reply = yield handler(self.dummy_api, cmd)
-        self.check_reply(reply, cmd, False)
-        self.check_not_sent()
+        self.assert_reply(reply, cmd, False)
+        self.assert_not_sent()
         self.assertEqual(reply['reason'], reason)
 
     def test_send_to_fails(self):
-        return self.check_fails("Generic sending not supported in Vumi Go",
-                                handler=self.resource.handle_send_to)
+        return self.assert_fails("Generic sending not supported in Vumi Go",
+                                 handler=self.resource.handle_send_to)
 
     @inlineCallbacks
     def test_send_to_tag(self):
@@ -63,26 +63,26 @@ class TestGoOutboundResource(TestCase):
             self.assertEqual(lc.messages(), [
                 "Sending outbound message to '6789' via tag ('pool1', '1234'),"
                 " content: 'bar'"])
-        self.check_reply(reply, cmd, True)
-        self.check_sent('6789', 'bar', **{'opt1': 'bar'})
+        self.assert_reply(reply, cmd, True)
+        self.assert_sent('6789', 'bar', **{'opt1': 'bar'})
 
     def test_send_to_tag_unacquired(self):
-        return self.check_fails("Tag ('foo', '12345') not held by account",
-                                tagpool='foo', tag='12345', to_addr='6789',
-                                content='bar')
+        return self.assert_fails("Tag ('foo', '12345') not held by account",
+                                 tagpool='foo', tag='12345', to_addr='6789',
+                                 content='bar')
 
     def test_send_to_tag_missing_tagpool(self):
-        return self.check_fails("Tag, content or to_addr not specified",
-                                tag='12345', to_addr='6789', content='bar')
+        return self.assert_fails("Tag, content or to_addr not specified",
+                                 tag='12345', to_addr='6789', content='bar')
 
     def test_send_to_tag_missing_tag(self):
-        return self.check_fails("Tag, content or to_addr not specified",
-                                tagpool='foo', to_addr='6789', content='bar')
+        return self.assert_fails("Tag, content or to_addr not specified",
+                                 tagpool='foo', to_addr='6789', content='bar')
 
     def test_send_to_tag_missing_to_addr(self):
-        return self.check_fails("Tag, content or to_addr not specified",
-                                tagpool='foo', tag='12345', content='bar')
+        return self.assert_fails("Tag, content or to_addr not specified",
+                                 tagpool='foo', tag='12345', content='bar')
 
     def test_send_to_tag_missing_content(self):
-        return self.check_fails("Tag, content or to_addr not specified",
-                                tagpool='foo', tag='12345', to_addr='6789')
+        return self.assert_fails("Tag, content or to_addr not specified",
+                                 tagpool='foo', tag='12345', to_addr='6789')

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -46,7 +46,7 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
                                               ("pool", "tag2")])
         yield self.user_api.api.set_pool_metadata("pool", {
             "transport_type": "sphex",
-            })
+        })
 
     @inlineCallbacks
     def setup_conversation(self, contact_count=2,

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -91,6 +91,11 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
         }
         return metadata
 
+    def mk_dummy_api(self, conversation):
+        dummy_api = mock.Mock()
+        dummy_api.conversation = conversation
+        return dummy_api
+
     @inlineCallbacks
     def test_start(self):
         conversation = yield self.setup_conversation()
@@ -118,6 +123,21 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
         yield self.vumi_api.mdb.add_outbound_message(msg, tag=tag)
         event = self.mkmsg_ack(user_message_id=msg['message_id'])
         yield self.dispatch_event(event)
+
+    @inlineCallbacks
+    def test_conversation_for_api(self):
+        conversation = yield self.setup_conversation()
+        dummy_api = self.mk_dummy_api(conversation)
+        self.assertEqual(self.app.conversation_for_api(dummy_api),
+                         conversation)
+
+    @inlineCallbacks
+    def test_user_api_for_api(self):
+        conversation = yield self.setup_conversation()
+        dummy_api = self.mk_dummy_api(conversation)
+        user_api = self.app.user_api_for_api(dummy_api)
+        self.assertEqual(user_api.user_account_key,
+                         conversation.user_account.key)
 
 
 class TestConversationConfigResource(TestCase):

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -67,6 +67,9 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
     def conversation_for_api(self, api):
         return api.conversation
 
+    def user_api_for_api(self, api):
+        return self.get_user_api(api.conversation.user_account.key)
+
     @inlineCallbacks
     def sandbox_protocol_for_message(self, msg_or_event):
         """Return a sandbox protocol for a message or event.

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -148,18 +148,9 @@ class ConversationWrapper(object):
 
     @Manager.calls_manager
     def make_message_options(self, tag):
-        msg_options = {}
-        # TODO: transport_type is probably irrelevant
-        msg_options['transport_type'] = yield self.get_tagpool_metadata(
-            'transport_type')
-        # TODO: not sure whether to declare that tag names must always be
-        #       valid from_addr values or whether to put in a mapping somewhere
-        msg_options['from_addr'] = tag[1]
-        msg_options.update(
-            (yield self.get_tagpool_metadata('msg_options', {})))
-        TaggingMiddleware.add_tag_to_payload(msg_options, tag)
-        DebitAccountMiddleware.add_user_to_payload(msg_options,
-                                                   self.c.user_account.key)
+        yield self.get_tagpool_metadata('msg_options')  # force cache update
+        msg_options = yield self.user_api.msg_options(
+            tag, self._tagpool_metadata)
         returnValue(msg_options)
 
     @Manager.calls_manager


### PR DESCRIPTION
Currently the JS sandbox allows replying via the tag the incoming message was received on. Sometimes one needs to send messages out via other tags but this should only be a tag currently owned by another conversation within the same account.

Once we have the new endpoints / Go routing in place, this can allow sending out via arbitrary endpoints attached to the JS sandbox conversation.
