### PR TITLE
VUMIGO-289 vumi command & event durability

### DIFF
--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -526,6 +526,7 @@ class VumiApiEvent(Message):
         'exchange': 'vumi',
         'exchange_type': 'direct',
         'routing_key': 'vumi.event',
+        'durable': True,
         }
 
     @classmethod

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -501,6 +501,7 @@ class VumiApiCommand(Message):
         'exchange': 'vumi',
         'exchange_type': 'direct',
         'routing_key': 'vumi.api',
+        'durable': True,
         }
 
     @classmethod

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -285,15 +285,23 @@ class TestVumiUserApi(TestTxVumiUserApi):
 class TestVumiApiCommand(TestCase):
     def test_default_routing_config(self):
         cfg = VumiApiCommand.default_routing_config()
-        self.assertEqual(set(cfg.keys()),
-                         set(['exchange', 'exchange_type', 'routing_key']))
+        self.assertEqual(cfg, {
+            'exchange': 'vumi',
+            'exchange_type': 'direct',
+            'routing_key': 'vumi.api',
+            'durable': True,
+            })
 
 
 class TestVumiApiEvent(TestCase):
     def test_default_routing_config(self):
         cfg = VumiApiEvent.default_routing_config()
-        self.assertEqual(set(cfg.keys()),
-                         set(['exchange', 'exchange_type', 'routing_key']))
+        self.assertEqual(cfg, {
+            'exchange': 'vumi',
+            'exchange_type': 'direct',
+            'routing_key': 'vumi.event',
+            'durable': True,
+            })
 
     def test_event(self):
         event = VumiApiEvent.event(


### PR DESCRIPTION
Our command & event default routing config assumes that our exchange is
set to being durable, while the call itself has it set to being False by
default, which is wrong.
