### PR TITLE
Claim tags at account level rather than conversation level

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -55,9 +55,9 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
     def test_new_conversation_with_user_selected_tags(self):
         tp_meta = self.api.tpm.get_metadata('longcode')
         tp_meta['user_selects_tag'] = True
-        self.api.tpm.set_metadata('longcode', tp_meta)
-        self.run_new_conversation('longcode:default10001', 'longcode',
-                                  'default10001')
+        self.api.tpm.set_metadata(u'longcode', tp_meta)
+        self.run_new_conversation(u'longcode:default10001', u'longcode',
+                                  u'default10001')
 
     def test_end(self):
         """

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -35,15 +35,7 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         # Create a test user account
         self.user_account = yield self.mk_user(self.vumi_api, u'testuser')
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
-
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
     @inlineCallbacks
     def setup_conversation(self, contact_count=2,

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -36,10 +36,13 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         self.user_account = yield self.mk_user(self.vumi_api, u'testuser')
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
-        yield self.user_api.api.declare_tags([("pool", "tag1"),
-                                              ("pool", "tag2")])
-        yield self.user_api.api.set_pool_metadata("pool", {
-            "transport_type": "sphex",
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
+            "transport_type": self.transport_type,
+            "msg_options": {
+                "transport_name": self.transport_name,
+                },
             })
 
     @inlineCallbacks

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -42,14 +42,7 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
         self.user_account = yield self.mk_user(self.vumi_api, u'testuser')
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
     @inlineCallbacks
     def setup_conversation(self, contact_count=2,

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -42,11 +42,14 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
         self.user_account = yield self.mk_user(self.vumi_api, u'testuser')
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
-        yield self.user_api.api.declare_tags([("pool", "tag1"),
-                                              ("pool", "tag2")])
-        yield self.user_api.api.set_pool_metadata("pool", {
-            "transport_type": "sphex",
-        })
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
+            "transport_type": self.transport_type,
+            "msg_options": {
+                "transport_name": self.transport_name,
+                },
+            })
 
     @inlineCallbacks
     def setup_conversation(self, contact_count=2,

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -69,12 +69,12 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         """A survey should not ask for recipients if the transport
         used only supports client initiated sessions (i.e. USSD)"""
 
-        self.api.set_pool_metadata("pool1", {
+        self.api.tpm.set_metadata("pool1", {
             "delivery_class": "sms",
             "server_initiated": True,
             })
 
-        self.api.set_pool_metadata("pool2", {
+        self.api.tpm.set_metadata("pool2", {
             "delivery_class": "ussd",
             "client_initiated": True,
             })

--- a/go/apps/multi_surveys/tests/test_vumi_app.py
+++ b/go/apps/multi_surveys/tests/test_vumi_app.py
@@ -55,13 +55,14 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        self.user_api.api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
-        self.user_api.api.set_pool_metadata("pool", {
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
             "transport_type": self.transport_type,
             "msg_options": {
                 "transport_name": self.transport_name,
-            },
-        })
+                },
+            })
 
         # Setup the poll manager
         self.pm = self.app.pm

--- a/go/apps/multi_surveys/tests/test_vumi_app.py
+++ b/go/apps/multi_surveys/tests/test_vumi_app.py
@@ -55,14 +55,7 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
         # Setup the poll manager
         self.pm = self.app.pm

--- a/go/apps/opt_out/tests/test_vumi_app.py
+++ b/go/apps/opt_out/tests/test_vumi_app.py
@@ -32,14 +32,7 @@ class TestOptOutApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
         self.conversation = yield self.create_conversation(
             delivery_tag_pool=u'pool',

--- a/go/apps/opt_out/tests/test_vumi_app.py
+++ b/go/apps/opt_out/tests/test_vumi_app.py
@@ -32,14 +32,14 @@ class TestOptOutApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        yield self.user_api.api.declare_tags([("pool", "tag1"),
-                                              ("pool", "tag2")])
-        yield self.user_api.api.set_pool_metadata("pool", {
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
             "transport_type": self.transport_type,
             "msg_options": {
                 "transport_name": self.transport_name,
-            },
-        })
+                },
+            })
 
         self.conversation = yield self.create_conversation(
             delivery_tag_pool=u'pool',

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -37,13 +37,14 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        self.user_api.api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
-        self.user_api.api.set_pool_metadata("pool", {
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
             "transport_type": self.transport_type,
             "msg_options": {
                 "transport_name": self.transport_name,
-            },
-        })
+                },
+            })
 
         # Give a user access to a tagpool
         self.user_api.api.account_store.tag_permissions(uuid.uuid4().hex,

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -37,14 +37,7 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
         # Give a user access to a tagpool
         self.user_api.api.account_store.tag_permissions(uuid.uuid4().hex,

--- a/go/apps/subscription/tests/test_vumi_app.py
+++ b/go/apps/subscription/tests/test_vumi_app.py
@@ -30,10 +30,14 @@ class TestSubscriptionApplication(AppWorkerTestCase):
         # Enable search for the contact store
         yield self.user_api.contact_store.contacts.enable_search()
 
-        yield self.user_api.api.declare_tags(
-            [("pool", "tag1"), ("pool", "tag2")])
-        yield self.user_api.api.set_pool_metadata(
-            "pool", {"transport_type": "sms"})
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
+            "transport_type": self.transport_type,
+            "msg_options": {
+                "transport_name": self.transport_name,
+                },
+            })
 
         self.contact = yield self.user_api.contact_store.new_contact(
             name=u'First', surname=u'Contact', msisdn=u'+27831234567')

--- a/go/apps/subscription/tests/test_vumi_app.py
+++ b/go/apps/subscription/tests/test_vumi_app.py
@@ -30,14 +30,7 @@ class TestSubscriptionApplication(AppWorkerTestCase):
         # Enable search for the contact store
         yield self.user_api.contact_store.contacts.enable_search()
 
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
         self.contact = yield self.user_api.contact_store.new_contact(
             name=u'First', surname=u'Contact', msisdn=u'+27831234567')

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -82,12 +82,12 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         """A survey should not ask for recipients if the transport
         used only supports client initiated sessions (i.e. USSD)"""
 
-        self.api.set_pool_metadata("pool1", {
+        self.api.tpm.set_metadata("pool1", {
             "delivery_class": "sms",
             "server_initiated": True,
             })
 
-        self.api.set_pool_metadata("pool2", {
+        self.api.tpm.set_metadata("pool2", {
             "delivery_class": "ussd",
             "client_initiated": True,
             })

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -60,14 +60,7 @@ class TestSurveyApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        yield self.declare_tags(self.vumi_api,
-                                [("pool", "tag1"), ("pool", "tag2")])
-        yield self.set_pool_metadata(self.vumi_api, "pool", {
-            "transport_type": self.transport_type,
-            "msg_options": {
-                "transport_name": self.transport_name,
-                },
-            })
+        yield self.setup_tagpools()
 
         # Setup the poll manager
         self.pm = self.app.pm

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -60,13 +60,14 @@ class TestSurveyApplication(AppWorkerTestCase):
         self.user_api = self.vumi_api.get_user_api(self.user_account.key)
 
         # Add tags
-        self.vumi_api.declare_tags([("pool", "tag1"), ("pool", "tag2")])
-        self.vumi_api.set_pool_metadata("pool", {
+        yield self.declare_tags(self.vumi_api,
+                                [("pool", "tag1"), ("pool", "tag2")])
+        yield self.set_pool_metadata(self.vumi_api, "pool", {
             "transport_type": self.transport_type,
             "msg_options": {
                 "transport_name": self.transport_name,
-            },
-        })
+                },
+            })
 
         # Setup the poll manager
         self.pm = self.app.pm

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import uuid
 
 from go.base.tests.utils import VumiGoDjangoTestCase, declare_longcode_tags
 from go.vumitools.tests.utils import CeleryTestMixIn
@@ -187,6 +188,9 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
 
     def setup_user_api(self, django_user):
         self.user_api = vumi_api_for_user(django_user)
+        # XXX: We assume the tagpool already exists here. We need to rewrite
+        #      a lot of this test infrastructure.
+        self.add_tagpool_permission(u"longcode")
         self.contact_store = self.user_api.contact_store
         self.contact_store.contacts.enable_search()
         self.contact_store.groups.enable_search()
@@ -194,6 +198,14 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
 
     def declare_longcode_tags(self):
         declare_longcode_tags(self.api)
+
+    def add_tagpool_permission(self, tagpool, max_keys=None):
+        permission = self.user_api.api.account_store.tag_permissions(
+           uuid.uuid4().hex, tagpool=tagpool, max_keys=max_keys)
+        permission.save()
+        account = self.user_api.get_user_account()
+        account.tagpools.add(permission)
+        account.save()
 
     def acquire_all_longcode_tags(self):
         for _i in range(4):

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -197,7 +197,7 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
 
     def acquire_all_longcode_tags(self):
         for _i in range(4):
-            self.api.acquire_tag("longcode")
+            self.user_api.acquire_tag(u"longcode")
 
     def get_api_commands_sent(self):
         consumer = self.get_cmd_consumer()

--- a/go/base/tests/test_go_account_stats.py
+++ b/go/base/tests/test_go_account_stats.py
@@ -15,6 +15,7 @@ class GoAccountStatsCommandTestCase(DjangoGoApplicationTestCase):
         self.user = self.mk_django_user()
 
         self.user_api = vumi_api_for_user(self.user)
+        self.add_tagpool_permission(u"longcode")
         self.message_store = self.api.mdb
 
         def mkconv(*args, **kwargs):

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -108,9 +108,9 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
 
 def declare_longcode_tags(api):
     """Declare a set of long codes to the tag pool."""
-    api.declare_tags([("longcode", "default%s" % i) for i
+    api.tpm.declare_tags([("longcode", "default%s" % i) for i
                       in range(10001, 10001 + 4)])
-    api.set_pool_metadata("longcode", {
+    api.tpm.set_metadata("longcode", {
         "display_name": "Long code",
         "delivery_class": "sms",
         "transport_type": "sms",

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -108,9 +108,9 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
 
 def declare_longcode_tags(api):
     """Declare a set of long codes to the tag pool."""
-    api.tpm.declare_tags([("longcode", "default%s" % i) for i
+    api.tpm.declare_tags([(u"longcode", u"default%s" % i) for i
                       in range(10001, 10001 + 4)])
-    api.tpm.set_metadata("longcode", {
+    api.tpm.set_metadata(u"longcode", {
         "display_name": "Long code",
         "delivery_class": "sms",
         "transport_type": "sms",

--- a/go/vumitools/account/migrations.py
+++ b/go/vumitools/account/migrations.py
@@ -1,0 +1,18 @@
+from vumi.persist.model import ModelMigrator
+
+
+class UserAccountMigrator(ModelMigrator):
+
+    def migrate_from_unversioned(self, mdata):
+        # Copy stuff that hasn't changed between versions
+        mdata.copy_values(
+            'username', 'created_at', 'msisdn', 'confirm_start_conversation')
+        mdata.copy_indexes('tagpools_bin', 'applications_bin')
+
+        # Add stuff that's new in this version
+        mdata.set_value('$VERSION', 1)
+        mdata.set_value('tags', [])
+        old_ehconfig = mdata.old_data.get('event_handler_config')
+        mdata.set_value('event_handler_config', old_ehconfig or [])
+
+        return mdata

--- a/go/vumitools/account/migrations.py
+++ b/go/vumitools/account/migrations.py
@@ -11,7 +11,7 @@ class UserAccountMigrator(ModelMigrator):
 
         # Add stuff that's new in this version
         mdata.set_value('$VERSION', 1)
-        mdata.set_value('tags', [])
+        mdata.set_value('tags', None)  # We populate this later
         old_ehconfig = mdata.old_data.get('event_handler_config')
         mdata.set_value('event_handler_config', old_ehconfig or [])
 

--- a/go/vumitools/account/models.py
+++ b/go/vumitools/account/models.py
@@ -40,7 +40,11 @@ class UserAccount(Model):
     event_handler_config = Json(default=list)
     msisdn = Unicode(max_length=255, null=True)
     confirm_start_conversation = Boolean(default=False)
-    tags = Json(default=list)
+    # `tags` is allowed to be null so that we can detect freshly-migrated
+    # accounts and populate the tags from active conversations. A new account
+    # has no legacy tags or conversations, so we start with an empty list and
+    # skip the tag collection.
+    tags = Json(default=[], null=True)
 
 
 class AccountStore(object):

--- a/go/vumitools/account/models.py
+++ b/go/vumitools/account/models.py
@@ -46,6 +46,14 @@ class UserAccount(Model):
     # skip the tag collection.
     tags = Json(default=[], null=True)
 
+    @Manager.calls_manager
+    def has_tagpool_permission(self, tagpool):
+        for tp_bunch in self.tagpools.load_all_bunches():
+            for tp in (yield tp_bunch):
+                if tp.tagpool == tagpool:
+                    returnValue(True)
+        returnValue(False)
+
 
 class AccountStore(object):
     def __init__(self, manager):

--- a/go/vumitools/account/models.py
+++ b/go/vumitools/account/models.py
@@ -6,8 +6,10 @@ from datetime import datetime
 from twisted.internet.defer import returnValue
 
 from vumi.persist.model import Model, Manager
-from vumi.persist.fields import (Integer, Unicode, Timestamp, ManyToMany, Json,
-                                    Boolean)
+from vumi.persist.fields import (
+   Integer, Unicode, Timestamp, ManyToMany, Json, Boolean)
+
+from go.vumitools.account.migrations import UserAccountMigrator
 
 
 class UserTagPermission(Model):
@@ -24,6 +26,10 @@ class UserAppPermission(Model):
 
 class UserAccount(Model):
     """A user account."""
+
+    VERSION = 1
+    MIGRATOR = UserAccountMigrator
+
     # key is uuid
     username = Unicode(max_length=255)
     # TODO: tagpools can be made OneToMany once vumi.persist.fields
@@ -31,9 +37,10 @@ class UserAccount(Model):
     tagpools = ManyToMany(UserTagPermission)
     applications = ManyToMany(UserAppPermission)
     created_at = Timestamp(default=datetime.utcnow)
-    event_handler_config = Json(null=True)
+    event_handler_config = Json(default=list)
     msisdn = Unicode(max_length=255, null=True)
     confirm_start_conversation = Boolean(default=False)
+    tags = Json(default=list)
 
 
 class AccountStore(object):

--- a/go/vumitools/account/old_models.py
+++ b/go/vumitools/account/old_models.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from vumi.persist.model import Model
+from vumi.persist.fields import (
+   Integer, Unicode, Timestamp, ManyToMany, Json,
+                                    Boolean)
+
+
+class UserTagPermissionVNone(Model):
+    """A description of a tag a user account is allowed access to."""
+    # key is uuid
+    tagpool = Unicode(max_length=255)
+    max_keys = Integer(null=True)
+
+
+class UserAppPermissionVNone(Model):
+    """An application that provides a certain conversation_type"""
+    application = Unicode(max_length=255)
+
+
+class UserAccountVNone(Model):
+    """A user account."""
+    # key is uuid
+    username = Unicode(max_length=255)
+    # TODO: tagpools can be made OneToMany once vumi.persist.fields
+    #       gains a OneToMany field
+    tagpools = ManyToMany(UserTagPermissionVNone)
+    applications = ManyToMany(UserAppPermissionVNone)
+    created_at = Timestamp(default=datetime.utcnow)
+    event_handler_config = Json(null=True)
+    msisdn = Unicode(max_length=255, null=True)
+    confirm_start_conversation = Boolean(default=False)

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -265,7 +265,10 @@ class VumiUserApi(object):
         """
         user_account = yield self.get_user_account()
         yield self._populate_tags(user_account)
-        # TODO: Check that account has access to pool.
+        if not (yield user_account.has_tagpool_permission(pool)):
+            log.warning("Account '%s' trying to access forbidden pool '%s'" % (
+                user_account.key, pool))
+            returnValue(None)
         tag = yield self.api.tpm.acquire_tag(pool)
         if tag is not None:
             user_account.tags.append(tag)
@@ -286,7 +289,10 @@ class VumiUserApi(object):
         """
         user_account = yield self.get_user_account()
         yield self._populate_tags(user_account)
-        # TODO: Check that account has access to pool.
+        if not (yield user_account.has_tagpool_permission(tag[0])):
+            log.warning("Account '%s' trying to access forbidden pool '%s'" % (
+                user_account.key, tag[0]))
+            returnValue(None)
         tag = yield self.api.tpm.acquire_specific_tag(tag)
         if tag is not None:
             user_account.tags.append(tag)

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -314,7 +314,6 @@ class VumiUserApi(object):
         """
         user_account = yield self.get_user_account()
         yield self._populate_tags(user_account)
-        # TODO: Check that account holds tag
         try:
             user_account.tags.remove(list(tag))
         except ValueError, e:

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -197,6 +197,7 @@ class VumiUserApi(object):
     def list_conversation_endpoints(self):
         """Returns a set of endpoints owned by conversations in an account.
         """
+        # XXX: Do we need both this method and the following method?
         tags = set()
         convs = yield self.active_conversations()
         for conv in convs:
@@ -205,10 +206,30 @@ class VumiUserApi(object):
         returnValue(tags)
 
     @Manager.calls_manager
+    def list_conversation_batch_tags(self):
+        """Returns a set of tags owned by conversation batches in an account.
+        """
+        # XXX: Do we need both this method and the previous method?
+        tags = set()
+        convs = yield self.active_conversations()
+        for conv in convs:
+            conv_tags = yield self.wrap_conversation(conv).get_tags()
+            tags.update(conv_tags)
+        returnValue(tags)
+
+    @Manager.calls_manager
+    def _populate_tags(self, user_account):
+        if user_account.tags is None:
+            # We need to populate this from conversations
+            conv_tags = yield self.list_conversation_batch_tags()
+            user_account.tags = [list(tag) for tag in conv_tags]
+
+    @Manager.calls_manager
     def list_endpoints(self):
         """Returns a set of endpoints owned by an account.
         """
         user_account = yield self.get_user_account()
+        yield self._populate_tags(user_account)
         returnValue(set(tuple(tag) for tag in user_account.tags))
 
     @Manager.calls_manager
@@ -243,6 +264,7 @@ class VumiUserApi(object):
             The tag acquired or None if no tag was available.
         """
         user_account = yield self.get_user_account()
+        yield self._populate_tags(user_account)
         # TODO: Check that account has access to pool.
         tag = yield self.api.tpm.acquire_tag(pool)
         if tag is not None:
@@ -263,6 +285,7 @@ class VumiUserApi(object):
             The tag acquired or None if the tag was not available.
         """
         user_account = yield self.get_user_account()
+        yield self._populate_tags(user_account)
         # TODO: Check that account has access to pool.
         tag = yield self.api.tpm.acquire_specific_tag(tag)
         if tag is not None:
@@ -284,6 +307,7 @@ class VumiUserApi(object):
             None.
         """
         user_account = yield self.get_user_account()
+        yield self._populate_tags(user_account)
         # TODO: Check that account holds tag
         try:
             user_account.tags.remove(list(tag))

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -145,8 +145,7 @@ class VumiUserApi(object):
 
     @Manager.calls_manager
     def tagpools(self):
-        account_store = self.api.account_store
-        user_account = yield account_store.get_user(self.user_account_key)
+        user_account = yield self.api.get_user_account(self.user_account_key)
         active_conversations = yield self.active_conversations()
 
         tp_usage = defaultdict(int)
@@ -168,8 +167,7 @@ class VumiUserApi(object):
 
     @Manager.calls_manager
     def applications(self):
-        account_store = self.api.account_store
-        user_account = yield account_store.get_user(self.user_account_key)
+        user_account = yield self.api.get_user_account(self.user_account_key)
         # NOTE: This assumes that we don't have very large numbers of
         #       applications.
         app_permissions = []
@@ -271,8 +269,11 @@ class VumiApi(object):
         :param str user_account_key:
             The user account key to check.
         """
-        user_data = yield self.account_store.get_user(user_account_key)
+        user_data = yield self.get_user_account(user_account_key)
         returnValue(user_data is not None)
+
+    def get_user_account(self, user_account_key):
+        return self.account_store.get_user(user_account_key)
 
     def get_user_api(self, user_account_key):
         return VumiUserApi(self, user_account_key)

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -406,45 +406,6 @@ class VumiApi(object):
         """
         return self.tpm.release_tag(tag)
 
-    def declare_tags(self, tags):
-        """Populate a pool with tags.
-
-        Tags already in the pool are not duplicated.
-
-        :type pool: str
-        :type tags: list of (pool, local_tag) tuples
-        :param tags:
-            list of tags to add to the pool.
-        :rtype:
-            None
-        """
-        return self.tpm.declare_tags(tags)
-
-    def set_pool_metadata(self, pool, metadata):
-        """Set the metadata for a tag pool.
-
-        :param str pool:
-            Name of the pool set metadata form.
-        :param dict metadata:
-            Metadata to set.
-        :rtype:
-            None
-        """
-        return self.tpm.set_metadata(pool, metadata)
-
-    def purge_pool(self, pool):
-        """Completely remove a pool with all its contents.
-
-        If tags in the pool are still in use it will throw an error.
-
-        :type pool: str
-        :param pool:
-            name of the pool to purge.
-        :rtype:
-            None.
-        """
-        return self.tpm.purge_pool(pool)
-
 
 class SyncMessageSender(object):
     def __init__(self):

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -194,11 +194,8 @@ class VumiUserApi(object):
         return self.conversation_store.new_conversation(*args, **kw)
 
     @Manager.calls_manager
-    def list_endpoints(self):
-        """Returns a set of end points owned by an account.
-
-        Currently this returns the list of tags in use by active
-        conversations.
+    def list_conversation_endpoints(self):
+        """Returns a set of endpoints owned by conversations in an account.
         """
         tags = set()
         convs = yield self.active_conversations()
@@ -206,6 +203,13 @@ class VumiUserApi(object):
             tag = (conv.delivery_tag_pool, conv.delivery_tag)
             tags.add(tag)
         returnValue(tags)
+
+    @Manager.calls_manager
+    def list_endpoints(self):
+        """Returns a set of endpoints owned by an account.
+        """
+        user_account = yield self.get_user_account()
+        returnValue(set(tuple(tag) for tag in user_account.tags))
 
     @Manager.calls_manager
     def msg_options(self, tag, tagpool_metadata=None):

--- a/go/vumitools/api_worker.py
+++ b/go/vumitools/api_worker.py
@@ -155,8 +155,7 @@ class EventDispatcher(ApplicationWorker):
         Hence the juggling of eggs below.
         """
         if account_key not in self.account_config:
-            user_account = yield self.vumi_api.account_store.get_user(
-                account_key)
+            user_account = yield self.vumi_api.get_user_account(account_key)
             event_handler_config = {}
             for k, v in (user_account.event_handler_config or
                          self.account_handler_configs.get(account_key) or []):

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -30,7 +30,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.mdb = self.api.mdb
         self.user = yield self.mk_user(self.api, u'username')
         self.user_api = self.api.get_user_api(self.user.key)
-        yield self.declare_tags()
+        yield self._declare_tags()
 
         raw_conv = yield self.user_api.conversation_store.new_conversation(
             u'bulk_message', u'subject', u'message',
@@ -38,10 +38,10 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.conv = ConversationWrapper(raw_conv, self.user_api)
 
     @inlineCallbacks
-    def declare_tags(self, name='longcode', count=4, metadata=None):
+    def _declare_tags(self, name='longcode', count=4, metadata=None):
         """Declare a set of long codes to the tag pool."""
-        yield self.api.declare_tags([(name, "%s%s" % (name, i)) for i
-                          in range(10001, 10001 + count)])
+        yield self.declare_tags(self.api, [
+            (name, "%s%s" % (name, i)) for i in range(10001, 10001 + count)])
         defaults = {
             "display_name": name,
             "delivery_class": "sms",
@@ -49,7 +49,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
             "server_initiated": True,
             }
         defaults.update(metadata or {})
-        yield self.api.set_pool_metadata(name, defaults)
+        yield self.set_pool_metadata(self.api, name, defaults)
 
     @inlineCallbacks
     def get_batch_id(self, conv, tag):
@@ -304,7 +304,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_acquire_tag_if_none_available(self):
-        yield self.declare_tags("shortcode", count=0)
+        yield self._declare_tags("shortcode", count=0)
         self.conv.c.delivery_tag_pool = u"shortcode"
         yield self.conv.save()
         yield self.assertFailure(self.conv.acquire_tag(),

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -38,7 +38,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.conv = ConversationWrapper(raw_conv, self.user_api)
 
     @inlineCallbacks
-    def _declare_tags(self, name='longcode', count=4, metadata=None):
+    def _declare_tags(self, name=u'longcode', count=4, metadata=None):
         """Declare a set of long codes to the tag pool."""
         yield self.declare_tags(self.api, [
             (name, "%s%s" % (name, i)) for i in range(10001, 10001 + count)])
@@ -304,7 +304,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_acquire_tag_if_none_available(self):
-        yield self._declare_tags("shortcode", count=0)
+        yield self._declare_tags(u"shortcode", count=0)
         self.conv.c.delivery_tag_pool = u"shortcode"
         yield self.conv.save()
         yield self.assertFailure(self.conv.acquire_tag(),

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -30,7 +30,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.mdb = self.api.mdb
         self.user = yield self.mk_user(self.api, u'username')
         self.user_api = self.api.get_user_api(self.user.key)
-        yield self._declare_tags()
+        yield self.setup_tags()
 
         raw_conv = yield self.user_api.conversation_store.new_conversation(
             u'bulk_message', u'subject', u'message',
@@ -38,7 +38,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.conv = ConversationWrapper(raw_conv, self.user_api)
 
     @inlineCallbacks
-    def _declare_tags(self, name=u'longcode', count=4, metadata=None):
+    def setup_tags(self, name=u'longcode', count=4, metadata=None):
         """Declare a set of long codes to the tag pool."""
         yield self.api.tpm.declare_tags(
             [(name, "%s%s" % (name, i)) for i in range(10001, 10001 + count)])
@@ -305,7 +305,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_acquire_tag_if_none_available(self):
-        yield self._declare_tags(u"shortcode", count=0)
+        yield self.setup_tags(u"shortcode", count=0)
         self.conv.c.delivery_tag_pool = u"shortcode"
         yield self.conv.save()
         yield self.assertFailure(self.conv.acquire_tag(),

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -40,8 +40,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def _declare_tags(self, name=u'longcode', count=4, metadata=None):
         """Declare a set of long codes to the tag pool."""
-        yield self.declare_tags(self.api, [
-            (name, "%s%s" % (name, i)) for i in range(10001, 10001 + count)])
+        yield self.api.tpm.declare_tags(
+            [(name, "%s%s" % (name, i)) for i in range(10001, 10001 + count)])
         defaults = {
             "display_name": name,
             "delivery_class": "sms",
@@ -49,7 +49,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
             "server_initiated": True,
             }
         defaults.update(metadata or {})
-        yield self.set_pool_metadata(self.api, name, defaults)
+        yield self.api.tpm.set_metadata(name, defaults)
 
     @inlineCallbacks
     def get_batch_id(self, conv, tag):

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -50,6 +50,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
             }
         defaults.update(metadata or {})
         yield self.api.tpm.set_metadata(name, defaults)
+        yield self.add_tagpool_permission(name)
 
     @inlineCallbacks
     def get_batch_id(self, conv, tag):

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -22,7 +22,6 @@ class ConversationWrapper(object):
         self.user_api = user_api
         self.api = user_api.api
         self.mdb = self.api.mdb
-        self.tpm = self.api.tpm
         self.manager = self.c.manager
         self.base_manager = self.api.manager
         self._tagpool_metadata = None
@@ -45,7 +44,7 @@ class ConversationWrapper(object):
         for batch in (yield self.get_batches()):
             yield self.mdb.batch_done(batch.key)  # TODO: why key?
             for tag in batch.tags:
-                yield self.tpm.release_tag(tag)
+                yield self.user_api.release_tag(tag)
 
     def __getattr__(self, name):
         # Proxy anything we don't have back to the wrapped conversation.
@@ -613,12 +612,13 @@ class ConversationWrapper(object):
     def acquire_tag(self):
         # TODO: Remove this once we have proper routing stuff.
         if self.c.delivery_tag is None:
-            tag = yield self.api.acquire_tag(self.c.delivery_tag_pool)
+            tag = yield self.user_api.acquire_tag(self.c.delivery_tag_pool)
             if tag is None:
                 raise ConversationSendError("No spare messaging tags.")
+            self.c.delivery_tag = tag[1]
         else:
             tag = (self.c.delivery_tag_pool, self.c.delivery_tag)
-            tag = yield self.api.acquire_specific_tag(tag)
+            tag = yield self.user_api.acquire_specific_tag(tag)
             if tag is None:
                 raise ConversationSendError("Requested tag not available.")
         returnValue(tag)

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -210,6 +210,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         tag1 = (u'pool1', u'1234')
         tag2 = (u'pool1', u'5678')
         yield self.api.tpm.declare_tags([tag1, tag2])
+        yield self.add_tagpool_permission(u'pool1')
         yield self.user_api.acquire_specific_tag(tag1)
         endpoints = yield self.user_api.list_endpoints()
         self.assertEqual(endpoints, set([tag1]))
@@ -260,18 +261,20 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     def test_declare_acquire_and_release_tags(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
         yield self.api.tpm.declare_tags([tag1, tag2])
+        yield self.add_tagpool_permission(u"poolA")
+        yield self.add_tagpool_permission(u"poolB")
 
         yield self.assert_account_tags([])
-        self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag1)
-        self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
-        self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)
-        self.assertEqual((yield self.user_api.acquire_tag("poolB")), None)
+        self.assertEqual((yield self.user_api.acquire_tag(u"poolA")), tag1)
+        self.assertEqual((yield self.user_api.acquire_tag(u"poolA")), tag2)
+        self.assertEqual((yield self.user_api.acquire_tag(u"poolA")), None)
+        self.assertEqual((yield self.user_api.acquire_tag(u"poolB")), None)
         yield self.assert_account_tags([list(tag1), list(tag2)])
 
         yield self.user_api.release_tag(tag2)
         yield self.assert_account_tags([list(tag1)])
-        self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
-        self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)
+        self.assertEqual((yield self.user_api.acquire_tag(u"poolA")), tag2)
+        self.assertEqual((yield self.user_api.acquire_tag(u"poolA")), None)
         yield self.assert_account_tags([list(tag1), list(tag2)])
 
 

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -98,14 +98,14 @@ class TestTxVumiApi(AppWorkerTestCase, CeleryTestMixIn):
     @inlineCallbacks
     def test_declare_tags_from_different_pools(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolB", "tag2")
-        yield self.declare_tags(self.api, [tag1, tag2])
+        yield self.api.tpm.declare_tags([tag1, tag2])
         self.assertEqual((yield self.api.tpm.acquire_tag("poolA")), tag1)
         self.assertEqual((yield self.api.tpm.acquire_tag("poolB")), tag2)
 
     @inlineCallbacks
     def test_start_batch_and_batch_done(self):
         tag = ("pool", "tag")
-        yield self.declare_tags(self.api, [tag])
+        yield self.api.tpm.declare_tags([tag])
 
         @inlineCallbacks
         def tag_batch(t):
@@ -197,7 +197,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         tag1 = (u'pool1', u'1234')
         tag2 = (u'pool1', u'5678')
         tag3 = (u'pool1', u'9012')
-        yield self.declare_tags(self.api, [tag1, tag2, tag3])
+        yield self.api.tpm.declare_tags([tag1, tag2, tag3])
         yield self.user_api.acquire_specific_tag(tag2)
         yield self.user_api.new_conversation(
             u'bulk_message', u'subject', u'message', delivery_class=u'sms',
@@ -209,7 +209,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     def test_list_endpoints(self):
         tag1 = (u'pool1', u'1234')
         tag2 = (u'pool1', u'5678')
-        yield self.declare_tags(self.api, [tag1, tag2])
+        yield self.api.tpm.declare_tags([tag1, tag2])
         yield self.user_api.acquire_specific_tag(tag1)
         endpoints = yield self.user_api.list_endpoints()
         self.assertEqual(endpoints, set([tag1]))
@@ -217,8 +217,8 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     @inlineCallbacks
     def test_msg_options(self):
         tag = ('pool1', '1234')
-        yield self.declare_tags(self.api, [tag])
-        yield self.set_pool_metadata(self.api, tag[0], {
+        yield self.api.tpm.declare_tags([tag])
+        yield self.api.tpm.set_metadata(tag[0], {
             'transport_type': 'dummy_transport',
             'msg_options': {'opt1': 'bar'},
         })
@@ -254,7 +254,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     @inlineCallbacks
     def test_declare_acquire_and_release_tags(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
-        yield self.declare_tags(self.api, [tag1, tag2])
+        yield self.api.tpm.declare_tags([tag1, tag2])
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag1)
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -98,7 +98,7 @@ class TestTxVumiApi(AppWorkerTestCase, CeleryTestMixIn):
     @inlineCallbacks
     def test_declare_acquire_and_release_tags(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
-        yield self.api.declare_tags([tag1, tag2])
+        yield self.declare_tags(self.api, [tag1, tag2])
         self.assertEqual((yield self.api.acquire_tag("poolA")), tag1)
         self.assertEqual((yield self.api.acquire_tag("poolA")), tag2)
         self.assertEqual((yield self.api.acquire_tag("poolA")), None)
@@ -111,14 +111,14 @@ class TestTxVumiApi(AppWorkerTestCase, CeleryTestMixIn):
     @inlineCallbacks
     def test_declare_tags_from_different_pools(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolB", "tag2")
-        yield self.api.declare_tags([tag1, tag2])
+        yield self.declare_tags(self.api, [tag1, tag2])
         self.assertEqual((yield self.api.acquire_tag("poolA")), tag1)
         self.assertEqual((yield self.api.acquire_tag("poolB")), tag2)
 
     @inlineCallbacks
     def test_start_batch_and_batch_done(self):
         tag = ("pool", "tag")
-        yield self.api.declare_tags([tag])
+        yield self.declare_tags(self.api, [tag])
 
         @inlineCallbacks
         def tag_batch(t):
@@ -209,7 +209,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     def test_list_endpoints(self):
         tag1 = (u'pool1', u'1234')
         tag2 = (u'pool1', u'5678')
-        yield self.api.declare_tags([tag1, tag2])
+        yield self.declare_tags(self.api, [tag1, tag2])
         yield self.user_api.new_conversation(
             u'bulk_message', u'subject', u'message', delivery_class=u'sms',
             delivery_tag_pool=tag1[0], delivery_tag=tag1[1])
@@ -219,8 +219,8 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     @inlineCallbacks
     def test_msg_options(self):
         tag = ('pool1', '1234')
-        yield self.api.declare_tags([tag])
-        yield self.api.tpm.set_metadata(tag[0], {
+        yield self.declare_tags(self.api, [tag])
+        yield self.set_pool_metadata(self.api, tag[0], {
             'transport_type': 'dummy_transport',
             'msg_options': {'opt1': 'bar'},
         })

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -96,24 +96,11 @@ class TestTxVumiApi(AppWorkerTestCase, CeleryTestMixIn):
         self.assertEqual((yield self.api.batch_tags(batch_id)), [tag1, tag2])
 
     @inlineCallbacks
-    def test_declare_acquire_and_release_tags(self):
-        tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
-        yield self.declare_tags(self.api, [tag1, tag2])
-        self.assertEqual((yield self.api.acquire_tag("poolA")), tag1)
-        self.assertEqual((yield self.api.acquire_tag("poolA")), tag2)
-        self.assertEqual((yield self.api.acquire_tag("poolA")), None)
-        self.assertEqual((yield self.api.acquire_tag("poolB")), None)
-
-        yield self.api.release_tag(tag2)
-        self.assertEqual((yield self.api.acquire_tag("poolA")), tag2)
-        self.assertEqual((yield self.api.acquire_tag("poolA")), None)
-
-    @inlineCallbacks
     def test_declare_tags_from_different_pools(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolB", "tag2")
         yield self.declare_tags(self.api, [tag1, tag2])
-        self.assertEqual((yield self.api.acquire_tag("poolA")), tag1)
-        self.assertEqual((yield self.api.acquire_tag("poolB")), tag2)
+        self.assertEqual((yield self.api.tpm.acquire_tag("poolA")), tag1)
+        self.assertEqual((yield self.api.tpm.acquire_tag("poolB")), tag2)
 
     @inlineCallbacks
     def test_start_batch_and_batch_done(self):
@@ -252,6 +239,19 @@ class TestTxVumiUserApi(AppWorkerTestCase):
             'transport_type': 'dummy_transport',
             'opt1': 'bar',
         })
+
+    @inlineCallbacks
+    def test_declare_acquire_and_release_tags(self):
+        tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
+        yield self.declare_tags(self.api, [tag1, tag2])
+        self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag1)
+        self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
+        self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)
+        self.assertEqual((yield self.user_api.acquire_tag("poolB")), None)
+
+        yield self.user_api.release_tag(tag2)
+        self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
+        self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)
 
 
 class TestVumiUserApi(TestTxVumiUserApi):

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -193,13 +193,24 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         self.assertFalse((yield VumiUserApi(self.api, 'foo').exists()))
 
     @inlineCallbacks
+    def test_list_conversation_endpoints(self):
+        tag1 = (u'pool1', u'1234')
+        tag2 = (u'pool1', u'5678')
+        tag3 = (u'pool1', u'9012')
+        yield self.declare_tags(self.api, [tag1, tag2, tag3])
+        yield self.user_api.acquire_specific_tag(tag2)
+        yield self.user_api.new_conversation(
+            u'bulk_message', u'subject', u'message', delivery_class=u'sms',
+            delivery_tag_pool=tag1[0], delivery_tag=tag1[1])
+        endpoints = yield self.user_api.list_conversation_endpoints()
+        self.assertEqual(endpoints, set([tag1]))
+
+    @inlineCallbacks
     def test_list_endpoints(self):
         tag1 = (u'pool1', u'1234')
         tag2 = (u'pool1', u'5678')
         yield self.declare_tags(self.api, [tag1, tag2])
-        yield self.user_api.new_conversation(
-            u'bulk_message', u'subject', u'message', delivery_class=u'sms',
-            delivery_tag_pool=tag1[0], delivery_tag=tag1[1])
+        yield self.user_api.acquire_specific_tag(tag1)
         endpoints = yield self.user_api.list_endpoints()
         self.assertEqual(endpoints, set([tag1]))
 

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -252,17 +252,27 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         })
 
     @inlineCallbacks
+    def assert_account_tags(self, expected):
+        user_account = yield self.user_api.get_user_account()
+        self.assertEqual(expected, user_account.tags)
+
+    @inlineCallbacks
     def test_declare_acquire_and_release_tags(self):
         tag1, tag2 = ("poolA", "tag1"), ("poolA", "tag2")
         yield self.api.tpm.declare_tags([tag1, tag2])
+
+        yield self.assert_account_tags([])
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag1)
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)
         self.assertEqual((yield self.user_api.acquire_tag("poolB")), None)
+        yield self.assert_account_tags([list(tag1), list(tag2)])
 
         yield self.user_api.release_tag(tag2)
+        yield self.assert_account_tags([list(tag1)])
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), tag2)
         self.assertEqual((yield self.user_api.acquire_tag("poolA")), None)
+        yield self.assert_account_tags([list(tag1), list(tag2)])
 
 
 class TestVumiUserApi(TestTxVumiUserApi):

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -160,8 +160,8 @@ class SendingEventDispatcherTestCase(AppWorkerTestCase):
         yield user_account.save()
 
         user_api = self.ed.vumi_api.get_user_api(user_account.key)
-        yield user_api.api.declare_tags([("pool", "tag1")])
-        yield user_api.api.set_pool_metadata("pool", {
+        yield self.declare_tags(user_api.api, [("pool", "tag1")])
+        yield self.set_pool_metadata(user_api.api, "pool", {
             "transport_type": "other",
             "msg_options": {"transport_name": "other_transport"},
             })

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -160,8 +160,8 @@ class SendingEventDispatcherTestCase(AppWorkerTestCase):
         yield user_account.save()
 
         user_api = self.ed.vumi_api.get_user_api(user_account.key)
-        yield self.declare_tags(user_api.api, [("pool", "tag1")])
-        yield self.set_pool_metadata(user_api.api, "pool", {
+        yield self.declare_tags(user_api.api, [(u"pool", u"tag1")])
+        yield self.set_pool_metadata(user_api.api, u"pool", {
             "transport_type": "other",
             "msg_options": {"transport_name": "other_transport"},
             })
@@ -249,7 +249,7 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
         msg = self.mkmsg_in(transport_type='xmpp',
                                 transport_name=self.transport_name)
 
-        tag = ('xmpp', 'test1@xmpp.org')
+        tag = (u'xmpp', u'test1@xmpp.org')
         batch_id = yield self.vumi_api.mdb.batch_start([tag],
             user_account=unicode(self.account.key))
         self.conversation.batches.add_key(batch_id)
@@ -275,7 +275,7 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
                                 transport_name=self.transport_name)
 
         # Make sure stuff is tagged properly so it can be routed.
-        tag = ('xmpp', 'test1@xmpp.org')
+        tag = (u'xmpp', u'test1@xmpp.org')
         batch_id = yield self.vumi_api.mdb.batch_start([tag],
             user_account=unicode(self.account.key))
         self.conversation.batches.add_key(batch_id)
@@ -303,7 +303,7 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
                                 transport_name=self.transport_name)
 
         # Make sure stuff is tagged properly so it can be routed.
-        tag = ('xmpp', 'test1@xmpp.org')
+        tag = (u'xmpp', u'test1@xmpp.org')
         batch_id = yield self.vumi_api.mdb.batch_start([tag],
             user_account=unicode(self.account.key))
         self.conversation.batches.add_key(batch_id)
@@ -351,7 +351,7 @@ class GoApplicationRouterTestCase(GoPersistenceMixin, DispatcherTestCase):
         msg = self.mkmsg_in(transport_type='xmpp',
                             transport_name='xmpp_transport')
         msg['content'] = 'stop'
-        tag = ('xmpp', 'test1@xmpp.org')
+        tag = (u'xmpp', u'test1@xmpp.org')
         batch_id = yield self.vumi_api.mdb.batch_start([tag],
             user_account=unicode(self.account.key))
         self.conversation.batches.add_key(batch_id)

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -165,13 +165,14 @@ class SendingEventDispatcherTestCase(AppWorkerTestCase):
             "msg_options": {"transport_name": "other_transport"},
             })
 
-        user_api = self.ed.vumi_api.get_user_api(user_account.key)
-        conversation = yield user_api.new_conversation(
+        self.user_api = self.ed.vumi_api.get_user_api(user_account.key)
+        yield self.add_tagpool_permission(u"pool")
+        conversation = yield self.user_api.new_conversation(
                                     u'bulk_message', u'subject', u'message',
                                     delivery_tag_pool=u'pool',
                                     delivery_class=u'sms')
 
-        conversation = user_api.wrap_conversation(conversation)
+        conversation = self.user_api.wrap_conversation(conversation)
         yield conversation.start()
 
         user_account.event_handler_config = [

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -159,13 +159,13 @@ class SendingEventDispatcherTestCase(AppWorkerTestCase):
         user_account = yield self.mk_user(self.ed.vumi_api, u'dbacct')
         yield user_account.save()
 
-        user_api = self.ed.vumi_api.get_user_api(user_account.key)
-        yield self.declare_tags(user_api.api, [(u"pool", u"tag1")])
-        yield self.set_pool_metadata(user_api.api, u"pool", {
+        yield self.ed.vumi_api.tpm.declare_tags([(u"pool", u"tag1")])
+        yield self.ed.vumi_api.tpm.set_metadata(u"pool", {
             "transport_type": "other",
             "msg_options": {"transport_name": "other_transport"},
             })
 
+        user_api = self.ed.vumi_api.get_user_api(user_account.key)
         conversation = yield user_api.new_conversation(
                                     u'bulk_message', u'subject', u'message',
                                     delivery_tag_pool=u'pool',

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -89,8 +89,8 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         self.mw = yield self.create_middleware(OptOutMiddleware,
             config=self.config)
         self._persist_redis_managers.append(self.mw.vumi_api.redis)
-        yield self.mw.vumi_api.declare_tags([("pool", "tag1")])
-        yield self.mw.vumi_api.set_pool_metadata("pool", {
+        yield self.declare_tags(self.mw.vumi_api, [("pool", "tag1")])
+        yield self.set_pool_metadata(self.mw.vumi_api, "pool", {
                 "transport_type": "other",
                 "msg_options": {"transport_name": "other_transport"},
                 })
@@ -126,7 +126,7 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
 
     @inlineCallbacks
     def test_disabled_by_tagpool(self):
-        yield self.mw.vumi_api.set_pool_metadata("pool", {
+        yield self.set_pool_metadata(self.mw.vumi_api, "pool", {
                 "transport_type": "other",
                 "msg_options": {"transport_name": "other_transport"},
                 "disable_global_opt_out": True,
@@ -147,8 +147,8 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         # This is a bit ugly. We get a new fakeredis here.
         mw = yield self.create_middleware(OptOutMiddleware, config=config)
         self._persist_redis_managers.append(mw.vumi_api.redis)
-        yield mw.vumi_api.declare_tags([("pool", "tag1")])
-        yield mw.vumi_api.set_pool_metadata("pool", {
+        yield self.declare_tags(mw.vumi_api, [("pool", "tag1")])
+        yield self.set_pool_metadata(mw.vumi_api, "pool", {
                 "transport_type": "other",
                 "msg_options": {"transport_name": "other_transport"},
                 })

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -89,8 +89,8 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         self.mw = yield self.create_middleware(OptOutMiddleware,
             config=self.config)
         self._persist_redis_managers.append(self.mw.vumi_api.redis)
-        yield self.declare_tags(self.mw.vumi_api, [("pool", "tag1")])
-        yield self.set_pool_metadata(self.mw.vumi_api, "pool", {
+        yield self.mw.vumi_api.tpm.declare_tags([("pool", "tag1")])
+        yield self.mw.vumi_api.tpm.set_metadata("pool", {
                 "transport_type": "other",
                 "msg_options": {"transport_name": "other_transport"},
                 })
@@ -126,7 +126,7 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
 
     @inlineCallbacks
     def test_disabled_by_tagpool(self):
-        yield self.set_pool_metadata(self.mw.vumi_api, "pool", {
+        yield self.mw.vumi_api.tpm.set_metadata("pool", {
                 "transport_type": "other",
                 "msg_options": {"transport_name": "other_transport"},
                 "disable_global_opt_out": True,
@@ -147,8 +147,8 @@ class OptOutMiddlewareTestCase(MiddlewareTestCase):
         # This is a bit ugly. We get a new fakeredis here.
         mw = yield self.create_middleware(OptOutMiddleware, config=config)
         self._persist_redis_managers.append(mw.vumi_api.redis)
-        yield self.declare_tags(mw.vumi_api, [("pool", "tag1")])
-        yield self.set_pool_metadata(mw.vumi_api, "pool", {
+        yield mw.vumi_api.tpm.declare_tags([("pool", "tag1")])
+        yield mw.vumi_api.tpm.set_metadata("pool", {
                 "transport_type": "other",
                 "msg_options": {"transport_name": "other_transport"},
                 })

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -3,6 +3,7 @@
 """Utilities for go.vumitools tests."""
 
 import os
+import uuid
 from contextlib import contextmanager
 
 from twisted.python.monkey import MonkeyPatcher
@@ -234,6 +235,16 @@ class AppWorkerTestCase(GoPersistenceMixin, ApplicationTestCase):
                 "transport_name": self.transport_name,
                 },
             })
+        yield self.add_tagpool_permission(u"pool")
+
+    @inlineCallbacks
+    def add_tagpool_permission(self, tagpool, max_keys=None):
+        permission = yield self.user_api.api.account_store.tag_permissions(
+           uuid.uuid4().hex, tagpool=tagpool, max_keys=max_keys)
+        yield permission.save()
+        account = yield self.user_api.get_user_account()
+        account.tagpools.add(permission)
+        yield account.save()
 
     def dispatch_command(self, command, *args, **kw):
         cmd = VumiApiCommand.command(

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -224,6 +224,32 @@ class AppWorkerTestCase(GoPersistenceMixin, ApplicationTestCase):
     def _command_rkey(self):
         return "%s.control" % (self._worker_name(),)
 
+    def declare_tags(self, api, tags):
+        """Populate a pool with tags.
+
+        Tags already in the pool are not duplicated.
+
+        :type pool: str
+        :type tags: list of (pool, local_tag) tuples
+        :param tags:
+            list of tags to add to the pool.
+        :rtype:
+            None
+        """
+        return api.tpm.declare_tags(tags)
+
+    def set_pool_metadata(self, api, pool, metadata):
+        """Set the metadata for a tag pool.
+
+        :param str pool:
+            Name of the pool set metadata form.
+        :param dict metadata:
+            Metadata to set.
+        :rtype:
+            None
+        """
+        return api.tpm.set_metadata(pool, metadata)
+
     def dispatch_command(self, command, *args, **kw):
         cmd = VumiApiCommand.command(
             self._worker_name(), command, *args, **kw)

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -226,40 +226,14 @@ class AppWorkerTestCase(GoPersistenceMixin, ApplicationTestCase):
 
     @inlineCallbacks
     def setup_tagpools(self):
-        yield self.declare_tags(self.vumi_api,
-                                [(u"pool", u"tag1"), (u"pool", u"tag2")])
-        yield self.set_pool_metadata(self.vumi_api, u"pool", {
+        yield self.vumi_api.tpm.declare_tags(
+           [(u"pool", u"tag1"), (u"pool", u"tag2")])
+        yield self.vumi_api.tpm.set_metadata(u"pool", {
             "transport_type": self.transport_type,
             "msg_options": {
                 "transport_name": self.transport_name,
                 },
             })
-
-    def declare_tags(self, api, tags):
-        """Populate a pool with tags.
-
-        Tags already in the pool are not duplicated.
-
-        :type pool: str
-        :type tags: list of (pool, local_tag) tuples
-        :param tags:
-            list of tags to add to the pool.
-        :rtype:
-            None
-        """
-        return api.tpm.declare_tags(tags)
-
-    def set_pool_metadata(self, api, pool, metadata):
-        """Set the metadata for a tag pool.
-
-        :param str pool:
-            Name of the pool set metadata form.
-        :param dict metadata:
-            Metadata to set.
-        :rtype:
-            None
-        """
-        return api.tpm.set_metadata(pool, metadata)
 
     def dispatch_command(self, command, *args, **kw):
         cmd = VumiApiCommand.command(

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -224,6 +224,17 @@ class AppWorkerTestCase(GoPersistenceMixin, ApplicationTestCase):
     def _command_rkey(self):
         return "%s.control" % (self._worker_name(),)
 
+    @inlineCallbacks
+    def setup_tagpools(self):
+        yield self.declare_tags(self.vumi_api,
+                                [(u"pool", u"tag1"), (u"pool", u"tag2")])
+        yield self.set_pool_metadata(self.vumi_api, u"pool", {
+            "transport_type": self.transport_type,
+            "msg_options": {
+                "transport_name": self.transport_name,
+                },
+            })
+
     def declare_tags(self, api, tags):
         """Populate a pool with tags.
 


### PR DESCRIPTION
We currently claim tags for particular conversations and release them when the conversation ends. We should claim tags separately from conversations and then select tags held by the account in the conversation setup.
