### PR TITLE
ContactStore.contact_for_addr() needs to use load_all_bunches

### DIFF
--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -7,7 +7,7 @@ from twisted.internet.defer import returnValue
 
 from vumi.persist.model import Model, Manager
 from vumi.persist.fields import (Unicode, ManyToMany, ForeignKey, Timestamp,
-                                    Dynamic)
+                                 Dynamic)
 
 from go.vumitools.account import UserAccount, PerAccountStore
 from go.vumitools.opt_out import OptOutStore
@@ -298,7 +298,11 @@ class ContactStore(PerAccountStore):
         keys = yield self.contacts.search(**field).get_keys()
 
         if keys:
-            returnValue((yield self.contacts.load(keys[0])))
+            contacts = []
+            bunches = yield self.contacts.load_all_bunches(keys)
+            for bunch in bunches:
+                contacts.extend((yield bunch))
+            returnValue(max(contacts, key=lambda c: c.created_at))
 
         if create:
             contact_id = uuid4().get_hex()

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -302,7 +302,11 @@ class ContactStore(PerAccountStore):
             bunches = yield self.contacts.load_all_bunches(keys)
             for bunch in bunches:
                 contacts.extend((yield bunch))
-            returnValue(max(contacts, key=lambda c: c.created_at))
+            # All the matches we get back may have been deleted from Riak,
+            # if that's the case then just continue and create if that's
+            # been requested.
+            if contacts:
+                returnValue(max(contacts, key=lambda c: c.created_at))
 
         if create:
             contact_id = uuid4().get_hex()


### PR DESCRIPTION
Currently we're doing a `load(keys[0])`. The first key we get back might have been deleted from Riak, `load_all_bunches(keys)` filters out the deleted ones.

When this happens the `load(keys[0])` returns a `None` instead of a contact instance.
