### PR TITLE
Zip messages export CSV before emailing.

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -1,4 +1,6 @@
 from datetime import date
+from zipfile import ZipFile
+from StringIO import StringIO
 
 from django.test.client import Client
 from django.core import mail
@@ -283,11 +285,15 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(email.recipients(), [self.user.email])
         self.assertTrue(self.conversation.name in email.subject)
         self.assertTrue(self.conversation.name in email.body)
-        [(file_name, content, mime_type)] = email.attachments
-        self.assertEqual(file_name, 'messages-export.csv')
+        [(file_name, contents, mime_type)] = email.attachments
+        self.assertEqual(file_name, 'messages-export.zip')
+
+        zipfile = ZipFile(StringIO(contents), 'r')
+        csv_contents = zipfile.open('messages-export.csv', 'r').read()
+
         # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(content.split('\n')))
-        self.assertEqual(mime_type, 'text/csv')
+        self.assertEqual(22, len(csv_contents.split('\n')))
+        self.assertEqual(mime_type, 'application/zip')
 
 
 class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -1,4 +1,6 @@
 from datetime import date
+from zipfile import ZipFile
+from StringIO import StringIO
 
 from django.test.client import Client
 from django.core.urlresolvers import reverse
@@ -194,8 +196,12 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(email.recipients(), [self.user.email])
         self.assertTrue(self.conversation.name in email.subject)
         self.assertTrue(self.conversation.name in email.body)
-        [(file_name, content, mime_type)] = email.attachments
-        self.assertEqual(file_name, 'messages-export.csv')
+        [(file_name, contents, mime_type)] = email.attachments
+        self.assertEqual(file_name, 'messages-export.zip')
+
+        zipfile = ZipFile(StringIO(contents), 'r')
+        csv_contents = zipfile.open('messages-export.csv', 'r').read()
+
         # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(content.split('\n')))
-        self.assertEqual(mime_type, 'text/csv')
+        self.assertEqual(22, len(csv_contents.split('\n')))
+        self.assertEqual(mime_type, 'application/zip')

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -1,4 +1,6 @@
 from datetime import date
+from zipfile import ZipFile
+from StringIO import StringIO
 
 from django.test.client import Client
 from django.core.urlresolvers import reverse
@@ -284,11 +286,15 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(email.recipients(), [self.user.email])
         self.assertTrue(self.conversation.name in email.subject)
         self.assertTrue(self.conversation.name in email.body)
-        [(file_name, content, mime_type)] = email.attachments
-        self.assertEqual(file_name, 'messages-export.csv')
+        [(file_name, contents, mime_type)] = email.attachments
+        self.assertEqual(file_name, 'messages-export.zip')
+
+        zipfile = ZipFile(StringIO(contents), 'r')
+        csv_contents = zipfile.open('messages-export.csv', 'r').read()
+
         # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(content.split('\n')))
-        self.assertEqual(mime_type, 'text/csv')
+        self.assertEqual(22, len(csv_contents.split('\n')))
+        self.assertEqual(mime_type, 'application/zip')
 
     @patch('go.base.message_store_client.MatchResult')
     @patch('go.base.message_store_client.Client')

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -1,4 +1,5 @@
-
+from StringIO import StringIO
+from zipfile import ZipFile
 
 from celery.task import task
 
@@ -68,7 +69,7 @@ def export_conversation_messages(account_key, conversation_key):
                             for fn in field_names])
 
     zipio = StringIO()
-    zf = ZipfFile(zipio, "a")
+    zf = ZipFile(zipio, "a")
     zf.writestr("messages-export.csv", io.getvalue())
     zf.close()
 

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -1,4 +1,4 @@
-from StringIO import StringIO
+
 
 from celery.task import task
 
@@ -67,12 +67,17 @@ def export_conversation_messages(account_key, conversation_key):
         writer.writerow([unicode(message.payload.get(fn) or '')
                             for fn in field_names])
 
+    zipio = StringIO()
+    zf = ZipfFile(zipio, "a")
+    zf.writestr("messages-export.csv", io.getvalue())
+    zf.close()
+
     email = EmailMessage(
         'Conversation message export: %s' % (conversation.name,),
         'Please find the messages of the conversation %s attached.\n' % (
             conversation.name),
         settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
-    email.attach('messages-export.csv', io.getvalue(), 'text/csv')
+    email.attach('messages-export.zip', zipio.getvalue(), 'application/zip')
     email.send()
 
 


### PR DESCRIPTION
CSV balloons to sizes general mail servers aren't willing to accept as attachments.
