### PR TITLE
The Sent message list displays the contact for the `from_addr`

### DIFF
--- a/go/conversation/templates/generic/includes/message-list.html
+++ b/go/conversation/templates/generic/includes/message-list.html
@@ -11,7 +11,7 @@
     <tbody>
         {% for message in message_page.object_list %}
         <tr>
-            {% get_contact_for_message request.user_api message as contact %}
+            {% get_contact_for_message request.user_api message message_direction as contact %}
             <td><i class="icon-repeat"></i> {{conversation.delivery_class}}</td>
             <td>
                 <h6><a href="{% url 'contacts:person' person_key=contact.key %}">{{contact}}</a> via {{message.transport_type}} - {{message.timestamp}}</h6>

--- a/go/conversation/templatetags/conversation_tags.py
+++ b/go/conversation/templatetags/conversation_tags.py
@@ -114,7 +114,7 @@ def show_conversation_messages(context, conversation, direction=None,
 
 
 @register.assignment_tag
-def get_contact_for_message(user_api, message):
+def get_contact_for_message(user_api, message, direction='inbound'):
     # This is a temporary work around to deal with the hackiness that
     # lives in `contact_for_addr()`. It used to expect to be passed a
     # `conversation.delivery_class` and this emulates that.
@@ -128,8 +128,9 @@ def get_contact_for_message(user_api, message):
         TransportUserMessage.TT_TWITTER: 'twitter',
     }.get(message['transport_type'],
           message['transport_type'])
+    user = message.user() if direction == 'inbound' else message['to_addr']
     return user_api.contact_store.contact_for_addr(
-        delivery_class, unicode(message.user()))
+        delivery_class, unicode(user))
 
 
 @register.assignment_tag


### PR DESCRIPTION
Since this is usually the same, it's not very exciting. Sent messages should display the contact for the `to_addr` instead. This requires adding a `direction` argument to `get_contact_for_message` in `go.conversation.templatetags.conversation_tags` and then using that from the message list template.
