### PR TITLE
VUMIGO-286 streaming api health checks.

### DIFF
--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -349,3 +349,7 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
         response = yield http_request_full(health_url, method='GET')
         self.assertEqual(response.delivered_body, '0')
+
+        self.assertEqual(self.app.client_manager.clients, {
+            'sphex.stream.message.%s' % (self.conversation.key,): []
+            })

--- a/go/apps/http_api/vumi_app.py
+++ b/go/apps/http_api/vumi_app.py
@@ -141,6 +141,10 @@ class StreamingHTTPWorker(GoApplicationWorker):
         [conv_key] = yield mr.get_keys()
         yield self.stream(EventStream, conv_key, event)
 
+    def get_health_response(self):
+        return str(sum([len(callbacks) for callbacks in
+                    self.client_manager.clients.values()]))
+
     @inlineCallbacks
     def teardown_application(self):
         yield super(StreamingHTTPWorker, self).teardown_application()


### PR DESCRIPTION
The health check resource expects the transport to tell it whether
things are ok or not. This adds the necessary bits to make that happen.
It'll return how many streaming connections there currently are via HTTP
on the /health/ resource.
