### PR TITLE
Fix bug in new Outbound resource and add tests.

### DIFF
--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -48,8 +48,8 @@ class GoOutboundResource(SandboxResource):
         d = reply_func(orig_msg, content, continue_session=continue_session,
                        helper_metadata=helper_metadata)
         d.addCallback(lambda r: self.reply(command, success=True))
-        d.addErrback(lambda f: self.reply(command, success=False,
-                                          reason=unicode(f.getErrorMessage())))
+        d.addErrback(lambda f: self._mkfail(command,
+                                            unicode(f.getErrorMessage())))
         return d
 
     def handle_reply_to(self, api, command):

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -10,7 +10,11 @@ from vumi import log
 
 
 class GoOutboundResource(SandboxResource):
-    """Resource that provides outbound message support for Go."""
+    """Resource that provides outbound message support for Go.
+
+    Includes support for replying, replying to groups and sending
+    messages via given tags.
+    """
 
     def _handle_reply(self, api, command, reply_func):
         if 'content' not in command:
@@ -41,13 +45,82 @@ class GoOutboundResource(SandboxResource):
         return d
 
     def handle_reply_to(self, api, command):
+        """
+        Sends a reply to the individual who sent a received message.
+
+        Command fields:
+            - ``content``: The body of the reply message.
+            - ``in_reply_to``: The ``message id`` of the message being replied
+            to.
+            - ``continue_session``: Whether to continue the session (if any).
+            Defaults to ``true``.
+
+        Reply fields:
+            - ``success``: ``true`` if the operation was successful, otherwise
+            ``false``.
+
+        Example:
+        .. code-block:: javascript
+            api.request(
+                'outbound.reply_to',
+                {content: 'Welcome!',
+                 in_reply_to: '06233d4eede945a3803bf9f3b78069ec'},
+                function(reply) { api.log_info('Reply sent: ' +
+                                               reply.success); });
+        """
         return self._handle_reply(api, command, self.app_worker.reply_to)
 
     def handle_reply_to_group(self, api, command):
+        """
+        Sends a reply to the group from which a received message was sent.
+
+        Command fields:
+            - ``content``: The body of the reply message.
+            - ``in_reply_to``: The ``message id`` of the message being replied
+            to.
+            - ``continue_session``: Whether to continue the session (if any).
+            Defaults to ``true``.
+
+        Reply fields:
+            - ``success``: ``true`` if the operation was successful, otherwise
+            ``false``.
+
+        Example:
+        .. code-block:: javascript
+            api.request(
+                'outbound.reply_to_group',
+                {content: 'Welcome!',
+                 in_reply_to: '06233d4eede945a3803bf9f3b78069ec'},
+                function(reply) { api.log_info('Reply to group sent: ' +
+                                               reply.success); });
+        """
         return self._handle_reply(api, command, self.app_worker.reply_to_group)
 
     @inlineCallbacks
     def handle_send_to_tag(self, api, command):
+        """
+        Sends a message to a specified tag.
+
+        Command fields:
+            - ``content``: The body of the reply message.
+            - ``to_addr``: The address of the recipient (e.g. an MSISDN).
+            - ``tagpool``: The name of the tagpool to send the message via.
+            - ``tag``: The name of the tag (within the tagpool) to send the
+            message from. Your Go user account must have the tag acquired.
+
+        Reply fields:
+            - ``success``: ``true`` if the operation was successful, otherwise
+            ``false``.
+
+        Example:
+        .. code-block:: javascript
+            api.request(
+                'outbound.send_to_tag',
+                {content: 'Welcome!', to_addr: '+27831234567',
+                 tagpool: 'vumi_long', tag: 'default10001'},
+                function(reply) { api.log_info('Message sent: ' +
+                                               reply.success); });
+        """
         tag = (command.get('tagpool'), command.get('tag'))
         content = command.get('content')
         to_addr = command.get('to_addr')

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -17,14 +17,19 @@ class GoOutboundResource(SandboxResource):
     """
 
     def _handle_reply(self, api, command, reply_func):
-        if 'content' not in command:
+        if not isinstance(command.get('content'), unicode):
             return succeed(self.reply(
                 command, success=False,
                 reason=u"'content' must be given in replies."))
-        if 'in_reply_to' not in command:
+        if not isinstance(command.get('in_reply_to'), unicode):
             return succeed(self.reply(
                 command, success=False,
                 reason=u"'in_reply_to' must be given in replies."))
+        if command.get('continue_session', True) not in (True, False):
+            return succeed(self.reply(
+                command, success=False,
+                reason=u"'continue_session' must be either true or false"
+                " if given"))
         orig_msg = api.get_inbound_message(command['in_reply_to'])
         if orig_msg is None:
             return succeed(self.reply(
@@ -124,7 +129,8 @@ class GoOutboundResource(SandboxResource):
         tag = (command.get('tagpool'), command.get('tag'))
         content = command.get('content')
         to_addr = command.get('to_addr')
-        if None in (tag[0], tag[1], content, to_addr):
+        if any(not isinstance(u, unicode)
+               for u in (tag[0], tag[1], content, to_addr)):
             returnValue(self.reply(
                 command, success=False,
                 reason="Tag, content or to_addr not specified"))

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -3,23 +3,42 @@
 
 """Outbound message resource for JS Box sandboxes"""
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue, succeed
 
-from vumi.application.sandbox import OutboundResource
+from vumi.application.sandbox import SandboxResource
 from vumi import log
 
 
-class GoOutboundResource(OutboundResource):
+class GoOutboundResource(SandboxResource):
     """Resource that provides outbound message support for Go."""
 
     def _handle_reply(self, api, command, reply_func):
+        if 'content' not in command:
+            return succeed(self.reply(
+                command, success=False,
+                reason=u"'content' must be given in replies."))
+        if 'in_reply_to' not in command:
+            return succeed(self.reply(
+                command, success=False,
+                reason=u"'in_reply_to' must be given in replies."))
+        orig_msg = api.get_inbound_message(command['in_reply_to'])
+        if orig_msg is None:
+            return succeed(self.reply(
+                command, success=False, reason=u"Could not find original"
+                " message with id: %r" % command['in_reply_to']))
+
         content = command['content']
         continue_session = command.get('continue_session', True)
-        orig_msg = api.get_inbound_message(command['in_reply_to'])
         conv = self.app_worker.conversation_for_api(api)
-        helper_metadata = conv.set_go_helper_metadata()
-        return reply_func(orig_msg, content, continue_session=continue_session,
-                          helper_metadata=helper_metadata)
+        helper_metadata = conv.set_go_helper_metadata(
+            orig_msg['helper_metadata'])
+
+        d = reply_func(orig_msg, content, continue_session=continue_session,
+                       helper_metadata=helper_metadata)
+        d.addCallback(lambda r: self.reply(command, success=True))
+        d.addErrback(lambda f: self.reply(command, success=False,
+                                          reason=unicode(f.getErrorMessage())))
+        return d
 
     def handle_reply_to(self, api, command):
         return self._handle_reply(api, command, self.app_worker.reply_to)
@@ -53,8 +72,3 @@ class GoOutboundResource(OutboundResource):
             to_addr, content, endpoint=endpoint, **msg_options)
 
         returnValue(self.reply(command, success=True))
-
-    def handle_send_to(self, api, command):
-        # Generic sending is not supported in Vumi Go sandboxes
-        return self.reply(command, success=False,
-                          reason="Generic sending not supported in Vumi Go")

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -23,9 +23,12 @@ class GoOutboundResource(SandboxResource):
         return succeed(self._mkfail(command, reason))
 
     def _handle_reply(self, api, command, reply_func):
-        if not isinstance(command.get('content'), unicode):
+        if not 'content' in command:
             return self._mkfaild(
                 command, reason=u"'content' must be given in replies.")
+        if not isinstance(command['content'], (unicode, type(None))):
+            return self._mkfaild(
+                command, reason=u"'content' must be unicode or null.")
         if not isinstance(command.get('in_reply_to'), unicode):
             return self._mkfaild(
                 command, reason=u"'in_reply_to' must be given in replies.")

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -1,91 +1,196 @@
 """Tests for go.apps.jsbox.outbound."""
 
-import mock
+from mock import Mock
 
-from twisted.trial.unittest import TestCase
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, succeed
 
-from vumi.application.sandbox import SandboxCommand
+from vumi.message import TransportUserMessage
 from vumi.tests.utils import LogCatcher
+from vumi.application.tests.test_sandbox import (
+    ResourceTestCaseBase, DummyAppWorker)
 
 from go.apps.jsbox.outbound import GoOutboundResource
 
 
-class TestGoOutboundResource(TestCase):
+class StubbedAppWorker(DummyAppWorker):
 
-    def setUp(self):
-        self.conversation = mock.Mock()
-        self.user_api = mock.Mock()
-        self.app_worker = mock.Mock()
-        self.dummy_api = object()
-        self.resource = GoOutboundResource("test", self.app_worker, {})
-        self.app_worker.conversation_for_api = mock.Mock(
-            return_value=self.conversation)
-        self.app_worker.user_api_for_api = mock.Mock(
-            return_value=self.user_api)
-        self.user_api.list_endpoints = mock.Mock(
+    class DummyApi(DummyAppWorker.DummyApi):
+        def __init__(self, inbound_messages):
+            self._inbound_messages = inbound_messages
+
+        def get_inbound_message(self, msg_id):
+            return self._inbound_messages.get(msg_id)
+
+    sandbox_api_cls = DummyApi
+
+    def __init__(self):
+        super(StubbedAppWorker, self).__init__()
+        self.user_api = Mock()
+        self.user_api.list_endpoints = Mock(
             return_value=set([('pool1', '1234'), ('pool2', '1234')]))
-        self.user_api.msg_options = mock.Mock(
-            return_value={'opt1': 'bar'})
+        self.user_api.msg_options = Mock(return_value={'opt1': 'bar'})
+        self.conversation = Mock()
+        self.send_to = Mock(return_value=succeed(None))
+        self.reply_to = Mock(return_value=succeed(None))
+        self.reply_to_group = Mock(return_value=succeed(None))
 
-    def assert_reply(self, reply, cmd, success):
-        self.assertEqual(reply['reply'], True)
-        self.assertEqual(reply['cmd_id'], cmd['cmd_id'])
-        self.assertEqual(reply['success'], success)
+        self._inbound_messages = {}
+
+    def create_sandbox_api(self):
+        return self.sandbox_api_cls(self._inbound_messages)
+
+    def user_api_for_api(self, api):
+        return self.user_api
+
+    def conversation_for_api(self, api):
+        return self.conversation
+
+    def add_inbound_message(self, msg):
+        self._inbound_messages[msg['message_id']] = msg
+
+
+class TestGoOutboundResource(ResourceTestCaseBase):
+    app_worker_cls = StubbedAppWorker
+    resource_cls = GoOutboundResource
+
+    @inlineCallbacks
+    def setUp(self):
+        super(TestGoOutboundResource, self).setUp()
+        yield self.create_resource({})
+
+    def check_reply(self, reply, **kw):
+        kw.setdefault('success', True)
+        for key, expected_value in kw.iteritems():
+            self.assertEqual(reply[key], expected_value)
+
+    @inlineCallbacks
+    def assert_cmd_fails(self, reason, cmd, **cmd_args):
+        reply = yield self.dispatch_command(cmd, **cmd_args)
+        self.check_reply(reply, success=False, reason=reason)
+        self.assertFalse(self.app_worker.send_to.called)
+        self.assertFalse(self.app_worker.reply_to.called)
+        self.assertFalse(self.app_worker.reply_to_group.called)
+
+    def mkmsg_in(self, **kw):
+        opts = {
+            'content': 'hello world', 'to_addr': '12345', 'from_addr': '67890',
+            'transport_name': 'dummy_transport', 'transport_type': 'dummy',
+        }
+        opts.update(kw)
+        msg = TransportUserMessage(**opts)
+        self.app_worker.add_inbound_message(msg)
+        return msg
+
+    def dummy_metadata_adder(self, md=None):
+        if md is None:
+            md = {}
+        md['new'] = 'foo'
+        return md
+
+    @inlineCallbacks
+    def test_reply_to(self):
+        msg = self.mkmsg_in(content='Hello', helper_metadata={'orig': 'data'})
+        msg_reply = msg.reply('Reply!')
+        self.app_worker.conversation.set_go_helper_metadata = (
+            self.dummy_metadata_adder)
+
+        reply = yield self.dispatch_command(
+            'reply_to', content=msg_reply['content'],
+            in_reply_to=msg['message_id'])
+
+        self.check_reply(reply)
+        self.app_worker.reply_to.assert_called_once_with(
+            msg, 'Reply!', continue_session=True,
+            helper_metadata={'orig': 'data', 'new': 'foo'})
+
+    def test_reply_to_fails_with_no_content(self):
+        return self.assert_cmd_fails(
+            "'content' must be given in replies.",
+            'reply_to', in_reply_to=u'unknown')
+
+    def test_reply_to_fails_with_no_in_reply_to(self):
+        return self.assert_cmd_fails(
+            "'in_reply_to' must be given in replies.",
+            'reply_to', content=u'foo')
+
+    def test_reply_to_fails_with_bad_id(self):
+        return self.assert_cmd_fails(
+            "Could not find original message with id: u'unknown'",
+            'reply_to', content='Hello?', in_reply_to=u'unknown')
+
+    @inlineCallbacks
+    def test_reply_to_group(self):
+        msg = self.mkmsg_in(content='Hello', helper_metadata={'orig': 'data'})
+        msg_reply = msg.reply('Reply!')
+        self.app_worker.conversation.set_go_helper_metadata = (
+            self.dummy_metadata_adder)
+
+        reply = yield self.dispatch_command(
+            'reply_to_group', content=msg_reply['content'],
+            in_reply_to=msg['message_id'])
+
+        self.check_reply(reply)
+        self.app_worker.reply_to_group.assert_called_once_with(
+            msg, 'Reply!', continue_session=True,
+            helper_metadata={'orig': 'data', 'new': 'foo'})
+
+    def test_reply_to_group_fails_with_no_content(self):
+        return self.assert_cmd_fails(
+            "'content' must be given in replies.",
+            'reply_to_group', in_reply_to=u'unknown')
+
+    def test_reply_to_group_fails_with_no_in_reply_to(self):
+        return self.assert_cmd_fails(
+            "'in_reply_to' must be given in replies.",
+            'reply_to_group', content=u'foo')
+
+    def test_reply_to_group_fails_with_bad_id(self):
+        return self.assert_cmd_fails(
+            "Could not find original message with id: u'unknown'",
+            'reply_to_group', content='Hello?', in_reply_to=u'unknown')
 
     def assert_sent(self, to_addr, content, msg_options):
         self.app_worker.send_to.assert_called_once_with(
             to_addr, content, **msg_options)
 
-    def assert_not_sent(self):
-        self.assertFalse(self.app_worker.send_to.called)
-
-    @inlineCallbacks
-    def assert_fails(self, reason, handler=None, **cmd_args):
-        if handler is None:
-            handler = self.resource.handle_send_to_tag
-        cmd = SandboxCommand(**cmd_args)
-        reply = yield handler(self.dummy_api, cmd)
-        self.assert_reply(reply, cmd, False)
-        self.assert_not_sent()
-        self.assertEqual(reply['reason'], reason)
-
-    def test_send_to_fails(self):
-        # check that send_to is overridden to return the expected
-        # failure message by calling send_to without arguments
-        return self.assert_fails("Generic sending not supported in Vumi Go",
-                                 handler=self.resource.handle_send_to)
+    def assert_send_fails(self, reason, **cmd_args):
+        return self.assert_cmd_fails(reason, 'send_to_tag', **cmd_args)
 
     @inlineCallbacks
     def test_send_to_tag(self):
-        cmd = SandboxCommand(tagpool='pool1', tag='1234', to_addr='6789',
-                             content='bar')
         with LogCatcher() as lc:
-            reply = yield self.resource.handle_send_to_tag(self.dummy_api, cmd)
+            reply = yield self.dispatch_command(
+                'send_to_tag', tagpool='pool1', tag='1234', to_addr='6789',
+                content='bar')
             self.assertEqual(lc.messages(), [
-                "Sending outbound message to '6789' via tag ('pool1', '1234'),"
-                " content: 'bar'"])
-        self.assert_reply(reply, cmd, True)
+                "Sending outbound message to u'6789' via tag "
+                "(u'pool1', u'1234'), content: u'bar'"])
+        self.check_reply(reply)
         self.assert_sent(
             '6789', 'bar', {'endpoint': 'pool1:1234', 'opt1': 'bar'})
 
     def test_send_to_tag_unacquired(self):
-        return self.assert_fails("Tag ('foo', '12345') not held by account",
-                                 tagpool='foo', tag='12345', to_addr='6789',
-                                 content='bar')
+        return self.assert_send_fails(
+            "Tag (u'foo', u'12345') not held by account",
+            tagpool='foo', tag='12345', to_addr='6789',
+            content='bar')
 
     def test_send_to_tag_missing_tagpool(self):
-        return self.assert_fails("Tag, content or to_addr not specified",
-                                 tag='12345', to_addr='6789', content='bar')
+        return self.assert_send_fails(
+            "Tag, content or to_addr not specified",
+            tag='12345', to_addr='6789', content='bar')
 
     def test_send_to_tag_missing_tag(self):
-        return self.assert_fails("Tag, content or to_addr not specified",
-                                 tagpool='foo', to_addr='6789', content='bar')
+        return self.assert_send_fails(
+            "Tag, content or to_addr not specified",
+            tagpool='foo', to_addr='6789', content='bar')
 
     def test_send_to_tag_missing_to_addr(self):
-        return self.assert_fails("Tag, content or to_addr not specified",
-                                 tagpool='foo', tag='12345', content='bar')
+        return self.assert_send_fails(
+            "Tag, content or to_addr not specified",
+            tagpool='foo', tag='12345', content='bar')
 
     def test_send_to_tag_missing_content(self):
-        return self.assert_fails("Tag, content or to_addr not specified",
-                                 tagpool='foo', tag='12345', to_addr='6789')
+        return self.assert_send_fails(
+            "Tag, content or to_addr not specified",
+            tagpool='foo', tag='12345', to_addr='6789')


### PR DESCRIPTION
Recent updates to the Outbound resource added new methods without tests and these methods contained a subtle bug (helper_metadata wasn't being preserved in replies).
