### PR TITLE
VUMIGO-253 limits on smart groups

### DIFF
--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -470,6 +470,22 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         })
         self.assertContains(response, person_url(self.contact_key))
 
+    def test_group_contact_query_limits(self):
+        default_limit = self.client.get(group_url(self.group_key), {
+            'q': TEST_CONTACT_NAME,
+        })
+        custom_limit = self.client.get(group_url(self.group_key), {
+            'q': TEST_CONTACT_NAME,
+            'limit': 10,
+        })
+        no_limit = self.client.get(group_url(self.group_key), {
+            'q': TEST_CONTACT_NAME,
+            'limit': 0,
+        })
+        self.assertContains(default_limit, 'Showing 100 random contacts')
+        self.assertContains(custom_limit, 'Showing 10 random contacts')
+        self.assertNotContains(no_limit, 'Showing 100 random contacts')
+
     def test_group_contact_filter_by_letter(self):
         first_letter = TEST_CONTACT_SURNAME[0]
 
@@ -686,6 +702,30 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(
             set(self.contact_store.get_contacts_for_conversation(conv)),
             set([contact1.key, contact2.key, contact3.key]))
+
+    def test_smart_group_limit(self):
+        self.client.post(reverse('contacts:groups'), {
+            'name': 'a smart group',
+            'query': 'name:foo OR surname:bar',
+            '_new_smart_group': '1',
+            })
+        group = newest(self.contact_store.list_groups())
+        default_limit = self.client.get('%s?query=foo:bar' % (
+            reverse('contacts:group', kwargs={
+            'group_key': group.key,
+            }),))
+        custom_limit = self.client.get('%s?query=foo:bar&limit=10' % (
+            reverse('contacts:group', kwargs={
+            'group_key': group.key,
+            }),))
+        no_limit = self.client.get('%s?query=foo:bar&limit=0' % (
+            reverse('contacts:group', kwargs={
+            'group_key': group.key,
+            }),))
+
+        self.assertContains(default_limit, 'Showing 100 random contacts')
+        self.assertContains(custom_limit, 'Showing 10 random contacts')
+        self.assertNotContains(no_limit, 'Showing 0 random contacts')
 
 
 class TestFieldNormalizer(TestCase):

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -482,9 +482,15 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
             'q': TEST_CONTACT_NAME,
             'limit': 0,
         })
-        self.assertContains(default_limit, 'Showing 100 random contacts')
-        self.assertContains(custom_limit, 'Showing 10 random contacts')
-        self.assertNotContains(no_limit, 'Showing 100 random contacts')
+        self.assertContains(default_limit, 'alert-success')
+        self.assertContains(default_limit, 'Showing up to 100 random contacts')
+        self.assertContains(custom_limit, 'alert-success')
+        self.assertContains(custom_limit, 'Showing up to 10 random contacts')
+        # Testing for CSS class not existing (since that's used to display
+        # notification messages). We cannot check the context for messages
+        # since that uses Django's internal messages framework which cleared
+        # during rendering.
+        self.assertNotContains(no_limit, 'alert-success')
 
     def test_group_contact_filter_by_letter(self):
         first_letter = TEST_CONTACT_SURNAME[0]
@@ -723,9 +729,15 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
             'group_key': group.key,
             }),))
 
-        self.assertContains(default_limit, 'Showing 100 random contacts')
-        self.assertContains(custom_limit, 'Showing 10 random contacts')
-        self.assertNotContains(no_limit, 'Showing 0 random contacts')
+        self.assertContains(default_limit, 'alert-success')
+        self.assertContains(default_limit, 'Showing up to 100 random contacts')
+        self.assertContains(custom_limit, 'alert-success')
+        self.assertContains(custom_limit, 'Showing up to 10 random contacts')
+        # Testing for CSS class not existing (since that's used to display
+        # notification messages). We cannot check the context for messages
+        # since that uses Django's internal messages framework which cleared
+        # during rendering.
+        self.assertNotContains(no_limit, 'alert-success')
 
 
 class TestFieldNormalizer(TestCase):

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -199,7 +199,14 @@ def _static_group(request, contact_store, group):
             query_kwargs = _query_to_kwargs(request.GET.get('q'))
         else:
             query_kwargs = _query_to_kwargs('name:%s' % query)
+
+        limit = int(request.GET.get('limit', 100))
         keys = contact_store.contacts.search(**query_kwargs).get_keys()
+        if limit:
+            messages.info(request,
+                'Showing %s random contacts matching your query' % (limit,))
+            keys = keys[:limit]
+
         selected_contacts = []
         for contact_bunch in contact_store.contacts.load_all_bunches(keys):
             selected_contacts.extend(contact_bunch)
@@ -244,8 +251,13 @@ def _smart_group(request, contact_store, group):
             })
 
     keys = contact_store.contacts.raw_search(group.query).get_keys()
+    limit = int(request.GET.get('limit', 100))
+    if limit:
+        messages.info(request,
+            'Showing %s random contacts matching your query' % (limit,))
+        keys = keys[:limit]
     selected_contacts = []
-    for contacts in contact_store.contacts.load_all_bunches(keys[:100]):
+    for contacts in contact_store.contacts.load_all_bunches(keys):
         selected_contacts.extend(contacts)
     return render(request, 'contacts/smart_group.html', {
         'group': group,
@@ -315,7 +327,12 @@ def _people(request):
     if query:
         if not ':' in query:
             query = 'name:%s' % (query,)
+        limit = int(request.GET.get('limit', 100))
         keys = contact_store.contacts.raw_search(query).get_keys()
+        if limit:
+            messages.info(request,
+                'Showing %s random contacts matching your query' % (limit,))
+            keys = keys[:limit]
         selected_contacts = []
         for contact_bunch in contact_store.contacts.load_all_bunches(keys):
             selected_contacts.extend(contact_bunch)

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -204,7 +204,8 @@ def _static_group(request, contact_store, group):
         keys = contact_store.contacts.search(**query_kwargs).get_keys()
         if limit:
             messages.info(request,
-                'Showing %s random contacts matching your query' % (limit,))
+                'Showing up to %s random contacts matching your query' % (
+                    limit,))
             keys = keys[:limit]
 
         selected_contacts = []
@@ -254,7 +255,8 @@ def _smart_group(request, contact_store, group):
     limit = int(request.GET.get('limit', 100))
     if limit:
         messages.info(request,
-            'Showing %s random contacts matching your query' % (limit,))
+                'Showing up to %s random contacts matching your query' % (
+                    limit,))
         keys = keys[:limit]
     selected_contacts = []
     for contacts in contact_store.contacts.load_all_bunches(keys):
@@ -331,7 +333,8 @@ def _people(request):
         keys = contact_store.contacts.raw_search(query).get_keys()
         if limit:
             messages.info(request,
-                'Showing %s random contacts matching your query' % (limit,))
+                'Showing up to %s random contacts matching your query' % (
+                    limit,))
             keys = keys[:limit]
         selected_contacts = []
         for contact_bunch in contact_store.contacts.load_all_bunches(keys):

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -215,6 +215,10 @@ class GoApplicationRouter(BaseDispatchRouter):
             return
 
         batch = yield outbound_message.batch.get()
+        if batch is None:
+            log.error('Outbound message without a batch id. Result of bad routing')
+            return
+
         account_key = batch.metadata['user_account']
         user_api = self.vumi_api.get_user_api(account_key)
         conversations = user_api.conversation_store.conversations


### PR DESCRIPTION
Since smart groups might return anything from 0 to millions of keys
without any option of providing pagination or sorting it is a good idea
to provide a sensible default that can be overriden.

Some of these changes are already live on the server as they needed to
be put in place as an emergency measure over the break.
