### PR TITLE
VUMIGO-258 seq send should ignore ended conversations.

### DIFF
--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -146,6 +146,24 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         self.assertEqual(self.message_convs, [conv, conv])
 
     @inlineCallbacks
+    def test_schedule_daily_with_ended_conv(self):
+        conv = yield self.create_conversation(metadata={
+                'schedule': {'recurring': 'daily', 'time': '00:01:40'}})
+        yield self.start_conversation(conv)
+        yield conv.end_conversation()
+
+        yield self._stub_out_async(conv)
+
+        yield self.check_message_convs_and_advance([], 70)
+        yield self.check_message_convs_and_advance([], 70)
+        # had it been scheduled it should show up after from here on onwards
+        yield self.check_message_convs_and_advance([], 70)
+        yield self.check_message_convs_and_advance([], 3600 * 24 - 140)
+        yield self.check_message_convs_and_advance([], 70)
+        yield self.check_message_convs_and_advance([], 70)
+        self.assertEqual(self.message_convs, [])
+
+    @inlineCallbacks
     def test_schedule_day_of_month_conv(self):
         conv = yield self.create_conversation(metadata={'schedule': {
             'recurring': 'day_of_month', 'time': '12:00:00', 'days': '1, 5'}})

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -93,7 +93,8 @@ class SequentialSendApplication(GoApplicationWorker):
         log.debug("Processing %s to %s: %s" % (
             then, now, [c.key for c in conversations]))
         for conv in conversations:
-            yield self.process_conversation_schedule(then, now, conv)
+            if not conv.ended():
+                yield self.process_conversation_schedule(then, now, conv)
 
     @inlineCallbacks
     def process_conversation_schedule(self, then, now, conv):


### PR DESCRIPTION
An ended conversation shouldn't be allowed to send out more messages
even if the scheduled slot matches.

I'm deliberately not removing them from the set of
scheduled_conversations because of the posibility of at one point being
able to re-open a conversation. If and when that happens the scheduling
should kick in again.
