### PR TITLE
Client side needs simple inhertance infrastructure

### DIFF
--- a/go/base/static/js/src/utils/utils.js
+++ b/go/base/static/js/src/utils/utils.js
@@ -1,0 +1,8 @@
+(function(exports) {
+  exports.Extendable = function () {};
+
+  // Backbone has an internal `extend()` function which it assigns to its
+  // structures. We need this function, so we arbitrarily choose
+  // `Backbone.Model`, since it has the `extend()` function we are looking for.
+  exports.Extendable.extend = Backbone.Model.extend;
+})(go.utils = {});

--- a/go/base/static/js/test/runner.html
+++ b/go/base/static/js/test/runner.html
@@ -23,11 +23,13 @@
 
     <script src="../src/go.js"></script>
     <script src="../src/errors/errors.js"></script>
+    <script src="../src/utils/utils.js"></script>
     <script src="../src/campaigns/campaigns.js"></script>
     <script src="../src/campaigns/setup/setup.js"></script>
     <script src="../src/campaigns/setup/interactive.js"></script>
 
     <script src="errors/errors.test.js"></script>
+    <script src="utils/utils.test.js"></script>
     <script src="campaigns/setup/interactive.test.js"></script>
     <script>
       if (window.mochaPhantomJS) { mochaPhantomJS.run(); }

--- a/go/base/static/js/test/utils/utils.test.js
+++ b/go/base/static/js/test/utils/utils.test.js
@@ -1,0 +1,32 @@
+describe("go.utils", function() {
+  var Extendable = go.utils.Extendable;
+
+  describe(".Extendable", function() {
+    it("should set up the prototype chain correctly", function() {
+      var Parent = Extendable.extend(),
+          Child = Parent.extend();
+
+       var child = new Child();
+       assert.instanceOf(child, Parent);
+       assert.instanceOf(child, Child);
+    });
+
+    it("should use a constructor function if specified", function() {
+      var Thing = Extendable.extend({
+        constructor: function (name) { this.name = name; }
+      });
+
+      assert.equal(new Thing('foo').name, 'foo');
+    });
+
+    it("should default to a parent's constructor", function() {
+      var Parent, Child;
+      Parent = Extendable.extend({
+        constructor: function (name) { this.name = name; }
+      });
+      Child = Parent.extend();
+
+      assert.equal(new Child('foo').name, 'foo');
+    });
+  });
+});


### PR DESCRIPTION
When creating with objects that aren't Backbone structures (Model, View, Router, etc), we are left without an easy way to inherit. Instead of verbose workarounds or including another dependency, I think this can be done quite simply by borrowing as much as we can from Backbone. This will also give us some uniformity in our code, since our structures will look similar to Backbone structures.
