### PR TITLE
VUMIGO-260 fix ordering of extras on export

### DIFF
--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -94,8 +94,9 @@ def export_group_contacts(account_key, group_key, include_extra):
             extra_fields.update(contact.extra.keys())
 
     # write the CSV header
-    writer.writerow(fields + ['extra-%s' % (key,)
-                                    for key in sorted(extra_fields)])
+    extra_fields = sorted(extra_fields)
+    writer.writerow(fields + ['extras-%s' % (key,)
+                                    for key in extra_fields])
 
     # loop over the contacts and create the row populated with
     # the values of the selected fields.

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -570,6 +570,7 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
 
         # add some extra info to ensure it gets exported properly
         self.contact.extra['foo'] = u'bar'
+        self.contact.extra['bar'] = u'baz'
         self.contact.save()
 
         response = self.client.post(group_url, {
@@ -589,8 +590,13 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
             in email.body)
         self.assertEqual(file_name, 'contacts-export.csv')
         [header, contact, _] = contents.split('\r\n')
-        self.assertTrue(header.endswith('foo'))
-        self.assertTrue(contact.endswith('bar'))
+
+        self.assertEqual(header,
+            ','.join(['name', 'surname', 'email_address', 'msisdn', 'dob',
+                'twitter_handle', 'facebook_id', 'bbm_pin', 'gtalk_id',
+                'created_at', 'extras-bar', 'extras-foo']))
+
+        self.assertTrue(contact.endswith('baz,bar'))
         self.assertTrue(contents)
         self.assertEqual(mime_type, 'text/csv')
 


### PR DESCRIPTION
There was a subtle bug in the export script causing the ordering of the
values from the dynamic proxy being different from the column headers.
