### PR TITLE
Conversation lifecycle improvements

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -253,8 +253,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             10)
 
     def test_aggregates(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-            self.conv_key, 10, start_timestamp=date(2012, 1, 1),
+        self.put_sample_messages_in_conversation(
+            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
             time_multiplier=12)
         response = self.client.get(reverse('bulk_message:aggregates', kwargs={
             'conversation_key': self.conv_key
@@ -269,8 +269,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             ]))
 
     def test_export_messages(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-            self.conv_key, 10, start_timestamp=date(2012, 1, 1),
+        self.put_sample_messages_in_conversation(
+            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
             time_multiplier=12)
         conv_url = reverse('bulk_message:show', kwargs={
             'conversation_key': self.conv_key,

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -159,9 +159,12 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         conversation = yield self.setup_conversation()
         yield self.start_conversation(conversation)
         batch_id = yield conversation.get_latest_batch_key()
-        yield self.dispatch_command("send_message", command_data={
+        yield self.dispatch_command(
+            "send_message",
+            user_account_key=conversation.user_account.key,
+            conversation_key=conversation.key,
+            command_data={
             "batch_id": batch_id,
-            "conversation_key": conversation.key,
             "to_addr": "123456",
             "content": "hello world",
             "msg_options": msg_options,
@@ -189,10 +192,12 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         batch_id = yield conversation.get_latest_batch_key()
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
         yield self.store_inbound_msg(msg)
-        command = VumiApiCommand.command('worker', 'send_message',
+        command = VumiApiCommand.command(
+            'worker', 'send_message',
+            user_account_key=conversation.user_account.key,
+            conversation_key=conversation.key,
             command_data={
                 u'batch_id': batch_id,
-                u'conversation_key': conversation.key,
                 u'content': u'foo',
                 u'to_addr': u'to_addr',
                 u'msg_options': {
@@ -215,10 +220,12 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         batch_id = yield conversation.get_latest_batch_key()
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex, transport_name="bad")
         yield self.store_inbound_msg(msg)
-        command = VumiApiCommand.command('worker', 'send_message',
+        command = VumiApiCommand.command(
+            'worker', 'send_message',
+            user_account_key=conversation.user_account.key,
+            conversation_key=conversation.key,
             command_data={
                 u'batch_id': batch_id,
-                u'conversation_key': conversation.key,
                 u'content': u'foo',
                 u'to_addr': u'to_addr',
                 u'msg_options': {

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -66,9 +66,6 @@ class BulkMessageApplication(GoApplicationWorker):
             'msg_options': msg_options,
             })
 
-    def process_command_initial_action_hack(self, *args, **kwargs):
-        return self.process_command_bulk_send(*args, **kwargs)
-
     @inlineCallbacks
     def process_command_bulk_send(self, user_account_key, conversation_key,
                                   batch_id, msg_options, is_client_initiated,
@@ -154,3 +151,10 @@ class BulkMessageApplication(GoApplicationWorker):
     def collect_metrics(self, user_api, conversation_key):
         conv = yield user_api.get_wrapped_conversation(conversation_key)
         yield self.collect_message_metrics(conv)
+
+    def process_command_initial_action_hack(self, *args, **kwargs):
+        # HACK: This lets us do whatever we used to do when we got a `start'
+        # message without having horrible app-specific view logic.
+        # TODO: Remove this when we've decoupled the various conversation
+        # actions from the lifecycle.
+        return self.process_command_bulk_send(*args, **kwargs)

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -83,8 +83,8 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
     def get_config(self, msg):
         return self.get_message_config(msg)
 
-    def process_command_start(self, batch_id, conversation_type,
-                              conversation_key, msg_options,
-                              is_client_initiated, **extra_params):
+    def process_command_start(self, user_account_key, conversation_key):
         log.info("Starting javascript sandbox conversation (key: %r)." %
                  (conversation_key,))
+        return super(JsBoxApplication, self).process_command_start(
+            user_account_key, conversation_key)

--- a/go/apps/multi_surveys/templates/multi_surveys/includes/new.html
+++ b/go/apps/multi_surveys/templates/multi_surveys/includes/new.html
@@ -49,23 +49,3 @@
     </div>
 </div>
 {% endfor %}
-<!--
-<div class="control-group">
-    <label class="control-label" for="cdate">Date</label>
-    <div class="controls">
-        <div class="input-prepend">
-            <span class="add-on"><i class="icon-calendar"></i></span>
-            {{form.start_date}}
-        </div>
-    </div>
-</div>
-<div class="control-group">
-    <label class="control-label" for="ctime">Time</label>
-    <div class="controls">
-        <div class="input-prepend">
-            <span class="add-on"><i class="icon-time"></i></span>
-            {{form.start_time}}
-        </div>
-    </div>
-</div>
--->

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -117,7 +117,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             'conversation_key': self.conv_key}))
 
         conversation = self.get_wrapped_conv()
-        [cmd] = self.fetch_cmds(consumer)
+        [start_cmd, hack_cmd] = self.fetch_cmds(consumer)
         [batch] = conversation.get_batches()
         [tag] = list(batch.tags)
         [contact] = self.get_contacts_for_conversation(conversation)
@@ -131,14 +131,17 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
                 },
             }
 
-        self.assertEqual(cmd, VumiApiCommand.command(
-            '%s_application' % (conversation.conversation_type,), 'start',
-            conversation_type=conversation.conversation_type,
-            conversation_key=conversation.key,
-            is_client_initiated=conversation.is_client_initiated(),
-            batch_id=batch.key,
-            msg_options=msg_options
-            ))
+        self.assertEqual(start_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,), 'start',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key))
+        self.assertEqual(hack_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,),
+                'initial_action_hack',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key,
+                is_client_initiated=conversation.is_client_initiated(),
+                batch_id=batch.key, msg_options=msg_options))
 
     def test_send_fails(self):
         """

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -164,8 +164,8 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(conversation.name, 'Test Conversation')
 
     def test_aggregates(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-            self.conv_key, 10, start_timestamp=date(2012, 1, 1),
+        self.put_sample_messages_in_conversation(
+            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
             time_multiplier=12)
         response = self.client.get(reverse('survey:aggregates', kwargs={
             'conversation_key': self.conv_key
@@ -180,8 +180,8 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             ]))
 
     def test_export_messages(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-            self.conv_key, 10, start_timestamp=date(2012, 1, 1),
+        self.put_sample_messages_in_conversation(
+            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
             time_multiplier=12)
         conv_url = reverse('survey:show', kwargs={
             'conversation_key': self.conv_key,

--- a/go/apps/multi_surveys/views.py
+++ b/go/apps/multi_surveys/views.py
@@ -78,13 +78,13 @@ def new(request):
             if tag_info[2]:
                 conversation_data['delivery_tag'] = tag_info[2]
 
-            start_date = form.cleaned_data['start_date'] or datetime.utcnow()
-            start_time = (form.cleaned_data['start_time'] or
-                            datetime.utcnow().time())
-            conversation_data['start_timestamp'] = datetime(
-                start_date.year, start_date.month, start_date.day,
-                start_time.hour, start_time.minute, start_time.second,
-                start_time.microsecond)
+            # start_date = form.cleaned_data['start_date'] or datetime.utcnow()
+            # start_time = (form.cleaned_data['start_time'] or
+            #                 datetime.utcnow().time())
+            # conversation_data['start_timestamp'] = datetime(
+            #     start_date.year, start_date.month, start_date.day,
+            #     start_time.hour, start_time.minute, start_time.second,
+            #     start_time.microsecond)
 
             conversation = request.user_api.new_conversation(
                 u'multi_survey', **conversation_data)
@@ -111,8 +111,8 @@ def surveys(request, conversation_key):
 
     survey_form = make_read_only_form(ConversationForm(request.user_api,
         instance=conversation, initial={
-            'start_date': conversation.start_timestamp.date(),
-            'start_time': conversation.start_timestamp.time(),
+            'start_date': conversation.created_at.date(),
+            'start_time': conversation.created_at.time(),
         }))
 
     return render(request, 'multi_surveys/surveys.html', {
@@ -154,8 +154,8 @@ def new_survey(request, conversation_key):
 
     survey_form = make_read_only_form(ConversationForm(request.user_api,
         instance=conversation, initial={
-            'start_date': conversation.start_timestamp.date(),
-            'start_time': conversation.start_timestamp.time(),
+            'start_date': conversation.created_at.date(),
+            'start_time': conversation.created_at.time(),
         }))
     return render(request, 'multi_surveys/contents.html', {
         'form': form,
@@ -214,8 +214,8 @@ def survey(request, conversation_key, poll_name):
 
     survey_form = make_read_only_form(ConversationForm(request.user_api,
         instance=conversation, initial={
-            'start_date': conversation.start_timestamp.date(),
-            'start_time': conversation.start_timestamp.time(),
+            'start_date': conversation.created_at.date(),
+            'start_time': conversation.created_at.time(),
         }))
 
     return render(request, 'multi_surveys/contents.html', {
@@ -271,8 +271,8 @@ def people(request, conversation_key):
 
     survey_form = make_read_only_form(ConversationForm(request.user_api,
         instance=conversation, initial={
-            'start_date': conversation.start_timestamp.date(),
-            'start_time': conversation.start_timestamp.time(),
+            'start_date': conversation.created_at.date(),
+            'start_time': conversation.created_at.time(),
         }))
     content_form = forms.make_form_set(initial=questions_data, extra=0)
     read_only_content_form = make_read_only_formset(content_form)

--- a/go/apps/multi_surveys/views.py
+++ b/go/apps/multi_surveys/views.py
@@ -78,14 +78,6 @@ def new(request):
             if tag_info[2]:
                 conversation_data['delivery_tag'] = tag_info[2]
 
-            # start_date = form.cleaned_data['start_date'] or datetime.utcnow()
-            # start_time = (form.cleaned_data['start_time'] or
-            #                 datetime.utcnow().time())
-            # conversation_data['start_timestamp'] = datetime(
-            #     start_date.year, start_date.month, start_date.day,
-            #     start_time.hour, start_time.minute, start_time.second,
-            #     start_time.microsecond)
-
             conversation = request.user_api.new_conversation(
                 u'multi_survey', **conversation_data)
             messages.add_message(request, messages.INFO,
@@ -94,11 +86,7 @@ def new(request):
                 kwargs={'conversation_key': conversation.key}))
 
     else:
-        form = ConversationForm(request.user_api, initial={
-            'start_date': datetime.utcnow().date(),
-            'start_time': datetime.utcnow().time().replace(second=0,
-                                                            microsecond=0),
-        })
+        form = ConversationForm(request.user_api)
     return render(request, 'multi_surveys/new.html', {
         'form': form,
     })

--- a/go/apps/multi_surveys/vumi_app.py
+++ b/go/apps/multi_surveys/vumi_app.py
@@ -133,16 +133,17 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
         return self.consume_user_message(msg)
 
     @inlineCallbacks
-    def process_command_start(self, batch_id, conversation_type,
-                              conversation_key, msg_options,
-                              is_client_initiated, **extra_params):
+    def process_command_initial_action_hack(self, user_account_key,
+                                            conversation_key, batch_id,
+                                            msg_options, is_client_initiated,
+                                            **extra_params):
 
         if is_client_initiated:
             log.debug('Conversation %r is client initiated, no need to notify '
                 'the application worker' % (conversation_key,))
             return
 
-        conv = yield self.get_conversation(batch_id, conversation_key)
+        conv = yield self.get_conversation(user_account_key, conversation_key)
 
         for contacts in (yield conv.get_opted_in_contact_bunches()):
             for contact in (yield contacts):

--- a/go/apps/multi_surveys/vumi_app.py
+++ b/go/apps/multi_surveys/vumi_app.py
@@ -133,10 +133,9 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
         return self.consume_user_message(msg)
 
     @inlineCallbacks
-    def process_command_initial_action_hack(self, user_account_key,
-                                            conversation_key, batch_id,
-                                            msg_options, is_client_initiated,
-                                            **extra_params):
+    def process_command_send_survey(self, user_account_key, conversation_key,
+                                    batch_id, msg_options, is_client_initiated,
+                                    **extra_params):
 
         if is_client_initiated:
             log.debug('Conversation %r is client initiated, no need to notify '
@@ -149,3 +148,10 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
             for contact in (yield contacts):
                 to_addr = contact.addr_for(conv.delivery_class)
                 yield self.start_survey(to_addr, conv, **msg_options)
+
+    def process_command_initial_action_hack(self, *args, **kwargs):
+        # HACK: This lets us do whatever we used to do when we got a `start'
+        # message without having horrible app-specific view logic.
+        # TODO: Remove this when we've decoupled the various conversation
+        # actions from the lifecycle.
+        return self.process_command_send_survey(*args, **kwargs)

--- a/go/apps/opt_out/vumi_app.py
+++ b/go/apps/opt_out/vumi_app.py
@@ -37,7 +37,7 @@ class OptOutApplication(GoApplicationWorker):
         else:
             yield self.reply_to(message, "You have opted out")
 
-    def process_command_start(self, batch_id, conversation_type,
-                              conversation_key, msg_options,
-                              is_client_initiated, **extra_params):
+    def process_command_start(self, user_account_key, conversation_key):
         log.debug('OptOutApplication started: %s' % (conversation_key,))
+        return super(OptOutApplication, self).process_command_start(
+            user_account_key, conversation_key)

--- a/go/apps/sequential_send/tests/test_views.py
+++ b/go/apps/sequential_send/tests/test_views.py
@@ -112,7 +112,7 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
             'conversation_key': self.conv_key}))
 
         conversation = self.get_wrapped_conv()
-        [cmd] = self.fetch_cmds(consumer)
+        [start_cmd, hack_cmd] = self.fetch_cmds(consumer)
         [batch] = conversation.get_batches()
         [] = list(batch.tags)
         [contact] = self.get_contacts_for_conversation(conversation)
@@ -126,15 +126,17 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
                 },
             }
 
-        self.assertEqual(cmd, VumiApiCommand.command(
-            '%s_application' % (conversation.conversation_type,), 'start',
-            conversation_type=conversation.conversation_type,
-            conversation_key=conversation.key,
-            is_client_initiated=conversation.is_client_initiated(),
-            batch_id=batch.key,
-            msg_options=msg_options,
-            dedupe=False,
-            ))
+        self.assertEqual(start_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,), 'start',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key))
+        self.assertEqual(hack_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,),
+                'initial_action_hack',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key,
+                is_client_initiated=conversation.is_client_initiated(),
+                batch_id=batch.key, msg_options=msg_options, dedupe=False))
 
     def test_send_fails(self):
         consumer = self.get_cmd_consumer()

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -99,7 +99,7 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         """
 
         # Avoid hitting Riak for the conversation and Redis for poll times.
-        expected = [[conv.get_batch_keys()[0], conv.key] for conv in convs]
+        expected = [[conv.user_account.key, conv.key] for conv in convs]
         poll_times = [(yield self.app._get_last_poll_time())]
         scheduled_conversations = yield self.app._get_scheduled_conversations()
 
@@ -221,6 +221,7 @@ class TestSequentialSendApplication(AppWorkerTestCase):
 
         [c1, c2] = yield self.app.get_conversations(
             [[batch_id1, conv1.key], [batch_id2, conv2.key]])
+        print c1, c2
 
         self.assertEqual(sorted([c1.key, c2.key]),
                          sorted([conv1.key, conv2.key]))

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -138,11 +138,12 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
     @inlineCallbacks
     def test_handle_event_default(self):
         yield self.send_event(self.contact.msisdn)
-        [start_cmd, send_msg_command] = self.get_dispatcher_commands()
+        [start_cmd, hack_cmd, send_msg_cmd] = self.get_dispatcher_commands()
 
         self.assertEqual(start_cmd['command'], 'start')
-        self.assertEqual(send_msg_command['command'], 'send_message')
-        self.assertEqual(send_msg_command['kwargs'], {
+        self.assertEqual(hack_cmd['command'], 'initial_action_hack')
+        self.assertEqual(send_msg_cmd['command'], 'send_message')
+        self.assertEqual(send_msg_cmd['kwargs'], {
             'command_data': {
                 'conversation_key': self.conversation.key,
                 'batch_id': (yield self.conversation.get_latest_batch_key()),
@@ -157,7 +158,7 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
         self.contact.extra['language'] = u'1'
         yield self.contact.save()
         yield self.send_event(self.contact.msisdn)
-        [command] = self.get_dispatcher_commands()[1:]
+        [command] = self.get_dispatcher_commands()[2:]
 
         data = command['kwargs']['command_data']
         self.assertEqual(data['content'], 'english sms')
@@ -167,7 +168,7 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
         self.contact.extra['language'] = u'2'
         yield self.contact.save()
         yield self.send_event(self.contact.msisdn)
-        [command] = self.get_dispatcher_commands()[1:]
+        [command] = self.get_dispatcher_commands()[2:]
 
         data = command['kwargs']['command_data']
         self.assertEqual(data['content'], 'swahili sms')

--- a/go/apps/subscription/tests/test_views.py
+++ b/go/apps/subscription/tests/test_views.py
@@ -90,16 +90,18 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
                 },
             }
 
-        [cmd] = self.get_api_commands_sent()
-        expected_cmd = VumiApiCommand.command(
-            '%s_application' % (conversation.conversation_type,), 'start',
-            batch_id=batch.key,
-            msg_options=msg_options,
-            conversation_type=conversation.conversation_type,
-            conversation_key=conversation.key,
-            is_client_initiated=conversation.is_client_initiated(),
-            )
-        self.assertEqual(cmd, expected_cmd)
+        [start_cmd, hack_cmd] = self.get_api_commands_sent()
+        self.assertEqual(start_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,), 'start',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key))
+        self.assertEqual(hack_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,),
+                'initial_action_hack',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key,
+                is_client_initiated=conversation.is_client_initiated(),
+                batch_id=batch.key, msg_options=msg_options))
 
     def test_send_fails(self):
         """

--- a/go/apps/subscription/vumi_app.py
+++ b/go/apps/subscription/vumi_app.py
@@ -22,13 +22,6 @@ class SubscriptionApplication(GoApplicationWorker):
         yield self.vumi_api.mdb.add_outbound_message(msg, batch_id=batch_id)
         log.info('Stored outbound %s' % (msg,))
 
-    def process_command_start(self, batch_id, conversation_type,
-                              conversation_key, msg_options,
-                              is_client_initiated, **extra_params):
-        if not is_client_initiated:
-            log.warning('Trying to start a server initiated conversation '
-                        'on a subscription handler.')
-
     def handlers_for_content(self, conv, content):
         words = (content or '').strip().split() + ['']
         keyword = words[0].lower()

--- a/go/apps/surveys/templates/surveys/includes/new.html
+++ b/go/apps/surveys/templates/surveys/includes/new.html
@@ -51,23 +51,3 @@
     </div>
 </div>
 {% endfor %}
-<!--
-<div class="control-group">
-    <label class="control-label" for="cdate">Date</label>
-    <div class="controls">
-        <div class="input-prepend">
-            <span class="add-on"><i class="icon-calendar"></i></span>
-            {{form.start_date}}
-        </div>
-    </div>
-</div>
-<div class="control-group">
-    <label class="control-label" for="ctime">Time</label>
-    <div class="controls">
-        <div class="input-prepend">
-            <span class="add-on"><i class="icon-time"></i></span>
-            {{form.start_time}}
-        </div>
-    </div>
-</div>
--->

--- a/go/apps/surveys/templates/surveys/includes/overview.html
+++ b/go/apps/surveys/templates/surveys/includes/overview.html
@@ -2,7 +2,7 @@
     <div class="span12">
         <div class="pull-right">
            {% if conversation.ended %}
-                <h4 class="btn btn-info"><i class="icon-ok icon-white"></i> Conversation ended on {{conversation.end_date|date:"d F Y"}}</h4>
+                <h4 class="btn btn-info"><i class="icon-ok icon-white"></i> Conversation ended on {{conversation.archived_at|date:"d F Y"}}</h4>
             {% else %}
                 <form id="conversation-end" name="conversation-end" method="post" action="{{ conversation.get_absolute_url }}end/">
                      <a href="{{conversation.get_absolute_url}}edit/" class="btn btn-success"><i class="icon-edit icon-white"></i> Edit Conversation</a>
@@ -11,7 +11,7 @@
                 </form>
             {% endif %}
         </div>
-        <span class="label label-info">{{conversation.start_timestamp|date:"d F Y"}}</span> 
+        <span class="label label-info">{{conversation.created_at|date:"d F Y"}}</span> 
         <span class="label">{{conversation.delivery_class_description}}</span> 
 
         {% for group in conversation.get_groups %}

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -254,8 +254,8 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertTrue(lines[1].endswith(',answer 1,answer 2'))
 
     def test_aggregates(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-            self.conv_key, 10, start_timestamp=date(2012, 1, 1),
+        self.put_sample_messages_in_conversation(
+            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
             time_multiplier=12)
         response = self.client.get(reverse('survey:aggregates', kwargs={
             'conversation_key': self.conv_key
@@ -270,8 +270,8 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             ]))
 
     def test_export_messages(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-            self.conv_key, 10, start_timestamp=date(2012, 1, 1),
+        self.put_sample_messages_in_conversation(
+            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
             time_multiplier=12)
         conv_url = reverse('survey:show', kwargs={
             'conversation_key': self.conv_key,

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -136,13 +136,13 @@ class TestSurveyApplication(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_start(self):
-        # We need to wait for process_command_start() to finish completely.
-        # Since it runs in response to an async command, we need to wrap it in
-        # something that fires a deferred at the appropriate time.
-        pcs_d = Deferred()
-        pcs = self.app.process_command_start
-        pcs_wrapper = lambda *args, **kw: pcs(*args, **kw).chainDeferred(pcs_d)
-        self.app.process_command_start = pcs_wrapper
+        # We need to wait for process_command_send_survey() to finish
+        # completely. Since it runs in response to an async command, we need to
+        # wrap it in something that fires a deferred at the appropriate time.
+        pcss_d = Deferred()
+        pcss = self.app.process_command_send_survey
+        pcss_wrapper = lambda *a, **kw: pcss(*a, **kw).chainDeferred(pcss_d)
+        self.app.process_command_send_survey = pcss_wrapper
 
         self.contact1 = yield self.create_contact(name=u'First',
             surname=u'Contact', msisdn=u'+27831234567', groups=[self.group])
@@ -153,7 +153,7 @@ class TestSurveyApplication(AppWorkerTestCase):
             yield self.start_conversation(self.conversation)
             self.assertEqual(log.errors, [])
 
-        yield pcs_d
+        yield pcss_d
         [msg1, msg2] = self.get_dispatched_messages()
         self.assertEqual(msg1['content'], self.default_questions[0]['copy'])
         self.assertEqual(msg2['content'], self.default_questions[0]['copy'])

--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -55,14 +55,6 @@ def new(request):
             if tag_info[2]:
                 conversation_data['delivery_tag'] = tag_info[2]
 
-            # start_date = form.cleaned_data['start_date'] or datetime.utcnow()
-            # start_time = (form.cleaned_data['start_time'] or
-            #                 datetime.utcnow().time())
-            # conversation_data['start_timestamp'] = datetime(
-            #     start_date.year, start_date.month, start_date.day,
-            #     start_time.hour, start_time.minute, start_time.second,
-            #     start_time.microsecond)
-
             conversation = request.user_api.new_conversation(
                 u'survey', **conversation_data)
             messages.add_message(request, messages.INFO,
@@ -71,11 +63,7 @@ def new(request):
                 kwargs={'conversation_key': conversation.key}))
 
     else:
-        form = ConversationForm(request.user_api, initial={
-            'start_date': datetime.utcnow().date(),
-            'start_time': datetime.utcnow().time().replace(second=0,
-                                                            microsecond=0),
-        })
+        form = ConversationForm(request.user_api)
     return render(request, 'surveys/new.html', {
         'form': form,
     })

--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -55,13 +55,13 @@ def new(request):
             if tag_info[2]:
                 conversation_data['delivery_tag'] = tag_info[2]
 
-            start_date = form.cleaned_data['start_date'] or datetime.utcnow()
-            start_time = (form.cleaned_data['start_time'] or
-                            datetime.utcnow().time())
-            conversation_data['start_timestamp'] = datetime(
-                start_date.year, start_date.month, start_date.day,
-                start_time.hour, start_time.minute, start_time.second,
-                start_time.microsecond)
+            # start_date = form.cleaned_data['start_date'] or datetime.utcnow()
+            # start_time = (form.cleaned_data['start_time'] or
+            #                 datetime.utcnow().time())
+            # conversation_data['start_timestamp'] = datetime(
+            #     start_date.year, start_date.month, start_date.day,
+            #     start_time.hour, start_time.minute, start_time.second,
+            #     start_time.microsecond)
 
             conversation = request.user_api.new_conversation(
                 u'survey', **conversation_data)
@@ -133,8 +133,8 @@ def contents(request, conversation_key):
 
     survey_form = make_read_only_form(ConversationForm(request.user_api,
         instance=conversation, initial={
-            'start_date': conversation.start_timestamp.date(),
-            'start_time': conversation.start_timestamp.time(),
+            'start_date': conversation.created_at.date(),
+            'start_time': conversation.created_at.time(),
         }))
 
     return render(request, 'surveys/contents.html', {

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -130,33 +130,36 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         yield super(SurveyApplication, self).end_session(participant, poll,
             message)
 
+    # @inlineCallbacks
+    # def get_conversation(self, batch_id, conversation_key):
+    #     batch = yield self.vumi_api.mdb.get_batch(batch_id)
+    #     if batch is None:
+    #         log.error('Cannot find batch for batch_id %s' % (batch_id,))
+    #         return
+
+    #     user_account_key = batch.metadata["user_account"]
+    #     if user_account_key is None:
+    #         log.error("No account key in batch metadata: %r" % (batch,))
+    #         return
+
+    #     user_api = self.get_user_api(user_account_key)
+    #     conv = yield user_api.get_wrapped_conversation(conversation_key)
+    #     returnValue(conv)
+
+    def process_command_initial_action_hack(self, *args, **kwargs):
+        return self.process_command_send_survey(*args, **kwargs)
+
     @inlineCallbacks
-    def get_conversation(self, batch_id, conversation_key):
-        batch = yield self.vumi_api.mdb.get_batch(batch_id)
-        if batch is None:
-            log.error('Cannot find batch for batch_id %s' % (batch_id,))
-            return
-
-        user_account_key = batch.metadata["user_account"]
-        if user_account_key is None:
-            log.error("No account key in batch metadata: %r" % (batch,))
-            return
-
-        user_api = self.get_user_api(user_account_key)
-        conv = yield user_api.get_wrapped_conversation(conversation_key)
-        returnValue(conv)
-
-    @inlineCallbacks
-    def process_command_start(self, batch_id, conversation_type,
-                              conversation_key, msg_options,
-                              is_client_initiated, **extra_params):
+    def process_command_send_survey(self, user_account_key, conversation_key,
+                                    batch_id, msg_options, is_client_initiated,
+                                    **extra_params):
 
         if is_client_initiated:
             log.debug('Conversation %r is client initiated, no need to notify '
                       'the application worker' % (conversation_key,))
             return
 
-        conv = yield self.get_conversation(batch_id, conversation_key)
+        conv = yield self.get_conversation(user_account_key, conversation_key)
         if not conv:
             return
 

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -130,25 +130,6 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         yield super(SurveyApplication, self).end_session(participant, poll,
             message)
 
-    # @inlineCallbacks
-    # def get_conversation(self, batch_id, conversation_key):
-    #     batch = yield self.vumi_api.mdb.get_batch(batch_id)
-    #     if batch is None:
-    #         log.error('Cannot find batch for batch_id %s' % (batch_id,))
-    #         return
-
-    #     user_account_key = batch.metadata["user_account"]
-    #     if user_account_key is None:
-    #         log.error("No account key in batch metadata: %r" % (batch,))
-    #         return
-
-    #     user_api = self.get_user_api(user_account_key)
-    #     conv = yield user_api.get_wrapped_conversation(conversation_key)
-    #     returnValue(conv)
-
-    def process_command_initial_action_hack(self, *args, **kwargs):
-        return self.process_command_send_survey(*args, **kwargs)
-
     @inlineCallbacks
     def process_command_send_survey(self, user_account_key, conversation_key,
                                     batch_id, msg_options, is_client_initiated,
@@ -189,3 +170,10 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         else:
             yield self.send_to(
                 to_addr, content, endpoint='default', **msg_options)
+
+    def process_command_initial_action_hack(self, *args, **kwargs):
+        # HACK: This lets us do whatever we used to do when we got a `start'
+        # message without having horrible app-specific view logic.
+        # TODO: Remove this when we've decoupled the various conversation
+        # actions from the lifecycle.
+        return self.process_command_send_survey(*args, **kwargs)

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -220,7 +220,8 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
     def put_sample_messages_in_conversation(self, user_api, conversation_key,
                                             message_count,
                                             content_generator=None,
-                                            start_date=None, time_multiplier=10):
+                                            start_date=None,
+                                            time_multiplier=10):
         now = start_date or datetime.now().date()
         conversation = user_api.get_wrapped_conversation(conversation_key)
         conversation.start()

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -218,11 +218,10 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase, CeleryTestMixIn):
         return self.fetch_cmds(consumer)
 
     def put_sample_messages_in_conversation(self, user_api, conversation_key,
-                                                message_count,
-                                                content_generator=None,
-                                                start_timestamp=None,
-                                                time_multiplier=10):
-        now = start_timestamp or datetime.now().date()
+                                            message_count,
+                                            content_generator=None,
+                                            start_date=None, time_multiplier=10):
+        now = start_date or datetime.now().date()
         conversation = user_api.get_wrapped_conversation(conversation_key)
         conversation.start()
         batch_key = conversation.get_latest_batch_key()

--- a/go/apps/wikipedia/ussd/views.py
+++ b/go/apps/wikipedia/ussd/views.py
@@ -37,9 +37,6 @@ class NewWikipediaConversationView(NewConversationView):
         if tag_info[2]:
             conversation_data['delivery_tag'] = tag_info[2]
 
-        # Ignoring start time, because we don't actually do anything with it.
-        conversation_data['start_timestamp'] = datetime.utcnow()
-
         conversation = request.user_api.new_conversation(
             self.conversation_type, **conversation_data)
         messages.info(request,

--- a/go/apps/wikipedia/vumi_app.py
+++ b/go/apps/wikipedia/vumi_app.py
@@ -45,9 +45,3 @@ class WikipediaApplication(WikipediaWorker, GoApplicationMixin):
         return self.send_to(
             msg['from_addr'], sms_content, transport_type='sms',
             endpoint='sms_content', helper_metadata=helper_metadata)
-
-    def process_command_start(self, batch_id, conversation_type,
-                              conversation_key, msg_options,
-                              is_client_initiated, **extra_params):
-        log.debug('Conversation %r has been started, no need to '
-                    'do anything.' % (conversation_key,))

--- a/go/base/management/commands/go_setup_env.py
+++ b/go/base/management/commands/go_setup_env.py
@@ -331,7 +331,6 @@ class Command(BaseCommand):
             conv_info.pop('start', None)  # Don't pass to conversation.
             user = User.objects.get(username=conv_info.pop('account'))
             user_api = vumi_api_for_user(user)
-            timestamp = conv_info.pop('start_timestamp', datetime.utcnow())
             conversation_key = conv_info.pop('key')
             if user_api.get_wrapped_conversation(conversation_key):
                 self.stderr.write(
@@ -343,8 +342,7 @@ class Command(BaseCommand):
                 conversation_key, user_account=user_api.user_account_key,
                 conversation_type=unicode(conv_info.pop('conversation_type')),
                 name=unicode(conv_info.pop('name')),
-                config=conv_info.pop('config', {}),
-                start_timestamp=timestamp, **conv_info)
+                config=conv_info.pop('config', {}), **conv_info)
             conv.save()
             self.stdout.write('Conversation %s created\n' % (conv.key,))
 

--- a/go/base/management/commands/go_start_conversation.py
+++ b/go/base/management/commands/go_start_conversation.py
@@ -51,13 +51,13 @@ class Command(BaseCommand):
         handler(user_api, conversation)
 
     def default_start_conversation(self, user_api, conversation):
-        if conversation.started():
+        if conversation.archived() or conversation.running():
             raise CommandError('Conversation already started.')
 
         conversation.start()
 
     def start_sequential_send(self, user_api, conversation):
-        if conversation.started():
+        if conversation.archived() or conversation.running():
             raise CommandError('Conversation already started.')
 
         conversation.start(no_batch_tag=True, acquire_tag=False)

--- a/go/base/tests/test_go_start_conversation.py
+++ b/go/base/tests/test_go_start_conversation.py
@@ -47,7 +47,8 @@ class GoStartConversationTestCase(DjangoGoApplicationTestCase):
         SyncMessageSender.return_value = sender
         conversation = self.get_conversation()
         self.assertEqual(conversation.get_tags(), [])
-        self.assertEqual(conversation.get_status(), 'draft')
+        self.assertEqual(conversation.archive_status, 'active')
+        self.assertEqual(conversation.get_status(), 'stopped')
         self.command.handle(email_address=self.user.username,
             conversation_key=conversation.key)
         # reload b/c DB changed

--- a/go/base/tests/test_go_start_conversation.py
+++ b/go/base/tests/test_go_start_conversation.py
@@ -56,8 +56,9 @@ class GoStartConversationTestCase(DjangoGoApplicationTestCase):
         [(pool, tag)] = conversation.get_tags()
         self.assertEqual(pool, 'longcode')
         self.assertTrue(tag)
-        [command] = sender.outbox
-        self.assertEqual(command['command'], 'start')
+        [start_command, hack_command] = sender.outbox
+        self.assertEqual(start_command['command'], 'start')
+        self.assertEqual(hack_command['command'], 'initial_action_hack')
 
     @patch('go.vumitools.api.SyncMessageSender')
     def test_restart_conversation(self, SyncMessageSender):

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.http import HttpResponse
 
 from go.vumitools.conversation.models import (
-    CONVERSATION_DRAFT, CONVERSATION_RUNNING, CONVERSATION_FINISHED)
+    CONVERSATION_DRAFT, CONVERSATION_RUNNING, CONVERSATION_STOPPED)
 from go.vumitools.exceptions import ConversationSendError
 from go.base.django_token_manager import DjangoTokenManager
 from go.conversation.forms import (ConversationForm, ConversationGroupForm,
@@ -110,9 +110,6 @@ class NewConversationView(ConversationView):
         conversation_data['delivery_tag_pool'] = tag_info[0]
         if tag_info[2]:
             conversation_data['delivery_tag'] = tag_info[2]
-
-        # Ignoring start time, because we don't actually do anything with it.
-        conversation_data['start_timestamp'] = datetime.utcnow()
 
         conversation = request.user_api.new_conversation(
             self.conversation_type, **conversation_data)
@@ -302,7 +299,8 @@ class ShowConversationView(ConversationView):
         status = conversation.get_status()
         templ = lambda name: self.get_template_name('includes/%s' % (name,))
 
-        if status == CONVERSATION_FINISHED:
+        if status == CONVERSATION_STOPPED:
+            # HACK: This assumes "stopped" and "archived" are equivalent.
             params['button_template'] = templ('ended-button')
         elif status == CONVERSATION_RUNNING:
             params['button_template'] = templ('end-button')

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -1,5 +1,4 @@
 import csv
-from datetime import datetime
 from StringIO import StringIO
 
 from django.views.generic import TemplateView
@@ -15,8 +14,7 @@ from django.conf.urls.defaults import url, patterns
 from django.conf import settings
 from django.http import HttpResponse
 
-from go.vumitools.conversation.models import (
-    CONVERSATION_DRAFT, CONVERSATION_RUNNING, CONVERSATION_STOPPED)
+from go.vumitools.conversation.models import CONVERSATION_DRAFT
 from go.vumitools.exceptions import ConversationSendError
 from go.base.django_token_manager import DjangoTokenManager
 from go.conversation.forms import (ConversationForm, ConversationGroupForm,
@@ -296,15 +294,15 @@ class ShowConversationView(ConversationView):
             'is_editable': (self.edit_conversation_forms is not None),
             'user_api': request.user_api,
             }
-        status = conversation.get_status()
         templ = lambda name: self.get_template_name('includes/%s' % (name,))
 
-        if status == CONVERSATION_STOPPED:
+        if conversation.archived():
             # HACK: This assumes "stopped" and "archived" are equivalent.
             params['button_template'] = templ('ended-button')
-        elif status == CONVERSATION_RUNNING:
+        elif conversation.running():
             params['button_template'] = templ('end-button')
-        elif status == CONVERSATION_DRAFT:
+        else:
+            # TODO: Figure out better state management.
             params['button_template'] = templ('next-button')
             params['next_url'] = self.get_view_url(
                 self.get_next_view(conversation),

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -14,7 +14,6 @@ from django.conf.urls.defaults import url, patterns
 from django.conf import settings
 from django.http import HttpResponse
 
-from go.vumitools.conversation.models import CONVERSATION_DRAFT
 from go.vumitools.exceptions import ConversationSendError
 from go.base.django_token_manager import DjangoTokenManager
 from go.conversation.forms import (ConversationForm, ConversationGroupForm,
@@ -72,7 +71,7 @@ class ConversationView(TemplateView):
         return self.conversation_form(*args, **kw)
 
     def get_next_view(self, conversation):
-        if conversation.get_status() != CONVERSATION_DRAFT:
+        if not conversation.is_draft():
             return 'show'
         if self.conversation_initiator == 'client':
             return 'start'

--- a/go/conversation/templates/conversation/includes/conversation-box.html
+++ b/go/conversation/templates/conversation/includes/conversation-box.html
@@ -1,7 +1,7 @@
 {% if conversation %}
 	<div class="span4">
 	    <div class="convos shadow">
-	        <span class="label label-info">{{conversation.start_timestamp}}</span>
+	        <span class="label label-info">{{conversation.created_at}}</span>
 	        {% if conversation.ended %}
 	        	<span class="label label-important"><i class="icon-ok-circle icon-white"></i> Finished</span>
 	        {% else %}

--- a/go/conversation/templates/conversation/includes/overview.html
+++ b/go/conversation/templates/conversation/includes/overview.html
@@ -2,7 +2,7 @@
     <div class="span12">
         <div class="pull-right">
            {% if conversation.ended %}
-                <h4 class="btn btn-info"><i class="icon-ok icon-white"></i> Conversation ended on {{conversation.end_date|date:"d F Y"}}</h4>
+                <h4 class="btn btn-info"><i class="icon-ok icon-white"></i> Conversation ended on {{conversation.archived_at|date:"d F Y"}}</h4>
             {% else %}
                 <form id="conversation-end" name="conversation-end" method="post" action="{{ conversation.get_absolute_url }}end/">
                     {% csrf_token %}
@@ -10,7 +10,7 @@
                 </form>
             {% endif %}
         </div>
-        <span class="label label-info">{{conversation.start_timestamp|date:"d F Y"}}</span> 
+        <span class="label label-info">{{conversation.created_at|date:"d F Y"}}</span> 
         <span class="label">{{conversation.delivery_class_description}}</span> 
 
         {% for group in conversation.groups.get_all %}

--- a/go/conversation/templates/generic/includes/ended-button.html
+++ b/go/conversation/templates/generic/includes/ended-button.html
@@ -1,1 +1,1 @@
-<h4 class="btn btn-info"><i class="icon-ok icon-white"></i> Conversation ended on {{conversation.end_date|date:"d F Y"}}</h4>
+<h4 class="btn btn-info"><i class="icon-ok icon-white"></i> Conversation ended on {{conversation.archived_at|date:"d F Y"}}</h4>

--- a/go/conversation/templates/generic/includes/overview.html
+++ b/go/conversation/templates/generic/includes/overview.html
@@ -9,7 +9,7 @@
                 </form>
             {% endif %}
         </div>
-        <span class="label label-info">{{conversation.start_timestamp|date:"d F Y"}}</span>
+        <span class="label label-info">{{conversation.created_at|date:"d F Y"}}</span>
         <span class="label">{{conversation.delivery_class_description}}</span>
 
         {% for group in conversation.get_groups %}

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -272,7 +272,7 @@ class VumiUserApi(object):
                         'going with most recent: %r' % (conv_keys,))
 
         conversation = sorted(conversations, reverse=True,
-                              key=lambda c: c.start_timestamp)[0]
+                              key=lambda c: c.created_at)[0]
         returnValue(conversation)
 
     @Manager.calls_manager
@@ -667,6 +667,15 @@ class VumiApiCommand(Message):
                                  # JSON.
             'kwargs': kwargs,
         })
+
+    @classmethod
+    def conversation_command(cls, worker_name, command_name, user_account_key,
+                             conversation_key, *args, **kwargs):
+        kwargs.update({
+            'user_account_key': user_account_key,
+            'conversation_key': conversation_key,
+        })
+        return cls.command(worker_name, command_name, *args, **kwargs)
 
 
 class VumiApiEvent(Message):

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -23,7 +23,6 @@ from vumi import log
 from go.vumitools.account import AccountStore, RoutingTableHelper, GoConnector
 from go.vumitools.contact import ContactStore
 from go.vumitools.conversation import ConversationStore
-from go.vumitools.conversation.models import CONVERSATION_DRAFT
 from go.vumitools.conversation.utils import ConversationWrapper
 from go.vumitools.credit import CreditManager
 from go.vumitools.middleware import DebitAccountMiddleware
@@ -163,9 +162,9 @@ class VumiUserApi(object):
 
     @Manager.calls_manager
     def draft_conversations(self):
+        # TODO: Get rid of this once the old UI finally goes away.
         conversations = yield self.active_conversations()
-        returnValue([c for c in conversations
-                        if c.get_status() == CONVERSATION_DRAFT])
+        returnValue([c for c in conversations if c.is_draft()])
 
     @Manager.calls_manager
     def tagpools(self):

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -154,13 +154,17 @@ class GoWorkerMixin(object):
             return self.process_unknown_cmd(cmd_method_name, *args, **kwargs)
 
     @inlineCallbacks
+    def process_command_start(self, user_account_key, conversation_key):
+        pass
+
+    @inlineCallbacks
     def process_command_collect_metrics(self, conversation_key,
                                         user_account_key):
         key_tuple = (conversation_key, user_account_key)
         if key_tuple in self._metrics_conversations:
             log.info("Ignoring conversation %s for user %s because the "
                      "previous collection run is still going." % (
-                        conversation_key, user_account_key))
+                         conversation_key, user_account_key))
             return
         self._metrics_conversations.add(key_tuple)
         user_api = self.get_user_api(user_account_key)
@@ -174,7 +178,7 @@ class GoWorkerMixin(object):
         if key_tuple in self._cache_recon_conversations:
             log.info("Ignoring conversation %s for user %s because the "
                      "previous cache recon run is still going." % (
-                        conversation_key, user_account_key))
+                         conversation_key, user_account_key))
             return
         self._cache_recon_conversations.add(key_tuple)
         user_api = self.get_user_api(user_account_key)
@@ -231,21 +235,6 @@ class GoWorkerMixin(object):
             contact = yield user_api.contact_store.contact_for_addr(
                 conv.delivery_class, message.user(), create=create)
             returnValue(contact)
-
-    @inlineCallbacks
-    def get_user_account(self, batch_id):
-        batch = yield self.vumi_api.mdb.get_batch(batch_id)
-        if batch is None:
-            log.error('Cannot find batch for batch_id %s' % (batch_id,))
-            return
-
-        user_account_key = batch.metadata["user_account"]
-        if user_account_key is None:
-            log.error("No account key in batch metadata: %r" % (batch,))
-            return
-
-        user_account = yield self.vumi_api.get_user_account(user_account_key)
-        returnValue(user_account)
 
     @inlineCallbacks
     def get_conversation(self, batch_id, conversation_key):

--- a/go/vumitools/conversation/migrators.py
+++ b/go/vumitools/conversation/migrators.py
@@ -68,6 +68,8 @@ class ConversationMigrator(ModelMigrator):
             status = u'stopped'
         elif mdata.old_data['status'] == u'running':
             status = u'running'
+        elif mdata.old_data['status'] == u'draft':
+            status = u'stopped'
 
         mdata.set_value('status', status, index='status_bin')
         mdata.set_value('archive_status', archive_status,

--- a/go/vumitools/conversation/migrators.py
+++ b/go/vumitools/conversation/migrators.py
@@ -10,8 +10,13 @@ class ConversationMigrator(ModelMigrator):
             'start_timestamp', 'end_timestamp', 'created_at',
             'delivery_class', 'delivery_tag_pool')
         # Sometimes we don't have a delivery_tag field.
-        mdata.set_value('delivery_tag', mdata.old_data.get('delivery_tag', None))
+        delivery_tag = mdata.old_data.get('delivery_tag', None)
+        mdata.set_value('delivery_tag', delivery_tag)
         mdata.copy_indexes('user_account_bin', 'groups_bin', 'batches_bin')
+        # Set values for possible ancient index-only fields.
+        mdata.set_value('user_account', mdata.new_index['user_account_bin'][0])
+        mdata.set_value('groups', mdata.new_index['groups_bin'])
+        mdata.set_value('batches', mdata.new_index['batches_bin'])
 
         # Add stuff that's new in this version
         mdata.set_value('$VERSION', 1)
@@ -35,5 +40,37 @@ class ConversationMigrator(ModelMigrator):
         mdata.add_index(
             'start_timestamp_bin', mdata.new_data['start_timestamp'])
         mdata.add_index('created_at_bin', mdata.new_data['created_at'])
+
+        return mdata
+
+    def migrate_from_1(self, mdata):
+        # Copy stuff that hasn't changed between versions
+        mdata.copy_values(
+            'user_account', 'name', 'description', 'conversation_type',
+            'config', 'created_at', 'groups', 'batches', 'delivery_class',
+            'delivery_tag_pool', 'delivery_tag')
+        mdata.copy_indexes(
+            'user_account_bin', 'conversation_type_bin', 'created_at_bin',
+            'end_timestamp_bin', 'groups_bin', 'batches_bin')
+
+        # Add stuff that's new in this version
+        mdata.set_value('$VERSION', 2)
+        mdata.set_value('extra_endpoints', [])
+        mdata.set_value('archived_at', mdata.old_data['end_timestamp'])
+
+        # We don't use the constants here because they may change or disappear
+        # underneath us in the future.
+        archive_status = u'active'
+        status = u'draft'
+
+        if mdata.old_data['status'] == u'finished':
+            archive_status = u'archived'
+            status = u'stopped'
+        elif mdata.old_data['status'] == u'running':
+            status = u'running'
+
+        mdata.set_value('status', status, index='status_bin')
+        mdata.set_value('archive_status', archive_status,
+                        index='archive_status_bin')
 
         return mdata

--- a/go/vumitools/conversation/models.py
+++ b/go/vumitools/conversation/models.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from vumi.persist.model import Model, Manager
 from vumi.persist.fields import (
-    Unicode, ManyToMany, ForeignKey, Timestamp, Json)
+    Unicode, ManyToMany, ForeignKey, Timestamp, Json, ListOf)
 from vumi.components.message_store import Batch
 
 from twisted.internet.defer import returnValue
@@ -15,15 +15,20 @@ from go.vumitools.contact import ContactGroup
 from go.vumitools.conversation.migrators import ConversationMigrator
 
 
+CONVERSATION_ACTIVE = u'active'
+CONVERSATION_ARCHIVED = u'archived'
+
 CONVERSATION_DRAFT = u'draft'
+CONVERSATION_STARTING = u'starting'
 CONVERSATION_RUNNING = u'running'
-CONVERSATION_FINISHED = u'finished'
+CONVERSATION_STOPPING = u'stopping'
+CONVERSATION_STOPPED = u'stopped'
 
 
 class Conversation(Model):
     """A conversation with an audience"""
 
-    VERSION = 1
+    VERSION = 2
     MIGRATOR = ConversationMigrator
 
     user_account = ForeignKey(UserAccount)
@@ -31,10 +36,12 @@ class Conversation(Model):
     description = Unicode(default=u'')
     conversation_type = Unicode(index=True)
     config = Json(default=dict)
+    extra_endpoints = ListOf(Unicode())
 
     created_at = Timestamp(default=datetime.utcnow, index=True)
-    start_timestamp = Timestamp(index=True)
-    end_timestamp = Timestamp(null=True, index=True)
+    archived_at = Timestamp(null=True, index=True)
+
+    archive_status = Unicode(default=CONVERSATION_ACTIVE, index=True)
     status = Unicode(default=CONVERSATION_DRAFT, index=True)
 
     groups = ManyToMany(ContactGroup)
@@ -44,32 +51,51 @@ class Conversation(Model):
     delivery_tag_pool = Unicode(null=True)
     delivery_tag = Unicode(null=True)
 
-    def started(self):
-        return self.running() or self.ended()
+    def active(self):
+        return self.archive_status == CONVERSATION_ACTIVE
+
+    def archived(self):
+        return self.archive_status == CONVERSATION_ARCHIVED
 
     def ended(self):
-        return self.status == CONVERSATION_FINISHED
+        return self.archived()
 
     def running(self):
         return self.status == CONVERSATION_RUNNING
 
     def get_status(self):
-        """
-        Get the status of this conversation
+        """Get the status of this conversation.
 
-        :rtype: str, (CONVERSATION_FINISHED, CONVERSATION_RUNNING, or
-            CONVERSATION_DRAFT)
+        Possible values are:
+
+          * CONVERSATION_DRAFT
+          * CONVERSATION_STARTING
+          * CONVERSATION_RUNNING
+          * CONVERSATION_STOPPING
+          * CONVERSATION_STOPPED
+          * CONVERSATION_FINISHED
+
+        :rtype: str
 
         """
         return self.status
 
     # The following are to keep the implementation of this stuff in the model
     # rather than potentially multiple external places.
+    def set_status_starting(self):
+        self.status = CONVERSATION_STARTING
+
     def set_status_started(self):
         self.status = CONVERSATION_RUNNING
 
+    def set_status_stopping(self):
+        self.status = CONVERSATION_STOPPING
+
+    def set_status_stopped(self):
+        self.status = CONVERSATION_STOPPED
+
     def set_status_finished(self):
-        self.status = CONVERSATION_FINISHED
+        self.archive_status = CONVERSATION_ARCHIVED
 
     def add_group(self, group):
         if isinstance(group, ContactGroup):
@@ -108,9 +134,8 @@ class ConversationStore(PerAccountStore):
 
     @Manager.calls_manager
     def new_conversation(self, conversation_type, name, description, config,
-                         start_timestamp=None, **fields):
+                         **fields):
         conversation_id = uuid4().get_hex()
-        start_timestamp = start_timestamp or datetime.utcnow()
 
         # These are foreign keys.
         groups = fields.pop('groups', [])
@@ -118,8 +143,7 @@ class ConversationStore(PerAccountStore):
         conversation = self.conversations(
             conversation_id, user_account=self.user_account_key,
             conversation_type=conversation_type, name=name,
-            description=description, config=config,
-            start_timestamp=start_timestamp, **fields)
+            description=description, config=config, **fields)
 
         for group in groups:
             conversation.add_group(group)
@@ -129,38 +153,21 @@ class ConversationStore(PerAccountStore):
 
     @Manager.calls_manager
     def list_running_conversations(self):
-        # We need to list things by both the old-style 'end_timestamp' index
-        # and the new-style 'status' index, at least until we've migrated all
-        # old-style conversations to v1.
         keys = yield self.conversations.index_lookup(
             'status', CONVERSATION_RUNNING).get_keys()
-        keys.extend((yield self._list_oldstyle_running_conversations()))
-        returnValue(list(set(keys)))  # Dedupe
-
-    @Manager.calls_manager
-    def _list_oldstyle_running_conversations(self):
-        keys = yield self.conversations.index_lookup(
-            'end_timestamp', None).get_keys()
-        # NOTE: This assumes that we don't have very large numbers of active
-        #       conversations.
-        filtered_keys = []
-        for convs_bunch in self.load_all_bunches(keys):
-            for conv in (yield convs_bunch):
-                if conv.running:
-                    filtered_keys = conv.key
-        returnValue(filtered_keys)
+        returnValue(keys)
 
     @Manager.calls_manager
     def list_active_conversations(self):
-        # We need to list things by both the old-style 'end_timestamp' index
-        # and the new-style 'status' index, at least until we've migrated all
-        # old-style conversations to v1.
+        # We need to list things by both the old-style 'status' index and the
+        # new-style 'archive_status' index, at least until we've migrated all
+        # old-style conversations to v2.
         keys = yield self.conversations.index_lookup(
-            'status', CONVERSATION_RUNNING).get_keys()
+            'archive_status', CONVERSATION_ACTIVE).get_keys()
         keys.extend((yield self.conversations.index_lookup(
             'status', CONVERSATION_DRAFT).get_keys()))
         keys.extend((yield self.conversations.index_lookup(
-            'end_timestamp', None).get_keys()))
+            'status', CONVERSATION_RUNNING).get_keys()))
         returnValue(list(set(keys)))  # Dedupe.
 
     def load_all_bunches(self, keys):

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -39,9 +39,15 @@ class ConversationWrapper(object):
 
     @Manager.calls_manager
     def end_conversation(self):
-        self.c.set_status_stopped()
+        # TODO: `stop' and `archive' should be different operations.
+        self.c.set_status_stopping()
         self.c.set_status_finished()
         yield self.c.save()
+
+        yield self.dispatch_command('stop',
+                                    user_account_key=self.c.user_account.key,
+                                    conversation_key=self.c.key)
+
         yield self._remove_from_routing_table()
         yield self._release_batches()
 

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -39,7 +39,7 @@ class ConversationWrapper(object):
 
     @Manager.calls_manager
     def end_conversation(self):
-        self.c.end_timestamp = datetime.utcnow()
+        self.c.set_status_stopped()
         self.c.set_status_finished()
         yield self.c.save()
         yield self._remove_from_routing_table()

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -167,7 +167,7 @@ class ConversationWrapper(object):
 
     @Manager.calls_manager
     def start(self, no_batch_tag=False, batch_id=None, acquire_tag=True,
-                **extra_params):
+              **extra_params):
         """
         Send the start command to this conversations application worker.
 
@@ -223,16 +223,20 @@ class ConversationWrapper(object):
             outbound_only = not acquire_tag  # XXX: Hack for seq send.
             yield self._add_to_routing_table(tag, outbound_only=outbound_only)
 
+        yield self.dispatch_command('start',
+                                    user_account_key=self.c.user_account.key,
+                                    conversation_key=self.c.key)
+
         msg_options = yield self.make_message_options(tag)
 
         is_client_initiated = yield self.is_client_initiated()
-        yield self.dispatch_command('start',
-            batch_id=batch_id,
-            conversation_type=self.c.conversation_type,
-            conversation_key=self.c.key,
-            msg_options=msg_options,
-            is_client_initiated=is_client_initiated,
-            **extra_params)
+        yield self.dispatch_command('initial_action_hack',
+                                    user_account_key=self.c.user_account.key,
+                                    conversation_key=self.c.key,
+                                    batch_id=batch_id,
+                                    msg_options=msg_options,
+                                    is_client_initiated=is_client_initiated,
+                                    **extra_params)
 
         if batch_id not in self.get_batch_keys():
             self.c.batches.add_key(batch_id)
@@ -291,14 +295,17 @@ class ConversationWrapper(object):
         # the token in it.
         yield self._add_to_routing_table(tag)
 
-        yield self.dispatch_command('send_message', command_data={
-            "batch_id": batch_id,
-            "to_addr": msisdn,
-            "conversation_key": self.c.key,
-            "msg_options": msg_options,
-            "content": ("Please visit %s to start your conversation." %
-                        (token_url,)),
-        })
+        yield self.dispatch_command(
+            'send_message',
+            user_account_key=self.c.user_account.key,
+            conversation_key=self.c.key,
+            command_data={
+                "batch_id": batch_id,
+                "to_addr": msisdn,
+                "msg_options": msg_options,
+                "content": ("Please visit %s to start your conversation." %
+                            (token_url,)),
+                })
         self.c.batches.add_key(batch_id)
         yield self.c.save()
 

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -187,11 +187,12 @@ class SendingEventDispatcherTestCase(AppWorkerTestCase):
                 conv_key=conversation.key)
         yield self.publish_event(event)
 
-        [start_command, api_command] = self._amqp.get_messages('vumi',
-                                                               'vumi.api')
-        self.assertEqual(start_command['command'], 'start')
-        self.assertEqual(api_command['worker_name'], 'other_worker')
-        self.assertEqual(api_command['kwargs']['command_data'], {
+        [start_cmd, hack_cmd, api_cmd] = self._amqp.get_messages('vumi',
+                                                                 'vumi.api')
+        self.assertEqual(start_cmd['command'], 'start')
+        self.assertEqual(hack_cmd['command'], 'initial_action_hack')
+        self.assertEqual(api_cmd['worker_name'], 'other_worker')
+        self.assertEqual(api_cmd['kwargs']['command_data'], {
                 'content': 'hello',
                 'batch_id': conversation.batches.keys()[0],
                 'to_addr': '12345',

--- a/go/vumitools/tests/test_conversation.py
+++ b/go/vumitools/tests/test_conversation.py
@@ -55,7 +55,7 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual({u'foo': u'bar'}, conv.config)
         self.assertEqual([], conv.batches.keys())
         self.assertEqual(u'active', conv.archive_status)
-        self.assertEqual(u'draft', conv.status)
+        self.assertEqual(u'stopped', conv.status)
 
         dbconv = yield self.conv_store.get_conversation_by_key(conv.key)
         self.assert_models_equal(conv, dbconv)
@@ -74,7 +74,7 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual({u'foo': u'Zoë again.'}, conv.config)
         self.assertEqual([], conv.batches.keys())
         self.assertEqual(u'active', conv.archive_status)
-        self.assertEqual(u'draft', conv.status)
+        self.assertEqual(u'stopped', conv.status)
 
         dbconv = yield self.conv_store.get_conversation_by_key(conv.key)
         self.assert_models_equal(conv, dbconv)
@@ -98,7 +98,7 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual({}, dbconv.config)
         self.assertEqual([], dbconv.batches.keys())
         self.assertEqual(u'active', dbconv.archive_status)
-        self.assertEqual(u'draft', dbconv.status)
+        self.assertEqual(u'stopped', dbconv.status)
 
     @inlineCallbacks
     def test_get_conversation_v1(self):
@@ -119,7 +119,7 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual({}, dbconv.config)
         self.assertEqual([], dbconv.batches.keys())
         self.assertEqual(u'active', dbconv.archive_status)
-        self.assertEqual(u'draft', dbconv.status)
+        self.assertEqual(u'stopped', dbconv.status)
 
 
 class TestConversationStoreSync(TestConversationStore):

--- a/go/vumitools/tests/test_conversation.py
+++ b/go/vumitools/tests/test_conversation.py
@@ -13,7 +13,8 @@ from go.vumitools.account import AccountStore
 from go.vumitools.conversation import ConversationStore
 from go.vumitools.opt_out import OptOutStore
 from go.vumitools.contact import ContactStore
-from go.vumitools.conversation.old_models import ConversationVNone
+from go.vumitools.conversation.old_models import (
+    ConversationVNone, ConversationV1)
 
 
 class TestConversationStore(GoPersistenceMixin, TestCase):
@@ -53,6 +54,8 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual(u'desc', conv.description)
         self.assertEqual({u'foo': u'bar'}, conv.config)
         self.assertEqual([], conv.batches.keys())
+        self.assertEqual(u'active', conv.archive_status)
+        self.assertEqual(u'draft', conv.status)
 
         dbconv = yield self.conv_store.get_conversation_by_key(conv.key)
         self.assert_models_equal(conv, dbconv)
@@ -70,12 +73,14 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual(u'Return of Zoë!', conv.description)
         self.assertEqual({u'foo': u'Zoë again.'}, conv.config)
         self.assertEqual([], conv.batches.keys())
+        self.assertEqual(u'active', conv.archive_status)
+        self.assertEqual(u'draft', conv.status)
 
         dbconv = yield self.conv_store.get_conversation_by_key(conv.key)
         self.assert_models_equal(conv, dbconv)
 
     @inlineCallbacks
-    def test_get_old_conversation(self):
+    def test_get_conversation_vnone(self):
         conversation_id = uuid4().get_hex()
 
         conv = yield ConversationVNone(
@@ -92,6 +97,29 @@ class TestConversationStore(GoPersistenceMixin, TestCase):
         self.assertEqual(u'message', dbconv.description)
         self.assertEqual({}, dbconv.config)
         self.assertEqual([], dbconv.batches.keys())
+        self.assertEqual(u'active', dbconv.archive_status)
+        self.assertEqual(u'draft', dbconv.status)
+
+    @inlineCallbacks
+    def test_get_conversation_v1(self):
+        conversation_id = uuid4().get_hex()
+
+        conv = yield ConversationV1(
+            self.conv_store.manager,
+            conversation_id, user_account=self.conv_store.user_account_key,
+            conversation_type=u'bulk_message', name=u'name',
+            description=u'description', status=u'draft',
+            start_timestamp=datetime.utcnow()).save()
+
+        dbconv = yield self.conv_store.get_conversation_by_key(conv.key)
+
+        self.assertEqual(u'bulk_message', dbconv.conversation_type)
+        self.assertEqual(u'name', dbconv.name)
+        self.assertEqual(u'description', dbconv.description)
+        self.assertEqual({}, dbconv.config)
+        self.assertEqual([], dbconv.batches.keys())
+        self.assertEqual(u'active', dbconv.archive_status)
+        self.assertEqual(u'draft', dbconv.status)
 
 
 class TestConversationStoreSync(TestConversationStore):

--- a/go/vumitools/tests/test_metrics_worker.py
+++ b/go/vumitools/tests/test_metrics_worker.py
@@ -54,7 +54,6 @@ class GoMetricsWorkerTestCase(VumiWorkerTestCase, GoPersistenceMixin):
         return conv.save()
 
     def end_conv(self, conv):
-        conv.end_timestamp = datetime.utcnow()
         conv.set_status_finished()
         return conv.save()
 

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -282,10 +282,12 @@ class GoAppWorkerTestMixin(GoPersistenceMixin):
 
     @inlineCallbacks
     def start_conversation(self, conversation, *args, **kwargs):
+        old_cmds = len(self.get_dispatcher_commands())
         yield conversation.start(*args, **kwargs)
-        cmd = self.get_dispatcher_commands()[-1].payload
-        yield self.dispatch_command(
-            cmd['command'], *cmd['args'], **cmd['kwargs'])
+        for cmd in self.get_dispatcher_commands()[old_cmds:]:
+            yield self.dispatch_command(
+                cmd.payload['command'], *cmd.payload['args'],
+                **cmd.payload['kwargs'])
 
     def poll_metrics(self, assert_prefix=None, app=None):
         if app is None:

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -10,7 +10,8 @@ from twisted.python.monkey import MonkeyPatcher
 from twisted.internet.defer import inlineCallbacks, returnValue
 from celery.app import app_or_default
 
-from vumi.persist.fields import ForeignKeyProxy, ManyToManyProxy, DynamicProxy
+from vumi.persist.fields import (
+    ForeignKeyProxy, ManyToManyProxy, DynamicProxy, ListProxy)
 from vumi.message import TransportEvent
 from vumi.application.tests.test_base import ApplicationTestCase
 from vumi.tests.utils import PersistenceMixin
@@ -29,6 +30,8 @@ def field_eq(f1, f2):
         return f1.key == f2.key
     if isinstance(f1, DynamicProxy) and isinstance(f2, DynamicProxy):
         return f1.items() == f2.items()
+    if isinstance(f1, ListProxy) and isinstance(f2, ListProxy):
+        return list(f1) == list(f2)
     return False
 
 

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -255,7 +255,7 @@ class OldGoMessageMetadata(object):
             log.warning('Multiple conversations found '
                         'going with most recent: %r' % (conv_keys,))
         conversation = sorted(conversations, reverse=True,
-                              key=lambda c: c.start_timestamp)[0]
+                              key=lambda c: c.created_at)[0]
 
         self._go_metadata['conversation_key'] = conversation.key
         self._go_metadata['conversation_type'] = conversation.conversation_type


### PR DESCRIPTION
We currently have routing and certain conversation operations (such as bulk send) tied to conversation lifecycle transitions. We need to decouple these in the backend to make the new routing and UI features possible.
