### PR TITLE
http api should respond with correct content-type

### DIFF
--- a/go/apps/http_api/client.py
+++ b/go/apps/http_api/client.py
@@ -63,7 +63,8 @@ class VumiMessageReceiver(basic.LineReceiver):
 class StreamingClient(object):
 
     def __init__(self, persistent=True):
-        self.agent = Agent(reactor, pool=self.get_pool(persistent))
+        self.pool = self.get_pool(persistent)
+        self.agent = Agent(reactor, pool=self.pool)
 
     def get_pool(self, persistent):
         return HTTPConnectionPool(reactor, persistent=persistent)

--- a/go/apps/http_api/client.py
+++ b/go/apps/http_api/client.py
@@ -2,8 +2,7 @@ import json
 
 from twisted.internet.defer import Deferred
 from twisted.internet import reactor
-from twisted.web.client import (Agent, ResponseDone, ResponseFailed,
-    HTTPConnectionPool)
+from twisted.web.client import Agent, ResponseDone, ResponseFailed
 from twisted.web import http
 from twisted.protocols import basic
 
@@ -62,12 +61,8 @@ class VumiMessageReceiver(basic.LineReceiver):
 
 class StreamingClient(object):
 
-    def __init__(self, persistent=True):
-        self.pool = self.get_pool(persistent)
-        self.agent = Agent(reactor, pool=self.pool)
-
-    def get_pool(self, persistent):
-        return HTTPConnectionPool(reactor, persistent=persistent)
+    def __init__(self):
+        self.agent = Agent(reactor)
 
     def stream(self, message_class, callback, errback, url, headers=None):
         receiver = VumiMessageReceiver(message_class, callback, errback)

--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -62,7 +62,7 @@ class StreamResource(BaseResource):
 
     def render_GET(self, request):
         resp_headers = request.responseHeaders
-        request.defaultContentType = self.content_type
+        resp_headers.addRawHeader('Content-Type', self.content_type)
         # Turn off proxy buffering, nginx will otherwise buffer our streaming
         # output which makes clients sad.
         # See #proxy_buffering at

--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -48,7 +48,7 @@ class StreamResource(BaseResource):
     message_class = None
     proxy_buffering = False
     encoding = 'utf-8'
-    defaultContentType = 'application/json; charset=%s' % (encoding,)
+    content_type = 'application/json; charset=%s' % (encoding,)
 
     def __init__(self, worker, conversation_key):
         BaseResource.__init__(self, worker, conversation_key)
@@ -62,7 +62,7 @@ class StreamResource(BaseResource):
 
     def render_GET(self, request):
         resp_headers = request.responseHeaders
-        request.defaultContentType = 'application/json; charset=utf-8'
+        request.defaultContentType = self.content_type
         # Turn off proxy buffering, nginx will otherwise buffer our streaming
         # output which makes clients sad.
         # See #proxy_buffering at


### PR DESCRIPTION
```
> GET /api/v1/go/http_api/xxxxxxxx/messages.json HTTP/1.1
> Authorization: Basic xxxxxxxxxxxxxxxxxxxxxxxx
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5
> Host: go.vumi.org
> Accept: */*
> Connection: keep-alive
>
< HTTP/1.1 200 OK
< Server: nginx/0.7.65
< Date: Mon, 01 Apr 2013 08:57:39 GMT
< Content-Type: text/html
< Transfer-Encoding: chunked
< Connection: close
<
```

The `Content-Type: text/html` in the response should in this case be `Content-Type: application/javascript; charset=utf-8`
