### PR TITLE
VUMIGO-256 HTTP streaming API.

### DIFF
--- a/go/apps/http_api/tests/test_views.py
+++ b/go/apps/http_api/tests/test_views.py
@@ -1,0 +1,42 @@
+from django.test.client import Client
+from django.core.urlresolvers import reverse
+
+from go.apps.tests.base import DjangoGoApplicationTestCase
+
+
+class HttpApiTestCase(DjangoGoApplicationTestCase):
+
+    def setUp(self):
+        super(HttpApiTestCase, self).setUp()
+        self.setup_riak_fixtures()
+        self.client = Client()
+        self.client.login(username='username', password='password')
+
+    def test_new_conversation(self):
+        # render the form
+        self.assertEqual(len(self.conv_store.list_conversations()), 1)
+        response = self.client.get(reverse('http_api:new'))
+        self.assertEqual(response.status_code, 200)
+        # post the form
+        response = self.client.post(reverse('http_api:new'), {
+            'subject': 'the subject',
+            'message': 'the message',
+            'delivery_class': 'sms',
+            'delivery_tag_pool': 'longcode',
+        })
+        self.assertEqual(len(self.conv_store.list_conversations()), 2)
+        conversation = self.get_latest_conversation()
+        self.assertEqual(conversation.delivery_class, 'sms')
+        self.assertEqual(conversation.delivery_tag_pool, 'longcode')
+        self.assertEqual(conversation.delivery_tag, None)
+        self.assertEqual(conversation.metadata, None)
+        self.assertRedirects(response, reverse('http_api:people', kwargs={
+            'conversation_key': conversation.key,
+        }))
+
+    def test_show_conversation(self):
+        # render the form
+        [conversation_key] = self.conv_store.list_conversations()
+        kwargs = {'conversation_key': conversation_key}
+        response = self.client.get(reverse('http_api:show', kwargs=kwargs))
+        self.assertEqual(response.status_code, 200)

--- a/go/apps/http_api/urls.py
+++ b/go/apps/http_api/urls.py
@@ -1,0 +1,3 @@
+from go.apps.http_api.views import HttpApiConversationViews
+
+urlpatterns = HttpApiConversationViews().get_urlpatterns()

--- a/go/apps/http_api/views.py
+++ b/go/apps/http_api/views.py
@@ -1,0 +1,8 @@
+from go.conversation.base import ConversationViews
+
+
+class HttpApiConversationViews(ConversationViews):
+    conversation_type = u'http_api'
+    conversation_display_name = u'HTTP API'
+    conversation_initiator = None
+    edit_conversation_forms = None

--- a/go/apps/urls.py
+++ b/go/apps/urls.py
@@ -19,4 +19,6 @@ urlpatterns = patterns('',
         include('go.apps.wikipedia.sms.urls', namespace='wikipedia_sms')),
     url(r'^jsbox/',
         include('go.apps.jsbox.urls', namespace='jsbox')),
+    url(r'^http_api/',
+        include('go.apps.http_api.urls', namespace='http_api')),
 )

--- a/go/settings.py
+++ b/go/settings.py
@@ -130,6 +130,7 @@ TEMPLATE_DIRS = (
     abspath("apps", "sequential_send", "templates"),
     abspath("apps", "wikipedia", "ussd", "templates"),
     abspath("apps", "jsbox", "templates"),
+    abspath("apps", "http_api", "templates"),
 )
 
 INSTALLED_APPS = (
@@ -264,6 +265,10 @@ VUMI_INSTALLED_APPS = {
     'go.apps.jsbox': {
         'namespace': 'jsbox',
         'display_name': 'Javascript App',
+    },
+    'go.apps.http_api': {
+        'namespace': 'http_api',
+        'display_name': 'HTTP API',
     },
 }
 


### PR DESCRIPTION
This adds three HTTP endpoints, `messages.json`, `events.json` and `metrics.json`.
1. The messages and events endpoints allow for streaming of `vumi.message.Message` type of objects.
2. The messages and metrics endpoints allow for inserting of new objects via HTTP PUT.
3. The authentication is Basic Auth (so this needs to be run over HTTPS), the account key is used as the username and a conversation specific token is used as the password. There is a list of valid tokens stored in the conversation's `metadata` json field.
4. There is a concurrency limit that is at the moment specified per worker and set to 10. I think there's a small chance that if a worker dies without the appropriate shutdown stuff happening then the concurrent connection value stored in Redis may go out of sync.

There are a number of issues that need to be addressed:
1. It uses queues to publish messages specific to a conversation, these
   queues need to delete themselves if there are no consumers. (praekelt/vumi#451 addresses this)
2. The messages should not be persisted.
