### PR TITLE
Client side needs view collections

### DIFF
--- a/go/base/static/js/src/components/components.js
+++ b/go/base/static/js/src/components/components.js
@@ -1,0 +1,6 @@
+// go.components
+// =============
+// Reusable components for Go
+
+(function(exports) {
+})(go.components = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -3,7 +3,8 @@
 // Reusable, generic structures for Go
 
 (function(exports) {
-  var merge = go.utils.merge;
+  var merge = go.utils.merge,
+      GoError = go.errors.GoError;
 
   // Acts as a 'base' for class-like objects which can be extended (with the
   // prototype chain set up automatically)
@@ -81,25 +82,31 @@
       _.bindAll(this);
 
       this.models = collection;
-      this.models
-        .map(function(m) { return m.id; })
-        .forEach(this.add);
+      this.models.each(this._add);
 
-      this.models.on('add', function(m) { self.add(m.id); });
-      this.models.on('remove', function(m) { self.remove(m.id); });
+      this.models.on('add', this._add);
+      this.models.on('remove', this._remove);
     },
 
     // Override to specialise how the view is created
     create: function(model) { return new Backbone.View({model: model}); },
 
-    add: function(id) {
-      var view = this.create(this.models.get(id));
-      Lookup.prototype.add.call(this, id, view);
+    add: function() {
+      throw new GoError("ViewCollections cannot be added to externally");
+    },
+
+    remove: function() {
+      throw new GoError("ViewCollections cannot be removed from externally");
+    },
+
+    _add: function(model) {
+      var view = this.create(model);
+      Lookup.prototype.add.call(this, model.id, view);
       view.render();
     },
 
-    remove: function(id) {
-      var view = Lookup.prototype.remove.call(this, id);
+    _remove: function(model) {
+      var view = Lookup.prototype.remove.call(this, model.id);
       if (view && typeof view.destroy === 'function') { view.destroy(); }
       return view;
     },

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -75,14 +75,16 @@
   //   - 'remove' (id, view) - Emitted when a view is removed
   exports.ViewCollection = Lookup.extend({
     constructor: function(collection) {
+      var self = this;
+
       Lookup.prototype.constructor.call(this);
       _.bindAll(this);
 
       this.models = collection;
       this._modelIds().forEach(this.add);
 
-      this.models.on('add', this.render);
-      this.models.on('remove', this.render);
+      this.models.on('add', function(m) { self.add(m.id); });
+      this.models.on('remove', function(m) { self.remove(m.id); });
     },
 
     _modelId: function(m) { return m.id; },

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -24,14 +24,17 @@
   // Similar to a Backbone Collection, except the contents are key-value pairs
   // instead of models.
   //
+  // Arguments:
+  //   - items: the initial objects to be added
+  //
   // Events emitted:
   //   - 'add' (key, value) - Emitted when an item is added
   //   - 'remove' (key, value) - Emitted when an item is removed
-  exports.Lookup = exports.Eventable.extend({
-    // Arguments:
-    //   - items: the initial objects to be added
+  var Lookup = exports.Lookup = exports.Eventable.extend({
     constructor: function(items) {
       this._items = {};
+
+      items = items || {};
       for (var k in items) { this.add(k, items[k]); }
     },
 
@@ -54,6 +57,65 @@
         this.trigger('remove', key, value);
       }
       return value;
+    }
+  });
+
+  // Accepts a collection of models and maintains a corresponding collection of
+  // views. New views are created when models are added to the collection, old
+  // views are removed when models are removed from the collection. Views can
+  // also be looked up by the id of their corresponding models. Useful in
+  // situations where views are to be created dynamically (for eg, state views
+  // in a state machine diagram).
+  //
+  // Arguments:
+  //   - collection: the collection of models to create views for
+  //
+  // Events emitted:
+  //   - 'add' (id, view) - Emitted when a view is added
+  //   - 'remove' (id, view) - Emitted when a view is removed
+  exports.ViewCollection = Lookup.extend({
+    constructor: function(collection) {
+      Lookup.prototype.constructor.call(this);
+      _.bindAll(this);
+
+      this.models = collection;
+      this._modelIds().forEach(this.add);
+
+      this.models.on('add', this.render);
+      this.models.on('remove', this.render);
+    },
+
+    _modelId: function(m) { return m.id; },
+    _modelIds: function(m) { return this.models.map(this._modelId); },
+
+    // Override to specialise how the view is created
+    create: function(model) { return new Backbone.View({model: model}); },
+
+    add: function(id) {
+      Lookup.prototype.add.call(this, id, this.create(this.models.get(id)));
+    },
+
+    remove: function(id) {
+      var view = Lookup.prototype.remove.call(this, id);
+      if (view && typeof view.destroy === 'function') { view.destroy(); }
+      return view;
+    },
+
+    render: function() {
+      var modelIds = this._modelIds(),
+          viewIds = this.keys();
+
+      // Remove 'dead' views
+      // (views with models that no longer exist)
+      _.difference(viewIds, modelIds)
+       .forEach(this.remove);
+
+      // Add 'new' view
+      // (models with no corresponding views)
+      _.difference(modelIds, viewIds)
+       .forEach(this.add);
+
+      this.values().forEach(function(v) { v.render(); });
     }
   });
 })(go.components.structures = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -81,14 +81,13 @@
       _.bindAll(this);
 
       this.models = collection;
-      this._modelIds().forEach(this.add);
+      this.models
+        .map(function(m) { return m.id; })
+        .forEach(this.add);
 
       this.models.on('add', function(m) { self.add(m.id); });
       this.models.on('remove', function(m) { self.remove(m.id); });
     },
-
-    _modelId: function(m) { return m.id; },
-    _modelIds: function(m) { return this.models.map(this._modelId); },
 
     // Override to specialise how the view is created
     create: function(model) { return new Backbone.View({model: model}); },

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -42,7 +42,7 @@
     values: function() { return _.values(this._items); },
     items: function() { return _.clone(this._items); },
 
-    get: function(key) { return this._items[key] || null; },
+    get: function(key) { return this._items[key]; },
 
     add: function(key, value) {
       this._items[key] = value;

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -15,4 +15,45 @@
     // `Backbone.Model`, since it has the function we are looking for.
     return Backbone.Model.extend.call(this, merge.apply(this, arguments));
   };
+
+  // A class-like object onto which events can be bound and emitted
+  exports.Eventable = exports.Extendable.extend(Backbone.Events);
+
+  // A structure that stores key-value pairs, provides helpful operations for
+  // accessing the data, and emits events when items are added or removed.
+  // Similar to a Backbone Collection, except the contents are key-value pairs
+  // instead of models.
+  //
+  // Events emitted:
+  //   - 'add' (key, value) - Emitted when an item is added
+  //   - 'remove' (key, value) - Emitted when an item is removed
+  exports.Lookup = exports.Eventable.extend({
+    // Arguments:
+    //   - items: the initial objects to be added
+    constructor: function(items) {
+      this._items = {};
+      for (var k in items) { this.add(k, items[k]); }
+    },
+
+    keys: function() { return _.keys(this._items); },
+    values: function() { return _.values(this._items); },
+    items: function() { return _.clone(this._items); },
+
+    get: function(key) { return this._items[key] || null; },
+
+    add: function(key, value) {
+      this._items[key] = value;
+      this.trigger('add', key, value);
+      return this;
+    },
+
+    remove: function(key) {
+      var value = this._items[key];
+      if (value) {
+        delete this._items[key];
+        this.trigger('remove', key, value);
+      }
+      return value;
+    }
+  });
 })(go.components.structures = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -92,7 +92,9 @@
     create: function(model) { return new Backbone.View({model: model}); },
 
     add: function(id) {
-      Lookup.prototype.add.call(this, id, this.create(this.models.get(id)));
+      var view = this.create(this.models.get(id));
+      Lookup.prototype.add.call(this, id, view);
+      view.render();
     },
 
     remove: function(id) {
@@ -102,19 +104,6 @@
     },
 
     render: function() {
-      var modelIds = this._modelIds(),
-          viewIds = this.keys();
-
-      // Remove 'dead' views
-      // (views with models that no longer exist)
-      _.difference(viewIds, modelIds)
-       .forEach(this.remove);
-
-      // Add 'new' view
-      // (models with no corresponding views)
-      _.difference(modelIds, viewIds)
-       .forEach(this.add);
-
       this.values().forEach(function(v) { v.render(); });
     }
   });

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -1,0 +1,18 @@
+// go.components.structures
+// ========================
+// Reusable, generic structures for Go
+
+(function(exports) {
+  var merge = go.utils.merge;
+
+  // Acts as a 'base' for class-like objects which can be extended (with the
+  // prototype chain set up automatically)
+  exports.Extendable = function () {};
+
+  exports.Extendable.extend = function() {
+    // Backbone has an internal `extend()` function which it assigns to its
+    // structures. We need this function, so we arbitrarily choose
+    // `Backbone.Model`, since it has the function we are looking for.
+    return Backbone.Model.extend.call(this, merge.apply(this, arguments));
+  };
+})(go.components.structures = {});

--- a/go/base/static/js/src/utils.js
+++ b/go/base/static/js/src/utils.js
@@ -9,24 +9,6 @@
     return _.extend.apply(this, arguments);
   };
 
-  // Returns the internal prototype ([[Prototype]]) of the instance's internal
-  // prototype (One step up in the prototype chain, and thus the 'super'
-  // prototype).
-  //
-  // If `propName` is specified, a property on 'super' prototype is returned.
-  // If the property is a function, the function is bound to the instance.
-  exports.parent = function(that, propName) {
-    var proto = Object.getPrototypeOf(Object.getPrototypeOf(that)),
-        prop;
-
-    if (!propName) { return proto; }
-
-    prop = proto[propName];
-    return typeof prop === "function"
-      ? prop.bind(that)
-      : prop;
-  };
-
   exports.highlightActiveLinks = function() {
     // find links in the document that match the current
     // windows url and set them as active.

--- a/go/base/static/js/src/utils.js
+++ b/go/base/static/js/src/utils.js
@@ -3,18 +3,28 @@
 // Utilities and helpers for Go
 
 (function(exports) {
-  // Acts as a 'base' for class-like objects which can be extended (with the
-  // prototype chain set up automatically)
-  exports.Extendable = function () {};
-
-  // Backbone has an internal `extend()` function which it assigns to its
-  // structures. We need this function, so we arbitrarily choose
-  // `Backbone.Model`, since it has the `extend()` function we are looking for.
-  var extend = Backbone.Model.extend;
-
-  exports.Extendable.extend = function() {
+  // Merges the passed in objects together into a single object
+  var merge = exports.merge = function() {
     Array.prototype.unshift.call(arguments, {});
-    return extend.call(this, _.extend.apply(this, arguments));
+    return _.extend.apply(this, arguments);
+  };
+
+  // Returns the internal prototype ([[Prototype]]) of the instance's internal
+  // prototype (One step up in the prototype chain, and thus the 'super'
+  // prototype).
+  //
+  // If `propName` is specified, a property on 'super' prototype is returned.
+  // If the property is a function, the function is bound to the instance.
+  exports.parent = function(that, propName) {
+    var proto = Object.getPrototypeOf(Object.getPrototypeOf(that)),
+        prop;
+
+    if (!propName) { return proto; }
+
+    prop = proto[propName];
+    return typeof prop === "function"
+      ? prop.bind(that)
+      : prop;
   };
 
   exports.highlightActiveLinks = function() {

--- a/go/base/static/js/test/runner.html
+++ b/go/base/static/js/test/runner.html
@@ -25,12 +25,15 @@
     <script src="../src/go.js"></script>
     <script src="../src/errors.js"></script>
     <script src="../src/utils.js"></script>
+    <script src="../src/components/components.js"></script>
+    <script src="../src/components/structures.js"></script>
     <script src="../src/campaign/campaign.js"></script>
     <script src="../src/campaign/interactive.js"></script>
     <script src="../src/campaign/bulkMessage.js"></script>
 
     <script src="tests/errors.test.js"></script>
     <script src="tests/utils.test.js"></script>
+    <script src="tests/components/structures.test.js"></script>
     <script src="tests/campaign/bulkMessage.test.js"></script>
     <script>
       if (window.mochaPhantomJS) { mochaPhantomJS.run(); }

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -1,0 +1,42 @@
+describe("go.components.structures", function() {
+  describe(".Extendable", function() {
+    var Extendable = go.components.structures.Extendable;
+
+    it("should set up the prototype chain correctly", function() {
+      var Parent = Extendable.extend(),
+          Child = Parent.extend();
+
+       var child = new Child();
+       assert.instanceOf(child, Parent);
+       assert.instanceOf(child, Child);
+    });
+
+    it("should use a constructor function if specified", function() {
+      var Thing = Extendable.extend({
+        constructor: function (name) { this.name = name; }
+      });
+
+      assert.equal(new Thing('foo').name, 'foo');
+    });
+
+    it("should default to a parent's constructor", function() {
+      var Parent,
+          Child;
+
+      Parent = Extendable.extend({
+        constructor: function (name) { this.name = name; }
+      });
+      Child = Parent.extend();
+
+      assert.equal(new Child('foo').name, 'foo');
+    });
+
+    it("should accept multiple object arguments", function() {
+      var Thing = Extendable.extend({'a': 'one'}, {'b': 'two'}),
+          thing = new Thing();
+
+      assert.equal(thing.a, 'one');
+      assert.equal(thing.b, 'two');
+    });
+  });
+});

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -77,10 +77,6 @@ describe("go.components.structures", function() {
       it("should get a value by its key", function() {
         assert.equal(lookup.get('a'), 1);
       });
-
-      it("return null if the key does not exist", function() {
-        assert.equal(lookup.get('d'), null);
-      });
     });
 
     describe(".add", function() {
@@ -181,7 +177,7 @@ describe("go.components.structures", function() {
          function() {
         var viewC = views.get('c');
         assert.equal(views.remove('c'), viewC);
-        assert.equal(views.get('c'), null);
+        assert.isUndefined(views.get('c'));
       });
 
       it("should emit a 'remove' event", function(done) {

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -138,8 +138,8 @@ describe("go.components.structures", function() {
       views = new ToyViewCollection(models);
     });
 
-    describe("on 'add' collection events", function(done) {
-      it("should add a corresponding view", function(done) {
+    describe("on 'add' collection events", function() {
+      it("should add a view corresponding to the model", function(done) {
         models.on('add', function() {
           assert.equal(views.get('d').model, models.get('d'));
           done();
@@ -147,9 +147,28 @@ describe("go.components.structures", function() {
 
         models.add({id: 'd'});
       });
+
+      it("should emit an 'add' event", function(done) {
+        views.on('add', function(id, view) {
+          assert.equal(id, 'd');
+          assert.equal(view, views.get('d'));
+          done();
+        });
+
+        models.add({id: 'd'});
+      });
+
+      it("should render the added view", function(done) {
+        models.on('add', function() {
+          assert(views.get('d').rendered);
+          done();
+        });
+
+        models.add({id: 'd'});
+      });
     });
 
-    describe("on 'remove' collection events", function(done) {
+    describe("on 'remove' collection events", function() {
       it("should remove the corresponding view", function(done) {
         models.on('remove', function() {
           assert.isUndefined(views.get('c'));
@@ -157,49 +176,6 @@ describe("go.components.structures", function() {
         });
 
         models.remove('c');
-      });
-    });
-
-    describe(".add", function() {
-      beforeEach(function() {
-        // stop the view collection from automatically adding a view when a
-        // model is added to the model collection
-        models.off('add');
-      });
-
-      it("should add a view corresponding to the model with the passed in id",
-         function() {
-        models.add({id: 'd'});
-        views.add('d');
-        assert.equal(views.get('d').model, models.get('d'));
-      });
-
-      it("should emit an 'add' event", function(done) {
-        models.add({id: 'd'});
-
-        views.on('add', function(id, view) {
-          assert.equal(id, 'd');
-          assert.equal(view, views.get('d'));
-          done();
-        });
-
-        views.add('d');
-      });
-
-      it("should render the added view",
-         function() {
-        models.add({id: 'd'});
-        views.add('d');
-        assert(views.get('d').rendered);
-      });
-    });
-
-    describe(".remove", function() {
-      it("should remove the view with the model with the passed in id",
-         function() {
-        var viewC = views.get('c');
-        assert.equal(views.remove('c'), viewC);
-        assert.isUndefined(views.get('c'));
       });
 
       it("should emit a 'remove' event", function(done) {
@@ -211,15 +187,19 @@ describe("go.components.structures", function() {
           done();
         });
 
-        views.remove('c');
+        models.remove('c');
       });
 
-      it("should call the view's destroy() function if it exists", function() {
+      it("should call the view's destroy() function if it exists",
+         function(done) {
         var viewC = views.get('c');
 
-        assert(!viewC.destroyed);
-        views.remove('c');
-        assert(viewC.destroyed);
+        models.on('remove', function() {
+          assert(viewC.destroyed);
+          done();
+        });
+
+        models.remove('c');
       });
     });
 

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -1,4 +1,6 @@
 describe("go.components.structures", function() {
+  var structures = go.components.structures;
+
   describe(".Extendable", function() {
     var Extendable = go.components.structures.Extendable;
 
@@ -37,6 +39,82 @@ describe("go.components.structures", function() {
 
       assert.equal(thing.a, 'one');
       assert.equal(thing.b, 'two');
+    });
+  });
+
+  describe(".Lookup", function() {
+    var Lookup = structures.Lookup,
+        lookup;
+
+    beforeEach(function() {
+      lookup = new Lookup({a: 1, b: 2, c: 3});
+    });
+
+    describe(".keys", function() {
+      it("should get the lookup's item's keys", function() {
+        assert.deepEqual(lookup.keys(), ['a', 'b', 'c']);
+      });
+    });
+
+    describe(".values", function() {
+      it("should get the lookup's item's values", function() {
+        assert.deepEqual(lookup.values(), [1, 2, 3]);
+      });
+    });
+
+    describe(".items", function() {
+      it("should get a shallow copy of the lookup's items", function() {
+        var items = lookup.items();
+
+        items.a = 'one';
+        assert.deepEqual(items, {a: 'one', b: 2, c: 3});
+
+        assert.deepEqual(lookup.items(), {a: 1, b: 2, c: 3});
+      });
+    });
+
+    describe(".get", function() {
+      it("should get a value by its key", function() {
+        assert.equal(lookup.get('a'), 1);
+      });
+
+      it("return null if the key does not exist", function() {
+        assert.equal(lookup.get('d'), null);
+      });
+    });
+
+    describe(".add", function() {
+      it("should add the item to the lookup", function() {
+        assert.equal(lookup.add('d', 4), lookup);
+        assert.deepEqual(lookup.items(), {a: 1, b: 2, c: 3, d: 4});
+      });
+
+      it("should emit an 'add' event", function(done) {
+        lookup.on('add', function(key, value) {
+          assert.equal(key, 'd');
+          assert.equal(value, 4);
+          done();
+        });
+
+        lookup.add('d', 4);
+      });
+    });
+
+    describe(".remove", function() {
+      it("should remove an item from the lookup", function() {
+        assert.equal(lookup.remove('c'), 3);
+        assert.deepEqual(lookup.items(), {a: 1, b: 2});
+      });
+
+      it("should emit a 'remove' event", function(done) {
+        lookup.on('remove', function(key, value) {
+          assert.equal(key, 'c');
+          assert.equal(value, 3);
+          done();
+        });
+
+        lookup.remove('c');
+      });
     });
   });
 });

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -167,6 +167,13 @@ describe("go.components.structures", function() {
 
         views.add('d');
       });
+
+      it("should render the added view",
+         function() {
+        models.add({id: 'd'});
+        views.add('d');
+        assert(views.get('d').rendered);
+      });
     });
 
     describe(".remove", function() {
@@ -199,31 +206,8 @@ describe("go.components.structures", function() {
     });
 
     describe(".render()", function() {
-      beforeEach(function() {
-        // stop the view collection from automatically rendering when a model is
-        // added/removed from the model collection
-        models.off('add');
-        models.off('remove');
-      });
-
-      it("should remove 'dead' views", function() {
-        models.remove('c');
-
-        assert.deepEqual(views.keys(), ['a', 'b', 'c']);
-        views.render();
-        assert.deepEqual(views.keys(), ['a', 'b']);
-      });
-
-      it("should add 'new' views", function() {
-        models.add({id: 'd'});
-
-        assert.deepEqual(views.keys(), ['a', 'b', 'c']);
-        views.render();
-        assert.deepEqual(views.keys(), ['a', 'b', 'c', 'd']);
-      });
-
       it("should render all the views in the collection", function() {
-        views.values().forEach(function(v) { assert(!v.rendered); });
+        views.values().forEach(function(v) { v.rendered = false; });
         views.render();
         views.values().forEach(function(v) { assert(v.rendered); });
       });

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -138,6 +138,28 @@ describe("go.components.structures", function() {
       views = new ToyViewCollection(models);
     });
 
+    describe("on 'add' collection events", function(done) {
+      it("should add a corresponding view", function(done) {
+        models.on('add', function() {
+          assert.equal(views.get('d').model, models.get('d'));
+          done();
+        });
+
+        models.add({id: 'd'});
+      });
+    });
+
+    describe("on 'remove' collection events", function(done) {
+      it("should remove the corresponding view", function(done) {
+        models.on('remove', function() {
+          assert.isUndefined(views.get('c'));
+          done();
+        });
+
+        models.remove('c');
+      });
+    });
+
     describe(".add", function() {
       beforeEach(function() {
         // stop the view collection from automatically adding a view when a

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -124,7 +124,12 @@ describe("go.components.structures", function() {
         views;
 
     var ToyView = Backbone.View.extend({
-      initialize: function() { this.rendered = false; },
+      initialize: function() {
+        this.rendered = false;
+        this.destroyed = false;
+      },
+
+      destroy: function() { this.destroyed = true; },
       render: function() { this.rendered = true; }
     });
 
@@ -167,9 +172,9 @@ describe("go.components.structures", function() {
     describe(".remove", function() {
       it("should remove the view with the model with the passed in id",
          function() {
-           var viewC = views.get('c');
-           assert.equal(views.remove('c'), viewC);
-           assert.equal(views.get('c'), null);
+        var viewC = views.get('c');
+        assert.equal(views.remove('c'), viewC);
+        assert.equal(views.get('c'), null);
       });
 
       it("should emit a 'remove' event", function(done) {
@@ -182,6 +187,14 @@ describe("go.components.structures", function() {
         });
 
         views.remove('c');
+      });
+
+      it("should call the view's destroy() function if it exists", function() {
+        var viewC = views.get('c');
+
+        assert(!viewC.destroyed);
+        views.remove('c');
+        assert(viewC.destroyed);
       });
     });
 

--- a/go/base/static/js/test/tests/utils.test.js
+++ b/go/base/static/js/test/tests/utils.test.js
@@ -28,32 +28,4 @@ describe("go.utils", function() {
       assert.deepEqual(c, {c: 3});
     });
   });
-
-  describe(".parent", function() {
-    var Extendable = go.components.structures.Extendable,
-        parent = go.utils.parent;
-
-    it("should provide the 'super' prototype", function() {
-      var Parent = Extendable.extend(),
-          Child = Parent.extend();
-
-      assert.equal(parent(new Child()), Parent.prototype);
-    });
-
-    it("should provide a property on the 'super' prototype", function() {
-      var Parent = Extendable.extend({prop: 23}),
-          Child = Parent.extend({prop: 22});
-
-      assert.equal(parent(new Child(), 'prop'), 23);
-    });
-
-    it("should provide binded versions of the 'super' prototype's functions",
-       function() {
-      var Parent = Extendable.extend({fn: function() { return this; }}),
-          Child = Parent.extend({fn: function() { return 22; }}),
-          child = new Child();
-
-      assert.equal(parent(child, 'fn')(), child);
-    });
-  });
 });

--- a/go/base/static/js/test/tests/utils.test.js
+++ b/go/base/static/js/test/tests/utils.test.js
@@ -1,40 +1,59 @@
 describe("go.utils", function() {
-  var Extendable = go.utils.Extendable;
+  describe(".merge", function() {
+    var merge = go.utils.merge;
 
-  describe(".Extendable", function() {
-    it("should set up the prototype chain correctly", function() {
+    it("should merge objects together into a single object", function() {
+      assert.deepEqual(
+        merge({a: 1}, {b: 2, c: 3}, {d: 4}),
+        {a: 1, b: 2, c: 3, d: 4});
+
+      assert.deepEqual(
+        merge({a: 1}, {}, {d: 4}),
+        {a: 1, d: 4});
+
+      assert.deepEqual(
+        merge({a: 1}, {b: 2}, {a: 'one'}),
+        {a: 'one', b: 2});
+    });
+
+    it("should not modify any of the passed in objects", function() {
+      var a = {a: 1},
+          b = {b: 2},
+          c = {c: 3};
+
+      merge(a, b, c);
+
+      assert.deepEqual(a, {a: 1});
+      assert.deepEqual(b, {b: 2});
+      assert.deepEqual(c, {c: 3});
+    });
+  });
+
+  describe(".parent", function() {
+    var Extendable = go.components.structures.Extendable,
+        parent = go.utils.parent;
+
+    it("should provide the 'super' prototype", function() {
       var Parent = Extendable.extend(),
           Child = Parent.extend();
 
-       var child = new Child();
-       assert.instanceOf(child, Parent);
-       assert.instanceOf(child, Child);
+      assert.equal(parent(new Child()), Parent.prototype);
     });
 
-    it("should use a constructor function if specified", function() {
-      var Thing = Extendable.extend({
-        constructor: function (name) { this.name = name; }
-      });
+    it("should provide a property on the 'super' prototype", function() {
+      var Parent = Extendable.extend({prop: 23}),
+          Child = Parent.extend({prop: 22});
 
-      assert.equal(new Thing('foo').name, 'foo');
+      assert.equal(parent(new Child(), 'prop'), 23);
     });
 
-    it("should default to a parent's constructor", function() {
-      var Parent, Child;
-      Parent = Extendable.extend({
-        constructor: function (name) { this.name = name; }
-      });
-      Child = Parent.extend();
+    it("should provide binded versions of the 'super' prototype's functions",
+       function() {
+      var Parent = Extendable.extend({fn: function() { return this; }}),
+          Child = Parent.extend({fn: function() { return 22; }}),
+          child = new Child();
 
-      assert.equal(new Child('foo').name, 'foo');
-    });
-
-    it("should accept multiple object arguments", function() {
-      var Thing = Extendable.extend({'a': 'one'}, {'b': 'two'}),
-          thing = new Thing();
-
-      assert.equal(thing.a, 'one');
-      assert.equal(thing.b, 'two');
+      assert.equal(parent(child, 'fn')(), child);
     });
   });
 });

--- a/go/settings.py
+++ b/go/settings.py
@@ -367,6 +367,8 @@ PIPELINE_JS = {
             'js/src/utils.js',
             'js/src/errors.js',
             'js/src/tables.js',
+            'js/src/components/components.js',
+            'js/src/components/structures.js',
             'js/src/campaign/campaign.js',
             'js/src/campaign/interactive.js',
             'js/src/campaign/bulkMessage.js',


### PR DESCRIPTION
We need some extendable base structure that takes in a collection of models and provides:
- Looking up views by their model ids
- Accessing all the views at once
- Removing 'dead' views on render calls (views that no longer have corresponding models in the collection)
- Adding 'new' views (models in the collection that currently do not have views representing them)
- Rendering all the views in one go

Two use cases I've found for this so far:
- Adding/removing/keeping track of endpoint views on a `StateView` in the plumbing component.
- Adding/removing/keeping track of state views in a `PlumbView` in the plumbing component
