### PR TITLE
ContactsResource update and new api methods need to set contact fields better

### DIFF
--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -121,11 +121,11 @@ class ContactsResource(SandboxResource):
     @inlineCallbacks
     def handle_new(self, api, command):
         try:
-            if 'fields' not in command:
+            if 'contact' not in command:
                 raise SandboxError(
-                    "'fields' needs to be specified for command")
+                    "'contact' needs to be specified for command")
 
-            fields = self.pick_fields(command['fields'],
+            fields = self.pick_fields(command['contact'],
                                       *Contact.field_descriptors)
             contact_store = self._contact_store_for_api(api)
             contact = yield contact_store.new_contact(**fields)

--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -73,8 +73,13 @@ class ContactsResource(SandboxResource):
             if 'key' not in command:
                 raise SandboxError("'key' needs to be specified for command")
 
+            if 'fields' not in command:
+                raise SandboxError(
+                    "'fields' needs to be specified for command")
+
             store = self._contact_store_for_api(api)
-            fields = self.pick_fields(command, *Contact.field_descriptors)
+            fields = self.pick_fields(
+                command['fields'], *Contact.field_descriptors)
             yield store.update_contact(command['key'], **fields)
         except (SandboxError, ContactError) as e:
             log.warning(str(e))
@@ -115,8 +120,18 @@ class ContactsResource(SandboxResource):
 
     @inlineCallbacks
     def handle_new(self, api, command):
-        contact = yield self._contact_store_for_api(api).new_contact(
-            **self.pick_fields(command, *Contact.field_descriptors))
+        try:
+            if 'fields' not in command:
+                raise SandboxError(
+                    "'fields' needs to be specified for command")
+
+            fields = self.pick_fields(command['fields'],
+                                      *Contact.field_descriptors)
+            contact_store = self._contact_store_for_api(api)
+            contact = yield contact_store.new_contact(**fields)
+        except (SandboxError, ContactError) as e:
+            log.warning(str(e))
+            returnValue(self.reply(command, success=False, reason=unicode(e)))
 
         returnValue(self.reply(
             command,

--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -128,12 +128,9 @@ class ContactsResource(SandboxResource):
             fields = self.pick_fields(command['fields'],
                                       *Contact.field_descriptors)
             contact_store = self._contact_store_for_api(api)
-            contact = yield contact_store.new_contact(**fields)
+            yield contact_store.new_contact(**fields)
         except (SandboxError, ContactError) as e:
             log.warning(str(e))
             returnValue(self.reply(command, success=False, reason=unicode(e)))
 
-        returnValue(self.reply(
-            command,
-            success=True,
-            contact=contact.get_data()))
+        returnValue(self.reply(command, success=True))

--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -128,9 +128,9 @@ class ContactsResource(SandboxResource):
             fields = self.pick_fields(command['fields'],
                                       *Contact.field_descriptors)
             contact_store = self._contact_store_for_api(api)
-            yield contact_store.new_contact(**fields)
+            contact = yield contact_store.new_contact(**fields)
         except (SandboxError, ContactError) as e:
             log.warning(str(e))
             returnValue(self.reply(command, success=False, reason=unicode(e)))
 
-        returnValue(self.reply(command, success=True))
+        returnValue(self.reply(command, success=True, key=contact.key))

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -185,9 +185,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             msisdn=u'+27831234567')
 
         reply = yield self.dispatch_command(
-            'update',
-            key=contact.key,
-            surname=u'Jackal')
+            'update', key=contact.key, fields={'surname': u'Jackal'})
         self.check_reply(reply)
 
         self.check_contact_fields(
@@ -204,9 +202,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             msisdn=u'+27831234567')
 
         reply = yield self.dispatch_command(
-            'update',
-            key=contact.key,
-            surname=u'☃')
+            'update', key=contact.key, fields={'surname': u'☃'})
         self.check_reply(reply)
 
         self.check_contact_fields(
@@ -217,7 +213,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
 
     @inlineCallbacks
     def test_handle_update_for_nonexistent_contacts(self):
-        reply = yield self.dispatch_command('update', key='213123')
+        reply = yield self.dispatch_command('update', key='213123', fields={})
         self.check_reply(reply, success=False)
 
     @inlineCallbacks
@@ -316,11 +312,11 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
 
     @inlineCallbacks
     def test_handle_new(self):
-        reply = yield self.dispatch_command(
-            'new',
-            name=u'A Random',
-            surname=u'Jackal',
-            msisdn=u'+27831234567')
+        reply = yield self.dispatch_command('new', fields={
+            'name': u'A Random',
+            'surname': u'Jackal',
+            'msisdn': u'+27831234567',
+        })
 
         self.check_contact_reply(
             reply,
@@ -330,13 +326,14 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
 
     @inlineCallbacks
     def test_handle_new_for_unicode_chars(self):
-        reply = yield self.dispatch_command(
-            'new',
-            name=u'A Random',
-            surname=u'☃',
-            msisdn=u'+27831234567')
+        reply = yield self.dispatch_command('new', fields={
+            'name': u'A Random',
+            'surname': u'☃',
+            'msisdn': u'+27831234567',
+        })
 
-        self.check_contact_reply(reply,
+        self.check_contact_reply(
+            reply,
             name=u'A Random',
             surname=u'☃',
             msisdn=u'+27831234567')

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -202,13 +202,13 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             msisdn=u'+27831234567')
 
         reply = yield self.dispatch_command(
-            'update', key=contact.key, fields={'surname': u'☃'})
+            'update', key=contact.key, fields={'surname': u'Robot'})
         self.check_reply(reply)
 
         self.check_contact_fields(
             contact.key,
             name=u'A Random',
-            surname=u'☃',
+            surname=u'Robot',
             msisdn=u'+27831234567')
 
     @inlineCallbacks
@@ -328,12 +328,12 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
     def test_handle_new_for_unicode_chars(self):
         reply = yield self.dispatch_command('new', fields={
             'name': u'A Random',
-            'surname': u'☃',
+            'surname': u'Robot',
             'msisdn': u'+27831234567',
         })
 
         self.check_contact_reply(
             reply,
             name=u'A Random',
-            surname=u'☃',
+            surname=u'Robot',
             msisdn=u'+27831234567')

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -312,7 +312,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
 
     @inlineCallbacks
     def test_handle_new(self):
-        reply = yield self.dispatch_command('new', fields={
+        reply = yield self.dispatch_command('new', contact={
             'name': u'A Random',
             'surname': u'Jackal',
             'msisdn': u'+27831234567',
@@ -322,7 +322,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
 
     @inlineCallbacks
     def test_handle_new_for_unicode_chars(self):
-        reply = yield self.dispatch_command('new', fields={
+        reply = yield self.dispatch_command('new', contact={
             'name': u'A Random',
             'surname': u'Robot',
             'msisdn': u'+27831234567',

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -318,11 +318,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             'msisdn': u'+27831234567',
         })
 
-        self.check_contact_reply(
-            reply,
-            name=u'A Random',
-            surname=u'Jackal',
-            msisdn=u'+27831234567')
+        self.check_contact_reply(reply)
 
     @inlineCallbacks
     def test_handle_new_for_unicode_chars(self):
@@ -332,8 +328,4 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             'msisdn': u'+27831234567',
         })
 
-        self.check_contact_reply(
-            reply,
-            name=u'A Random',
-            surname=u'Robot',
-            msisdn=u'+27831234567')
+        self.check_contact_reply(reply)


### PR DESCRIPTION
Currently, ContactsResource's `.update()` and `.new()` methods need command objects like this to update a contact's fields: 

``` js
{key: '123abc', some_field: 'some_field_value'}
```

The following is command format is nicer  and allows a contact to have `key` field:

``` js
{key: '123abc', fields: {some_field: 'some_field_value'}}
```
