### PR TITLE
GO-285 crash during one-off reply handling.

### DIFF
--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -134,7 +134,7 @@ class BulkMessageApplication(GoApplicationWorker):
         if in_reply_to:
             msg = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
             if msg:
-                yield self.reply_to(msg, content, continue_session=False)
+                yield self.reply_to(msg, content)
                 return
 
         yield self.send_to(to_addr, content, **msg_options)

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -135,9 +135,11 @@ class BulkMessageApplication(GoApplicationWorker):
             msg = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
             if msg:
                 yield self.reply_to(msg, content)
-                return
-
-        yield self.send_to(to_addr, content, **msg_options)
+            else:
+                log.warning('Unable to reply, message %s does not exist.' % (
+                    in_reply_to))
+        else:
+            yield self.send_to(to_addr, content, **msg_options)
 
     @inlineCallbacks
     def collect_metrics(self, user_api, conversation_key):

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -127,11 +127,17 @@ class BulkMessageApplication(GoApplicationWorker):
     def process_command_send_message(self, *args, **kwargs):
         command_data = kwargs['command_data']
         log.info('Processing send_message: %s' % kwargs)
-        yield self.send_message(
-                command_data['batch_id'],
-                command_data['to_addr'],
-                command_data['content'],
-                command_data['msg_options'])
+        to_addr = command_data['to_addr']
+        content = command_data['content']
+        msg_options = command_data['msg_options']
+        in_reply_to = msg_options.pop('in_reply_to', None)
+        if in_reply_to:
+            msg = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
+            if msg:
+                yield self.reply_to(msg, content, continue_session=False)
+                return
+
+        yield self.send_to(to_addr, content, **msg_options)
 
     @inlineCallbacks
     def collect_metrics(self, user_api, conversation_key):

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -12,6 +12,7 @@ from vumi.tests.utils import LogCatcher
 
 from go.apps.surveys.vumi_app import SurveyApplication
 from go.vumitools.tests.utils import AppWorkerTestCase
+from go.vumitools.api import VumiApiCommand
 
 
 class TestSurveyApplication(AppWorkerTestCase):
@@ -277,3 +278,60 @@ class TestSurveyApplication(AppWorkerTestCase):
         poll_id = 'poll-%s' % (self.conversation.key,)
         participant = yield self.pm.get_participant(poll_id, contact.msisdn)
         self.assertEqual(participant.labels, {})
+
+    @inlineCallbacks
+    def test_process_command_send_message(self):
+        command = VumiApiCommand.command('worker', 'send_message',
+            command_data={
+                u'batch_id': u'batch-id',
+                u'content': u'foo',
+                u'to_addr': u'to_addr',
+                u'msg_options': {
+                    u'helper_metadata': {
+                        u'go': {
+                            u'user_account': u'account-key'
+                        },
+                        u'tag': {
+                            u'tag': [u'longcode', u'default10080']
+                        }
+                    },
+                    u'transport_name': u'smpp_transport',
+                    u'transport_type': u'sms',
+                    u'from_addr': u'default10080',
+                }
+            })
+        yield self.app.consume_control_command(command)
+        [sent_msg] = self.get_dispatched_messages()
+        self.assertEqual(sent_msg['to_addr'], 'to_addr')
+        self.assertEqual(sent_msg['content'], 'foo')
+        self.assertEqual(sent_msg['in_reply_to'], None)
+
+    @inlineCallbacks
+    def test_process_command_send_message_in_reply_to(self):
+        msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
+        yield self.vumi_api.mdb.add_inbound_message(msg)
+        command = VumiApiCommand.command('worker', 'send_message',
+            command_data={
+                u'batch_id': u'batch-id',
+                u'content': u'foo',
+                u'to_addr': u'to_addr',
+                u'msg_options': {
+                    u'helper_metadata': {
+                        u'go': {
+                            u'user_account': u'account-key'
+                        },
+                        u'tag': {
+                            u'tag': [u'longcode', u'default10080']
+                        }
+                    },
+                    u'transport_name': u'smpp_transport',
+                    u'in_reply_to': msg['message_id'],
+                    u'transport_type': u'sms',
+                    u'from_addr': u'default10080',
+                }
+            })
+        yield self.app.consume_control_command(command)
+        [sent_msg] = self.get_dispatched_messages()
+        self.assertEqual(sent_msg['to_addr'], msg['from_addr'])
+        self.assertEqual(sent_msg['content'], 'foo')
+        self.assertEqual(sent_msg['in_reply_to'], msg['message_id'])

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -13,6 +13,7 @@ from go.vumitools.app_worker import GoApplicationMixin
 class SurveyApplication(PollApplication, GoApplicationMixin):
 
     worker_name = 'survey_application'
+    SEND_TO_TAGS = frozenset(['default'])
 
     def validate_config(self):
         self._go_validate_config()

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -170,6 +170,8 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             msg = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
             if msg:
                 yield self.reply_to(msg, content)
-                return
-
-        yield self.send_to(to_addr, content, **msg_options)
+            else:
+                log.warning('Unable to reply, message %s does not exist.' % (
+                    in_reply_to))
+        else:
+            yield self.send_to(to_addr, content, **msg_options)

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -169,7 +169,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         if in_reply_to:
             msg = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
             if msg:
-                yield self.reply_to(msg, content, continue_session=False)
+                yield self.reply_to(msg, content)
                 return
 
         yield self.send_to(to_addr, content, **msg_options)

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -165,4 +165,11 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         to_addr = command_data['to_addr']
         content = command_data['content']
         msg_options = command_data['msg_options']
+        in_reply_to = msg_options.pop('in_reply_to', None)
+        if in_reply_to:
+            msg = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
+            if msg:
+                yield self.reply_to(msg, content, continue_session=False)
+                return
+
         yield self.send_to(to_addr, content, **msg_options)


### PR DESCRIPTION
We made the assumption that `send_to()` would work for replies as well.
Turns out it doesn't because it in turn called
`TransportUserMessage.send()` which sets the `in_reply_to` keyword
argument to `None`. We then supply a second kwarg with the key of a
message we're replying to and it fails miserably.

This fixes that by calling `reply_to()` when given a value for
`in_reply_to`.
