### PR TITLE
ConversationWrapper get_opted_in_addresses and get_opted_in_contacts are being skipped

### DIFF
--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -25,8 +25,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         # Get a dummy worker so we have an amqp_client which we need
         # to set-up the MessageSender in the `VumiApi`
         self.worker = yield self.get_application({})
-        self.api = yield VumiApi.from_config_async(self.mk_config({}),
-            amqp_client=self.worker._amqp_client)
+        self.api = yield VumiApi.from_config_async(
+            self.mk_config({}), amqp_client=self.worker._amqp_client)
         self.mdb = self.api.mdb
         self.user = yield self.mk_user(self.api, u'username')
         self.user_api = self.api.get_user_api(self.user.key)
@@ -48,7 +48,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
             "transport_type": "sms",
             "server_initiated": True,
             "transport_name": self.transport_name,
-            }
+        }
         defaults.update(metadata or {})
         yield self.api.tpm.set_metadata(name, defaults)
         yield self.add_tagpool_permission(name)
@@ -62,17 +62,17 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def store_inbound(self, batch_key, count=10, addr_template='from-{0}',
-                        content_template='hello world {0}',
-                        start_timestamp=None, time_multiplier=10,
-                        helper_metadata=None):
+                      content_template='hello world {0}',
+                      start_timestamp=None, time_multiplier=10,
+                      helper_metadata=None):
         inbound = []
-        now = start_timestamp or datetime.now().replace(hour=23, minute=59,
-                                                    second=59, microsecond=999)
+        now = start_timestamp or datetime.now().replace(
+            hour=23, minute=59, second=59, microsecond=999)
         for i in range(count):
             msg_in = self.mkmsg_in(from_addr=addr_template.format(i),
-                message_id=TransportMessage.generate_id(),
-                content=content_template.format(i),
-                helper_metadata=helper_metadata)
+                                   message_id=TransportMessage.generate_id(),
+                                   content=content_template.format(i),
+                                   helper_metadata=helper_metadata)
             msg_in['timestamp'] = now - timedelta(hours=i * time_multiplier)
             yield self.mdb.add_inbound_message(msg_in, batch_id=batch_key)
             inbound.append(msg_in)
@@ -80,17 +80,17 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def store_outbound(self, batch_key, count=10, addr_template='to-{0}',
-                        content_template='hello world {0}',
-                        start_timestamp=None, time_multiplier=10,
-                        helper_metadata=None):
+                       content_template='hello world {0}',
+                       start_timestamp=None, time_multiplier=10,
+                       helper_metadata=None):
         outbound = []
-        now = start_timestamp or datetime.now().replace(hour=23, minute=59,
-                                                    second=59, microsecond=999)
+        now = start_timestamp or datetime.now().replace(
+            hour=23, minute=59, second=59, microsecond=999)
         for i in range(count):
             msg_out = self.mkmsg_out(to_addr=addr_template.format(i),
-                message_id=TransportMessage.generate_id(),
-                content=content_template.format(i),
-                helper_metadata=helper_metadata)
+                                     message_id=TransportMessage.generate_id(),
+                                     content=content_template.format(i),
+                                     helper_metadata=helper_metadata)
             msg_out['timestamp'] = now - timedelta(hours=i * time_multiplier)
             yield self.mdb.add_outbound_message(msg_out, batch_id=batch_key)
             outbound.append(msg_out)
@@ -104,7 +104,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         for message in messages:
             event_maker = getattr(self, 'mkmsg_%s' % (event_type,))
             event = event_maker(user_message_id=message['message_id'],
-                **kwargs)
+                                **kwargs)
             yield self.mdb.add_event(event)
             events.append(event)
         returnValue(events)
@@ -121,7 +121,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
         now = datetime.now()
         yield self.store_outbound(batch1,
-                                    start_timestamp=now - timedelta(days=1))
+                                  start_timestamp=now - timedelta(days=1))
         yield self.store_outbound(batch2, start_timestamp=now)
 
         conv = yield self.user_api.get_wrapped_conversation(self.conv.key)
@@ -144,21 +144,23 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_count_inbound_uniques(self):
         yield self.conv.start()
-        yield self.store_inbound((yield self.conv.get_latest_batch_key()),
-                                    count=5)
+        yield self.store_inbound(
+            (yield self.conv.get_latest_batch_key()), count=5)
         self.assertEqual((yield self.conv.count_inbound_uniques()), 5)
-        yield self.store_inbound((yield self.conv.get_latest_batch_key()),
-                                    count=5, addr_template='from')
+        yield self.store_inbound(
+            (yield self.conv.get_latest_batch_key()),
+            count=5, addr_template='from')
         self.assertEqual((yield self.conv.count_inbound_uniques()), 6)
 
     @inlineCallbacks
     def test_count_outbound_uniques(self):
         yield self.conv.start()
-        yield self.store_outbound((yield self.conv.get_latest_batch_key()),
-                                    count=5)
+        yield self.store_outbound(
+            (yield self.conv.get_latest_batch_key()), count=5)
         self.assertEqual((yield self.conv.count_outbound_uniques()), 5)
-        yield self.store_outbound((yield self.conv.get_latest_batch_key()),
-                                    count=5, addr_template='from')
+        yield self.store_outbound(
+            (yield self.conv.get_latest_batch_key()),
+            count=5, addr_template='from')
         self.assertEqual((yield self.conv.count_outbound_uniques()), 6)
 
     @inlineCallbacks
@@ -181,8 +183,9 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
                 'sensitive': True,
             }})
         self.assertEqual([], (yield self.conv.received_messages()))
-        self.assertEqual(20, len((yield self.conv.received_messages(
-                                        include_sensitive=True))))
+        self.assertEqual(
+            20,
+            len((yield self.conv.received_messages(include_sensitive=True))))
 
     @inlineCallbacks
     def test_received_messages_include_sensitive_and_scrub(self):
@@ -231,8 +234,9 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
                 'sensitive': True,
             }})
         self.assertEqual([], (yield self.conv.sent_messages()))
-        self.assertEqual(20, len((yield self.conv.sent_messages(
-                                        include_sensitive=True))))
+        self.assertEqual(
+            20,
+            len((yield self.conv.sent_messages(include_sensitive=True))))
 
     @inlineCallbacks
     def test_sent_messages_include_sensitive_and_scrub(self):
@@ -275,11 +279,11 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         yield self.store_event(outbound, 'ack', count=8)
         yield self.store_event(outbound, 'nack', count=2)
         yield self.store_event(outbound, 'delivery', count=4,
-            status='delivered')
+                               status='delivered')
         yield self.store_event(outbound, 'delivery', count=1,
-            status='failed')
+                               status='failed')
         yield self.store_event(outbound, 'delivery', count=1,
-            status='pending')
+                               status='pending')
         self.assertEqual((yield self.conv.get_progress_status()), {
             'sent': 10,
             'ack': 8,
@@ -288,7 +292,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
             'delivery_report_delivered': 4,
             'delivery_report_failed': 1,
             'delivery_report_pending': 1,
-            })
+        })
 
     @inlineCallbacks
     def test_get_progress_percentage_acks(self):
@@ -319,7 +323,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.conv.c.delivery_tag_pool = u"shortcode"
         yield self.conv.save()
         yield self.assertFailure(self.conv.acquire_tag(),
-            ConversationSendError)
+                                 ConversationSendError)
 
     @inlineCallbacks
     def test_acquire_tag_if_tag_unavailable(self):
@@ -327,7 +331,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         self.conv.c.delivery_tag = u'this-does-not-exist'
         yield self.conv.save()
         yield self.assertFailure(self.conv.acquire_tag(),
-            ConversationSendError)
+                                 ConversationSendError)
 
     def test_get_opted_in_contacts(self):
         raise SkipTest("Waiting for API to stabilize")
@@ -360,10 +364,9 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
             (yield self.conv.get_outbound_throughput(sample_time=20)), 60)
 
     @inlineCallbacks
-    def do_search(self, conv, direction, *args,
-                                    **kwargs):
-        batch_key = kwargs.get('batch_key',
-                            (yield self.conv.get_latest_batch_key()))
+    def do_search(self, conv, direction, *args, **kwargs):
+        batch_key = kwargs.get(
+            'batch_key', (yield self.conv.get_latest_batch_key()))
         search_callback = {
             'inbound': conv.find_inbound_messages_matching,
             'outbound': conv.find_outbound_messages_matching,
@@ -462,7 +465,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         outbound_aggregate = yield self.conv.get_aggregate_keys('outbound')
         bucket_keys = [bucket for bucket, _ in outbound_aggregate]
         buckets = [keys for _, keys in outbound_aggregate]
-        self.assertEqual(bucket_keys,
+        self.assertEqual(
+            bucket_keys,
             [datetime.now().date() - timedelta(days=i)
                 for i in range(9, -1, -1)])
         for bucket in buckets:
@@ -478,7 +482,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         outbound_aggregate = yield self.conv.get_aggregate_count('outbound')
         bucket_keys = [bucket for bucket, _ in outbound_aggregate]
         buckets = [keys for _, keys in outbound_aggregate]
-        self.assertEqual(bucket_keys,
+        self.assertEqual(
+            bucket_keys,
             [datetime.now().date() - timedelta(days=i)
                 for i in range(9, -1, -1)])
         for bucket in buckets:

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -373,8 +373,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         })
 
         self.assertEqual(
-            set(['+27000000001']),
-            set((yield get_contacts())))
+            ['+27000000001'],
+            (yield get_contacts()))
 
     @inlineCallbacks
     def test_get_inbound_throughput(self):


### PR DESCRIPTION
```
$ trial go/vumitools/conversation/tests/test_utils.py
go.vumitools.conversation.tests.test_utils
  ConversationWrapperTestCase

    test_get_opted_in_addresses ...                                  [SKIPPED]
    test_get_opted_in_contacts ...                                    [SKIPPED]

[SKIPPED]
Waiting for API to stabilize
```
