### PR TITLE
VUMIGO-262 Use fab for deploys

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -4,14 +4,36 @@ env.hosts = ['ubuntu@vumi.praekelt.com']
 env.path = '/var/praekelt/vumi-go'
 
 
-def deploy():
+def deploy_go():
     with cd(env.path):
+        sudo('git pull', user='vumi')
+        _venv_command('./go-admin.sh collectstatic --noinput')
+
+
+def deploy_vumi():
+    with cd('%s/ve/src/vumi/' % (env.path,)):
         sudo('git pull', user='vumi')
 
 
+def restart_celery():
+    with cd(env.path):
+        supervisorctl('restart celery')
+
+
 def restart_gunicorn():
+    """
+    Intentionally restart the gunicorns 1 by 1 so HAProxy is given
+    time to load balance across gunicorns that have either already restarted
+    or are waiting to be restarted
+    """
     with cd(env.path):
         for i in range(1, 5):
-            sudo('. ve/bin/activate && '
-                    './ve/bin/supervisorctl restart go:go_%s' % (i,),
-                    user='vumi')
+            supervisorctl('restart go:go_%s' % (i,))
+
+
+def supervisorctl(command):
+    return _venv_command('./ve/bin/supervisorctl %s' % (command,))
+
+
+def _venv_command(command, user='vumi'):
+    return sudo('. ve/bin/activate && %s' % (command,), user=user)


### PR DESCRIPTION
Adds some helpers for automating Go deploys & pulling in latest Vumi.
Also adds a helper for issuing random supervisorctl commands from the
command line.
