### PR TITLE
Fix confirm post tests and possibly protect against double-confirm race condition

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -428,8 +428,7 @@ class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertContains(response, conversation.subject)
         self.assertContains(response, conversation.message)
         self.assertContains(response, "Conversation confirmed")
-        self.assertContains(response, "%s started succesfully!" %
-                            conversation.name)
+        self.assertContains(response, "Conversation started succesfully!")
 
         # reload the conversation because batches are cached.
         conversation = self.user_api.get_wrapped_conversation(conversation.key)
@@ -467,7 +466,7 @@ class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):
 
         # check token was consumed so it can't be re-used to send the
         # conversation messages again
-        self.assertEqual(self.tm.verify_get(token), None)
+        self.assertEqual(self.tm.get(token), None)
 
         # check repost fails because token has been deleted
         response = self.client.post(reverse('bulk_message:confirm', kwargs={

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -272,11 +272,13 @@ class ConfirmConversationView(ConversationView):
         if confirmation_form.is_valid():
             try:
                 batch_id = conversation.get_latest_batch_key()
-                conversation.start(batch_id=batch_id, **params)
-                token_manager.delete(user_token)
-                messages.info(request, '%s started succesfully!' %
-                              (self.conversation_display_name,))
-                success = True
+                if token_manager.delete(user_token):
+                    conversation.start(batch_id=batch_id, **params)
+                    messages.info(request, '%s started succesfully!' %
+                                  (self.conversation_display_name,))
+                    success = True
+                else:
+                    messages.warning("Conversation already confirmed!")
             except ConversationSendError as error:
                 messages.error(request, str(error))
         else:


### PR DESCRIPTION
The post confirm test is failing (it asserts the wrong things) and there is a possibility of double-confirming a conversation if two HTTP requests are handled simultaneously.
