### PR TITLE
Protect against importing production settings during tests.

### DIFF
--- a/go/testsettings.py
+++ b/go/testsettings.py
@@ -1,4 +1,12 @@
 import os
+import sys
+import types
+
+# protect against importing production settings
+for name in ('production_settings', 'go.production_settings'):
+    sys.modules[name] = types.ModuleType(name)
+
+
 from settings import *
 
 


### PR DESCRIPTION
Currently testsettings does `from settings import *` which attempts `from production_settings import *`. If one happens to have `production_settings.py` in ones checkout, tests can failing confusingly.

One solution is to remove the `from production_settings import *` from `settings.py` and instead do `from go.settings import *` in `production_settings` and then use `production_settings` as the Django settings module everywhere.

An alternative is to put dummy `production_settings` and `go.production_settings` modules in sys.modules in `go.testsettings` (might be confusing if `go.testsettings` is imported outside of tests).
