### PR TITLE
VUMIGO-48 one-off replies

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -169,9 +169,10 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'conversation_key': self.conv_key}))
 
         # Check pagination
-        # We should have 20 links to contacts which by default display
-        # the from_addr if a contact cannot be found.
-        self.assertContains(response, 'from-', 20)
+        # We should have 60 references to a contact, which by default display
+        # the from_addr if a contact cannot be found. (each block as 3
+        # references, one in the table listing, 2 in the reply-to modal div)
+        self.assertContains(response, 'from-', 60)
         # We should have 2 links to page to, one for the actual page link
         # and one for the 'Next' page link
         self.assertContains(response, '&amp;p=2', 2)

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -513,6 +513,8 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
 
         [start_cmd, reply_to_cmd] = self.get_api_commands_sent()
         [tag] = conversation.get_tags()
+        msg_options = conversation.make_message_options(tag)
+        msg_options['in_reply_to'] = msg['message_id']
         self.assertEqual(reply_to_cmd['worker_name'],
                             'bulk_message_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
@@ -520,5 +522,5 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
             'batch_id': conversation.get_latest_batch_key(),
             'content': 'foo',
             'to_addr': msg['from_addr'],
-            'msg_options': conversation.make_message_options(tag),
+            'msg_options': msg_options,
             })

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -467,3 +467,58 @@ class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):
             )
 
         self.assertEqual(cmd, expected_cmd)
+
+
+class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
+
+    def setUp(self):
+        super(SendOneOffReplyTestCase, self).setUp()
+        self.setup_riak_fixtures()
+        self.client = Client()
+        self.client.login(username='username', password='password')
+
+    def get_wrapped_conv(self):
+        conv = self.conv_store.get_conversation_by_key(self.conv_key)
+        return self.user_api.wrap_conversation(conv)
+
+    def test_actions_on_inbound_only(self):
+        self.put_sample_messages_in_conversation(self.user_api,
+                                                    self.conv_key, 1)
+        response = self.client.get(reverse('bulk_message:show', kwargs={
+            'conversation_key': self.conv_key
+            }), {'direction': 'inbound'})
+        self.assertContains(response, 'Reply')
+
+        response = self.client.get(reverse('bulk_message:show', kwargs={
+            'conversation_key': self.conv_key
+            }), {'direction': 'outbound'})
+        self.assertNotContains(response, 'Reply')
+
+    def test_send_one_off_reply(self):
+        self.put_sample_messages_in_conversation(self.user_api,
+                                                    self.conv_key, 1)
+        conversation = self.get_wrapped_conv()
+        [msg] = conversation.received_messages()
+        response = self.client.post(reverse('bulk_message:show', kwargs={
+            'conversation_key': self.conv_key
+            }), {
+                'in_reply_to': msg['message_id'],
+                'content': 'foo',
+                'to_addr': 'should be ignored',
+                '_send_one_off_reply': True,
+            })
+        self.assertRedirects(response, reverse('bulk_message:show', kwargs={
+            'conversation_key': self.conv_key,
+            }))
+
+        [start_cmd, reply_to_cmd] = self.get_api_commands_sent()
+        [tag] = conversation.get_tags()
+        self.assertEqual(reply_to_cmd['worker_name'],
+                            'bulk_message_application')
+        self.assertEqual(reply_to_cmd['command'], 'send_message')
+        self.assertEqual(reply_to_cmd['kwargs']['command_data'], {
+            'batch_id': conversation.get_latest_batch_key(),
+            'content': 'foo',
+            'to_addr': msg['from_addr'],
+            'msg_options': conversation.make_message_options(tag),
+            })

--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -14,8 +14,10 @@ from vumi.persist.redis_manager import RedisManager
 from go.base.utils import (make_read_only_form, make_read_only_formset,
     conversation_or_404)
 from go.vumitools.exceptions import ConversationSendError
-from go.conversation.forms import ConversationForm, ConversationGroupForm
-from go.conversation.tasks import export_conversation_messages
+from go.conversation.forms import (ConversationForm, ConversationGroupForm,
+                                    ReplyToMessageForm)
+from go.conversation.tasks import (export_conversation_messages,
+                                    send_one_off_reply)
 from go.apps.surveys import forms
 
 from vxpolls.manager import PollManager
@@ -245,6 +247,22 @@ def show(request, conversation_key):
         return redirect(reverse('survey:show', kwargs={
             'conversation_key': conversation.key,
             }))
+
+    if '_send_one_off_reply' in request.POST:
+        form = ReplyToMessageForm(request.POST)
+        if form.is_valid():
+            in_reply_to = form.cleaned_data['in_reply_to']
+            content = form.cleaned_data['content']
+            send_one_off_reply.delay(
+                request.user_api.user_account_key, conversation.key,
+                in_reply_to, content)
+            messages.info(request, 'Reply scheduled for sending.')
+            return redirect(reverse('survey:show', kwargs={
+                'conversation_key': conversation.key,
+                }))
+        else:
+            messages.error(request,
+                'Something went wrong. Please try again.')
 
     return render(request, 'surveys/show.html', {
         'conversation': conversation,

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -156,3 +156,12 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             for contact in (yield contacts):
                 to_addr = contact.addr_for(conv.delivery_class)
                 yield self.start_survey(to_addr, conv, **msg_options)
+
+    @inlineCallbacks
+    def process_command_send_message(self, *args, **kwargs):
+        log.info('Processing send_message: %s' % kwargs)
+        command_data = kwargs['command_data']
+        to_addr = command_data['to_addr']
+        content = command_data['content']
+        msg_options = command_data['msg_options']
+        yield self.send_to(to_addr, content, **msg_options)

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -134,3 +134,10 @@ class ConversationSearchForm(BootstrapForm):
             ('draft', 'Draft'),
         ],
         widget=forms.Select(attrs={'class': 'input-small'}))
+
+
+class ReplyToMessageForm(BootstrapForm):
+    in_reply_to = forms.CharField(widget=forms.HiddenInput, required=True)
+    to_addr = forms.CharField(label='Send To', required=True)
+    content = forms.CharField(label='Reply Message', required=True,
+        widget=forms.Textarea)

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -138,6 +138,8 @@ class ConversationSearchForm(BootstrapForm):
 
 class ReplyToMessageForm(BootstrapForm):
     in_reply_to = forms.CharField(widget=forms.HiddenInput, required=True)
+    # NOTE: the to_addr is only used to display in the UI, when sending the
+    #       reply the 'from_addr' of the 'in_reply_to' message copied over.
     to_addr = forms.CharField(label='Send To', required=True)
     content = forms.CharField(label='Reply Message', required=True,
         widget=forms.Textarea)

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -74,3 +74,22 @@ def export_conversation_messages(account_key, conversation_key):
         settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
     email.attach('messages-export.csv', io.getvalue(), 'text/csv')
     email.send()
+
+
+@task(ignore_result=True)
+def send_one_off_reply(account_key, conversation_key, in_reply_to, content):
+    user_api = VumiUserApi.from_config_sync(account_key,
+                                            settings.VUMI_API_CONFIG)
+    inbound_message = user_api.api.mdb.get_inbound_message(in_reply_to)
+    if inbound_message is None:
+        print 'Replying to an unknown message'
+
+    conversation = user_api.get_wrapped_conversation(conversation_key)
+    [tag] = conversation.get_tags()
+    msg_options = conversation.make_message_options(tag)
+    conversation.dispatch_command('send_message', command_data={
+        "batch_id": conversation.get_latest_batch_key(),
+        "to_addr": inbound_message['from_addr'],
+        "content": content,
+        "msg_options": msg_options,
+        })

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -87,6 +87,7 @@ def send_one_off_reply(account_key, conversation_key, in_reply_to, content):
     conversation = user_api.get_wrapped_conversation(conversation_key)
     [tag] = conversation.get_tags()
     msg_options = conversation.make_message_options(tag)
+    msg_options['in_reply_to'] = in_reply_to
     conversation.dispatch_command('send_message', command_data={
         "batch_id": conversation.get_latest_batch_key(),
         "to_addr": inbound_message['from_addr'],

--- a/go/conversation/templates/generic/includes/message-list.html
+++ b/go/conversation/templates/generic/includes/message-list.html
@@ -5,7 +5,7 @@
         <tr>
             <th width="32">Type</th>
             <th>Response</th>
-            <th width="70">Actions</th>
+            {% if message_direction == 'inbound' and not conversation.is_client_initiated %}<th width="70">Actions</th>{% endif %}
         </tr>
     </thead>
     <tbody>
@@ -15,8 +15,30 @@
             <td><i class="icon-repeat"></i> {{conversation.delivery_class}}</td>
             <td>
                 <h6><a href="{% url 'contacts:person' person_key=contact.key %}">{{contact}}</a> via {{message.transport_type}} - {{message.timestamp}}</h6>
-                <p>{{message.content}}</p></td>
-            <td><a href="#" class="btn" title="Reply"><i class="icon-repeat"></i> Reply</a></td>
+                <p>{{message.content}}</p>
+            </td>
+            {% if message_direction == 'inbound' and not conversation.is_client_initiated %}
+            <td>
+                <a href="#reply-{{message.key}}" class="btn" title="Reply" data-toggle='modal'><i class="icon-repeat"></i> Reply</a>
+                <div id="reply-{{message.key}}" class="modal hide fade" role="dialog">
+                    <div class="modal-header">
+                        <a class="close" data-dismiss="modal">×</a>
+                        <h3>Reply to {{contact}}</h3>
+                    </div>
+                    <form method="post" action="" class="form-horizontal">
+                        {% csrf_token %}
+                        <div class="modal-body">
+                            {% get_reply_form_for_message message as reply_form %}
+                            {{ reply_form }}
+                        </div>
+                        <div class="modal-footer">
+                            <a href="#" class="btn" data-dismiss="modal">Cancel</a>
+                            <button type="submit" name="_send_one_off_reply" class="btn btn-primary" data-loading-text="sending...">Send Reply</button>
+                        </div>
+                    </form>
+                </div>
+            </td>
+            {% endif %}
         </tr>
         {% empty %}
             {% if query %}

--- a/go/conversation/templatetags/conversation_tags.py
+++ b/go/conversation/templatetags/conversation_tags.py
@@ -8,6 +8,7 @@ from django.contrib.sites.models import Site
 from django.template.defaultfilters import stringfilter
 
 from go.conversation.utils import PagedMessageCache
+from go.conversation.forms import ReplyToMessageForm
 from go.base import message_store_client as ms_client
 from go.base.utils import page_range_window
 
@@ -125,6 +126,16 @@ def get_contact_for_message(user_api, message):
     }.get(message['transport_type'], 'unkown')
     return user_api.contact_store.contact_for_addr(
         delivery_class, unicode(message.user()))
+
+
+@register.assignment_tag
+def get_reply_form_for_message(message):
+    form = ReplyToMessageForm(initial={
+        'to_addr': message['from_addr'],
+        'in_reply_to': message['message_id'],
+        })
+    form.fields['to_addr'].widget.attrs['readonly'] = True
+    return form
 
 
 @register.filter


### PR DESCRIPTION
Adds the ability to send one-off replies to messages received on a
conversation that isn't exclusively client initiated.

Some UI for this already existed but did nothing, this adds the missing
bits. It also builds on the already existing functionality of the 'send_message' command.
