### PR TITLE
Consolidate SMS & USSD Wikipedia apps.

### DIFF
--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -388,6 +388,8 @@ class ContactsResource(SandboxResource):
                 user_account=contact_store.user_account_key,
                 **ContactStore.settable_contact_fields(**fields))
 
+            # since we are basically creating a 'new' contact with the same
+            # key, we can be sure that the old groups were removed
             for group in groups:
                 contact.add_to_group(group)
 

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -435,12 +435,14 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             name=u'A Random',
             surname=u'Jackal',
             msisdn=u'+27831234567',
+            groups=['a', 'b', 'c'],
             extra={u'foo': u'bar', u'lorem': u'ipsum'})
 
         reply = yield self.dispatch_command('save', contact={
             'key': contact.key,
             'surname': u'Robot',
             'msisdn': u'unknown',
+            'groups': ['a', 'd', 'f'],
             'extra': {u'baz': u'qux'},
         })
 
@@ -448,6 +450,7 @@ class TestContactsResource(ResourceTestCaseBase, GoPersistenceMixin):
             'key': contact.key,
             'surname': u'Robot',
             'msisdn': u'unknown',
+            'groups': ['a', 'd', 'f'],
             'extras-baz': u'qux',
         }
         self.check_reply(reply, contact=expected_contact_fields)


### PR DESCRIPTION
Currently we have two conversation types, SMS & USSD. This was a hack due to lack of good enough routing options. When that lands & is deployed we need to consolidate the two into a single application.
