### PR TITLE
VUMIGO-263 survey conversation message search broken

### DIFF
--- a/go/apps/surveys/templates/surveys/show.html
+++ b/go/apps/surveys/templates/surveys/show.html
@@ -27,7 +27,7 @@
 
     {% include "surveys/includes/download.html" %}
 
-    {% show_conversation_messages conversation direction=request.GET.direction page=request.GET.p %}
+    {% show_conversation_messages conversation direction=request.GET.direction query=request.GET.q page=request.GET.p %}
 
 {% endblock %}
 

--- a/go/apps/surveys/urls.py
+++ b/go/apps/surveys/urls.py
@@ -18,5 +18,6 @@ urlpatterns = patterns('',
     url(r'^(?P<conversation_key>\w+)/aggregates\.csv$',
         views.download_aggregates, name='aggregates'),
     url(r'^(?P<conversation_key>\w+)/message_search_result/$',
-        MessageSearchResultConversationView.as_view()),
+        MessageSearchResultConversationView.as_view(),
+        name='message_search_result'),
 )

--- a/go/apps/surveys/urls.py
+++ b/go/apps/surveys/urls.py
@@ -1,5 +1,8 @@
 from django.conf.urls.defaults import patterns, url
+
 from go.apps.surveys import views
+from go.conversation.base import MessageSearchResultConversationView
+
 
 urlpatterns = patterns('',
     url(r'^new/$', views.new, name='new'),
@@ -14,4 +17,6 @@ urlpatterns = patterns('',
         name='user_data'),
     url(r'^(?P<conversation_key>\w+)/aggregates\.csv$',
         views.download_aggregates, name='aggregates'),
+    url(r'^(?P<conversation_key>\w+)/message_search_result/$',
+        MessageSearchResultConversationView.as_view()),
 )

--- a/go/conversation/templates/conversation/inclusion_tags/show_conversation_messages.html
+++ b/go/conversation/templates/conversation/inclusion_tags/show_conversation_messages.html
@@ -20,6 +20,7 @@
         </div>
         <form class="form-search">
             <input type="text" name="q" size="40" placeholder="Search ..." value="{{query|default:""}}" class="input-medium search-query">
+            <input type="hidden" name="direction" value="{{message_direction}}"/>
             <button type="submit" class="btn">Search</button>
         </form>
     </div>
@@ -42,7 +43,7 @@
         </li>
     </ul>
     <div class="tab-content" id="message-page">
-        {% if message_page %}
+        {% if message_page.paginator.num_pages %}
             {% include "generic/includes/message-list.html" %}
         {% else %}
             {% include "generic/includes/message-load-results.html" %}

--- a/go/conversation/templates/generic/includes/message-list.html
+++ b/go/conversation/templates/generic/includes/message-list.html
@@ -19,9 +19,15 @@
             <td><a href="#" class="btn" title="Reply"><i class="icon-repeat"></i> Reply</a></td>
         </tr>
         {% empty %}
-        <tr>
-            <td colspan="3">No one has replied yet</td>
-        </tr>
+            {% if query %}
+                <tr>
+                    <td colspan="3">No messages match <strong>{{query}}</strong></td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="3">No one has replied yet</td>
+                </tr>
+            {% endif %}
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
The bits for search were never hooked up for surveys. This fixes that.
Also, it turns out that Django resolves a Page instance to False if that
page has no results. Might be reasonable but our code didn't work with
that. Changed to look if the paginator has any pages to show instead.
