### PR TITLE
drop django-compressor dependency.

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -93,7 +93,6 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
-    'compressor.finders.CompressorFinder',
 )
 
 # Make this unique, and don't share it with anybody.
@@ -149,7 +148,6 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     'django.contrib.admindocs',
-    'compressor',
     'south',
     'gunicorn',
     'django_nose',

--- a/go/templates/base.html
+++ b/go/templates/base.html
@@ -1,6 +1,5 @@
 <!doctype html>
 {% load url from future %}
-{% load compress %}
 <!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
 <!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->

--- a/requirements.pip
+++ b/requirements.pip
@@ -16,10 +16,6 @@ https://github.com/praekelt/vumi/tarball/develop#egg=vumi-dev
 https://github.com/praekelt/vxpolls/tarball/develop#egg=vxpolls-dev
 Markdown==2.1.1
 django-registration==0.8
-# django_compressor==1.1.2 on Pypi has a bug, install from GitHub
-# until a new version has been published to pypi
-# -e git+git://github.com/jezdez/django_compressor@236e0d711#egg=compressor
-django_compressor>=1.2
 lesscpy==0.9h
 xlrd==0.8.0
 # -e git+git://github.com/earle/django-bootstrap.git@9ec5697#egg=bootstrap


### PR DESCRIPTION
It isn't used anywhere and is just cluttering our settings.py and various packaging things. See #224 for details.
