### PR TITLE
Prevent some UI elements from wrapping when the window is resized

### DIFF
--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -2,7 +2,7 @@ body {
   background: #2f3436;
   color: #c1c1c1;
 }
-.container-fluid {
+.main-container {
   min-width: 650px;
 }
 .footer {

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -2,6 +2,9 @@ body {
   background: #2f3436;
   color: #c1c1c1;
 }
+.container-fluid {
+  min-width: 650px;
+}
 .footer {
   margin: 1em;
 }
@@ -113,7 +116,7 @@ body {
   margin-left: -5px !important;
   height: 100%;
 }
-.content .actions .sidebar button {
+.content .actions .sidebar .btn {
   margin-left: -5px;
   padding-left: 20px;
   padding-right: 20px;

--- a/go/base/static/css/vumigo.less
+++ b/go/base/static/css/vumigo.less
@@ -6,7 +6,9 @@ body {
   color: #c1c1c1;
 }
 
-.container {
+.container-fluid {
+  // prevent wrapping.
+  min-width:650px;
 }
 
 .footer {
@@ -132,7 +134,7 @@ body {
       margin-left:-5px !important;
       height:100%;
 
-      button {
+      .btn {
         margin-left:-5px;
         padding-left:20px;
         padding-right:20px;

--- a/go/base/static/css/vumigo.less
+++ b/go/base/static/css/vumigo.less
@@ -6,7 +6,7 @@ body {
   color: #c1c1c1;
 }
 
-.container-fluid {
+.main-container {
   // prevent wrapping.
   min-width:650px;
 }

--- a/go/templates/base.html
+++ b/go/templates/base.html
@@ -26,7 +26,7 @@
 
 </head>
 <body>
-    <div class="container-fluid">
+    <div class="container-fluid main-container">
 
         <!--[if lt IE 7]>
         <p class=chromeframe>


### PR DESCRIPTION
1. The menu
2. Breadcrumbs and title.
3. Sidebar actions and page actions.
