### PR TITLE
VUMIGO-282 Random UI timeouts.

### DIFF
--- a/go/base/amqp.py
+++ b/go/base/amqp.py
@@ -1,0 +1,39 @@
+from kombu import Connection, Exchange
+
+
+class AmqpConnection(object):
+    """
+    Connect to the AMQP backend for easy publishing without
+    having to hack our way through Celery.
+    """
+    def __init__(self):
+        self.conn = None
+        self.default_exchange = Exchange('vumi', 'direct', durable=True)
+        self.metrics_exchange = Exchange('vumi.metrics', 'direct',
+            durable=True)
+
+    def connect(self, dsn):
+        self.conn = Connection(dsn)
+        self.producer = self.conn.Producer()
+
+    def is_connected(self):
+        return self.conn and self.conn.connected
+
+    def publish(self, message, exchange, routing_key):
+        self.producer.publish(message, exchange=exchange,
+            routing_key=routing_key)
+
+    def publish_command(self, command):
+        return self.publish(command.to_json, exchange=self.default_exchange,
+            routing_key='vumi.api')
+
+    def publish_metric(self, metric):
+        return self.publish(metric.to_json(), exchange=self.metrics_exchange,
+            routing_key='vumi.metrics')
+
+connection = AmqpConnection()
+
+
+def connect(dsn):
+    if not connection.is_connected():
+        connection.connect(dsn)

--- a/go/base/amqp.py
+++ b/go/base/amqp.py
@@ -1,4 +1,8 @@
+import time
+
 from kombu import Connection, Exchange
+
+from vumi.blinkenlights.metrics import MetricMessage
 
 
 class AmqpConnection(object):
@@ -23,13 +27,21 @@ class AmqpConnection(object):
         self.producer.publish(message, exchange=exchange,
             routing_key=routing_key)
 
-    def publish_command(self, command):
+    def publish_command_message(self, command):
         return self.publish(command.to_json, exchange=self.default_exchange,
             routing_key='vumi.api')
 
-    def publish_metric(self, metric):
+    def publish_metric_message(self, metric):
         return self.publish(metric.to_json(), exchange=self.metrics_exchange,
             routing_key='vumi.metrics')
+
+    def publish_metric(self, metric_name, aggregators, value, timestamp=None):
+        timestamp = timestamp or time.time()
+        metric_msg = MetricMessage()
+        metric_msg.append((metric_name,
+            tuple(sorted(agg.name for agg in aggregators)),
+            [(timestamp, value)]))
+        return self.publish_metric_message(metric_msg)
 
 connection = AmqpConnection()
 

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from go.base.utils import vumi_api_for_user
 from go.base.amqp import connection
 
-from vumi.blinkenlights.metrics import AVG, MetricMessage
+from vumi.blinkenlights.metrics import AVG
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +53,6 @@ class ResponseTimeMiddleware(object):
     def publish_metric(self, metric_name, value, timestamp=None,
                         aggregators=None):
         aggregators = aggregators or [AVG]
-        timestamp = timestamp or time.time()
-        metric_msg = MetricMessage()
         prefixed_metric_name = '%s%s' % (self.metrics_prefix, metric_name)
-        metric_msg.append((prefixed_metric_name,
-            tuple(sorted(agg.name for agg in aggregators)),
-            [(timestamp, value)]))
-        connection.publish_metric(metric_msg)
+        connection.publish_metric(prefixed_metric_name, aggregators,
+            value, timestamp)

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -26,6 +26,9 @@ class ResponseTimeMiddleware(object):
     Marks the time when a request is received and when the response for that
     request is sent back again. Fires off metrics for the time taken to
     generate the response.
+
+    It sets an X-Response-Time HTTP header which can be useful for debugging
+    or logging slow resources upstream.
     """
     def __init__(self):
         self.metrics_prefix = getattr(settings, 'METRICS_PREFIX', 'go.django.')

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -1,4 +1,14 @@
+import time
+import logging
+
+from django.core.urlresolvers import resolve, Resolver404
+
 from go.base.utils import vumi_api_for_user
+from go.base.amqp import connection
+
+from vumi.blinkenlights.metrics import AVG, MetricMessage
+
+logger = logging.getLogger(__name__)
 
 
 class VumiUserApiMiddleware(object):
@@ -6,3 +16,33 @@ class VumiUserApiMiddleware(object):
         user = getattr(request, 'user', None)
         if user is not None and user.is_authenticated():
             request.user_api = vumi_api_for_user(request.user)
+
+
+class ResponseTimeMiddleware(object):
+    """
+    Middleware for generating metrics on page response times.
+
+    """
+    def process_request(self, request):
+        request.start_time = time.time()
+
+    def process_response(self, request, response):
+        try:
+            func = resolve(request.path)[0]
+            metric_name = '%s.%s' % (func.__module__, func.__name__)
+            response_time = time.time() - request.start_time
+            self.publish_metric(metric_name, response_time)
+        except (Resolver404, AttributeError), e:
+            logger.exception(e)
+        if response:
+            return response
+
+    def publish_metric(self, metric_name, value, timestamp=None,
+                        aggregators=None):
+        aggregators = aggregators or [AVG]
+        timestamp = timestamp or time.time()
+        metric_msg = MetricMessage()
+        metric_msg.append((metric_name,
+            tuple(sorted(agg.name for agg in aggregators)),
+            [(timestamp, value)]))
+        connection.publish_metric(metric_msg)

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -23,6 +23,8 @@ class ResponseTimeMiddleware(object):
     """
     Middleware for generating metrics on page response times.
 
+
+
     """
     def __init__(self):
         self.metrics_prefix = getattr(settings, 'METRICS_PREFIX', 'go.django.')
@@ -34,7 +36,8 @@ class ResponseTimeMiddleware(object):
         try:
             stop_time = time.time()
             func = resolve(request.path)[0]
-            metric_name = '%s.%s' % (func.__module__, func.__name__)
+            metric_name = '%s.%s.%s' % (func.__module__, func.__name__,
+                                        request.method.upper())
             response_time = stop_time - request.start_time
             self.publish_metric(metric_name, response_time)
             response['X-Response-Time'] = response_time

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -23,8 +23,9 @@ class ResponseTimeMiddleware(object):
     """
     Middleware for generating metrics on page response times.
 
-
-
+    Marks the time when a request is received and when the response for that
+    request is sent back again. Fires off metrics for the time taken to
+    generate the response.
     """
     def __init__(self):
         self.metrics_prefix = getattr(settings, 'METRICS_PREFIX', 'go.django.')

--- a/go/base/tests/test_middleware.py
+++ b/go/base/tests/test_middleware.py
@@ -36,7 +36,9 @@ class ResponseTimeMiddlewareTestcase(TestCase):
         request.start_time = time.time()
 
         self.mw.process_response(request, response)
-        self.assertTrue(response['X-Response-Time'])
+        response_time_header = response['X-Response-Time']
+        self.assertTrue(response_time_header)
+        self.assertTrue(float(response_time_header))
 
         call = publish.call_args
         args, kwargs = call

--- a/go/base/tests/test_middleware.py
+++ b/go/base/tests/test_middleware.py
@@ -1,0 +1,48 @@
+import time
+import json
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from django.http import HttpResponse
+
+from go.base.middleware import ResponseTimeMiddleware
+from go.base.amqp import AmqpConnection
+
+from mock import patch
+
+
+class ResponseTimeMiddlewareTestcase(TestCase):
+
+    @override_settings(METRICS_PREFIX='test.prefix.')
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.mw = ResponseTimeMiddleware()
+
+    def test_setting_start_time(self):
+        request = self.factory.get('/accounts/login/')
+        self.assertFalse(hasattr(request, 'start_time'))
+        self.mw.process_request(request)
+        self.assertTrue(request.start_time)
+
+    @patch.object(AmqpConnection, 'is_connected')
+    @patch.object(AmqpConnection, 'publish')
+    def test_calculating_response_time(self, publish, is_connected):
+        is_connected.return_value = True
+        publish.return_value = True
+        response = HttpResponse('ok')
+
+        request = self.factory.get('/accounts/login/')
+        request.start_time = time.time()
+
+        self.mw.process_response(request, response)
+        self.assertTrue(response['X-Response-Time'])
+
+        call = publish.call_args
+        args, kwargs = call
+        command = json.loads(args[0])
+        [datapoint] = command['datapoints']
+        self.assertEqual(datapoint[0],
+            'test.prefix.django.contrib.auth.views.login')
+        self.assertEqual(datapoint[1], ['avg'])
+        self.assertTrue(datapoint[2])

--- a/go/base/tests/test_middleware.py
+++ b/go/base/tests/test_middleware.py
@@ -46,3 +46,7 @@ class ResponseTimeMiddlewareTestcase(TestCase):
             'test.prefix.django.contrib.auth.views.login')
         self.assertEqual(datapoint[1], ['avg'])
         self.assertTrue(datapoint[2])
+        self.assertEqual(kwargs['routing_key'], 'vumi.metrics')
+        exchange = kwargs['exchange']
+        self.assertEqual(exchange.name, 'vumi.metrics')
+        self.assertEqual(exchange.type, 'direct')

--- a/go/settings.py
+++ b/go/settings.py
@@ -291,7 +291,7 @@ MESSAGE_STORE_API_URL = 'http://localhost:8080/api/v1/'
 
 # Connect to AMQP straight
 from go.base import amqp
-amqp.connect('amqp://%s:%s@%s:%s/%s' % (
+amqp.connect('librabbitmq://%s:%s@%s:%s/%s' % (
     BROKER_USER, BROKER_PASSWORD, BROKER_HOST, BROKER_PORT, BROKER_VHOST))
 
 try:

--- a/go/settings.py
+++ b/go/settings.py
@@ -114,6 +114,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'go.base.middleware.VumiUserApiMiddleware',
+    'go.base.middleware.ResponseTimeMiddleware',
 )
 
 ROOT_URLCONF = 'go.urls'
@@ -287,6 +288,11 @@ VXPOLLS_PREFIX = 'vumigo'
 GOOGLE_ANALYTICS_UA = None
 
 MESSAGE_STORE_API_URL = 'http://localhost:8080/api/v1/'
+
+# Connect to AMQP straight
+from go.base import amqp
+amqp.connect('amqp://%s:%s@%s:%s/%s' % (
+    BROKER_USER, BROKER_PASSWORD, BROKER_HOST, BROKER_PORT, BROKER_VHOST))
 
 try:
     from production_settings import *

--- a/go/settings.py
+++ b/go/settings.py
@@ -107,6 +107,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -160,6 +161,7 @@ INSTALLED_APPS = (
     'registration',
     'bootstrap',
     'raven.contrib.django',
+    'debug_toolbar',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
@@ -175,6 +177,12 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "go.base.context_processors.credit",
     "go.base.context_processors.google_analytics",
 )
+
+DEBUG_TOOLBAR_CONFIG = {
+    'INTERCEPT_REDIRECTS': False,
+    'ENABLE_STACKTRACES': True,
+}
+
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/requirements.pip
+++ b/requirements.pip
@@ -27,3 +27,6 @@ requests==0.14.2
 mock==1.0.1
 raven>=2.0,<3.0
 django-debug-toolbar==0.9.4
+kombu==2.5.6
+librabbitmq==1.0.1
+hiredis==0.1.1

--- a/requirements.pip
+++ b/requirements.pip
@@ -27,3 +27,4 @@ raven==2.0.7
 requests==0.14.2
 mock==1.0.1
 raven>=2.0,<3.0
+django-debug-toolbar==0.9.4


### PR DESCRIPTION
We're getting random timeouts on various bits of our UI. This is the
start of adding the necessary bits to try & debug what's going on.

The main thing here is:
1. Straight connection to AMQP w/ Kombu & librabbitmq (no longer hacking
   our way through Celery)
2. Middleware for publishing response times to Graphite.
3. I've added hiredis to the requirements.pip, I'll install that on the
   server after we've got some metrics to compare with. Hiredis implements
   the binary Redis protocol and py-redis automatically uses it if
   installed. Hiredis claims 15-90x speed up on range queries.
