### PR TITLE
go_setup_env needs updating for allowing non-localhost connections

### DIFF
--- a/go/base/management/commands/go_setup_env.py
+++ b/go/base/management/commands/go_setup_env.py
@@ -106,6 +106,11 @@ class Command(BaseCommand):
             default='7101',
             help='The port supervisord should listen on.'),
         make_option(
+            '--webapp-bind',
+            dest='webapp_bind',
+            default='127.0.0.1:8000',
+            help='The host:addr that the Django webapp should bind to.'),
+        make_option(
             '--skip-startup-script',
             dest='write_startup_script',
             default=True,
@@ -127,6 +132,7 @@ class Command(BaseCommand):
         self.dest_dir = options['dest_dir']
         self.supervisord_host = options['supervisord_host']
         self.supervisord_port = options['supervisord_port']
+        self.webapp_bind = options['webapp_bind']
 
         self.contact_group_info = []
         self.conversation_info = []
@@ -500,7 +506,9 @@ class Command(BaseCommand):
             fp.write(self.auto_gen_warning)
             cp = ConfigParser()
             cp.add_section(section)
-            cp.set(section, "command", "./go-admin.sh runserver --noreload")
+            cp.set(
+                section, "command", "./go-admin.sh runserver %s --noreload" % (
+                    self.webapp_bind,))
             cp.set(section, "stdout_logfile",
                    "./logs/%(program_name)s_%(process_num)s.log")
             cp.set(section, "stderr_logfile",

--- a/go/base/tests/test_go_setup_env.py
+++ b/go/base/tests/test_go_setup_env.py
@@ -304,13 +304,15 @@ class GoBootstrapEnvTestCase(DjangoGoApplicationTestCase):
     def test_create_webui_supervisord_conf(self):
         fake_file = FakeFile()
         self.command.open_file = Mock(side_effect=[fake_file])
+        self.command.webapp_bind = '[::]:8000'
         self.command.create_webui_supervisord_conf()
         fake_file.seek(0)
         webui_cp = ConfigParser()
         webui_cp.readfp(fake_file)
         self.assertTrue(webui_cp.has_section('program:webui'))
         webui_command = webui_cp.get('program:webui', 'command')
-        self.assertEqual('./go-admin.sh runserver --noreload', webui_command)
+        self.assertEqual('./go-admin.sh runserver [::]:8000 --noreload',
+                         webui_command)
 
     def test_group_loading(self):
         self.command.setup_tagpools(self.tagpool_file.name)


### PR DESCRIPTION
Allows mapped ports from a vagrant host machine etc.
https://gist.github.com/anonymous/23701bd31a944d79f8f0
