### PR TITLE
VUMIGO-280 fix raven sentry mismatch

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -275,9 +275,6 @@ GOOGLE_ANALYTICS_UA = None
 
 MESSAGE_STORE_API_URL = 'http://localhost:8080/api/v1/'
 
-SENTRY_KEY = ''
-SENTRY_SERVERS = []
-
 try:
     from production_settings import *
 except ImportError:

--- a/go/settings.py
+++ b/go/settings.py
@@ -158,7 +158,7 @@ INSTALLED_APPS = (
     'vxpolls.djdashboard',
     'registration',
     'bootstrap',
-    'raven.contrib.django.raven_compat',
+    'raven.contrib.django',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
@@ -274,6 +274,9 @@ VXPOLLS_PREFIX = 'vumigo'
 GOOGLE_ANALYTICS_UA = None
 
 MESSAGE_STORE_API_URL = 'http://localhost:8080/api/v1/'
+
+SENTRY_KEY = ''
+SENTRY_SERVERS = []
 
 try:
     from production_settings import *

--- a/requirements.pip
+++ b/requirements.pip
@@ -26,4 +26,4 @@ raven==2.0.7
 -e git+git://github.com/praekelt/vumi-wikipedia@develop#egg=vumi-wikipedia
 requests==0.14.2
 mock==1.0.1
-raven==3.1.4
+raven>=2.0,<3.0


### PR DESCRIPTION
Our raven version is too new for our sentry deploy.
Need to stay < v3 until we upgrade our sentry.
