### PR TITLE
Client side needs a lookup group structure

### DIFF
--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -115,6 +115,7 @@
       lookup.on('remove', this._remove, this);
 
       this.members._add(key, lookup);
+      return this;
     },
 
     unsubscribe: function(key) {
@@ -125,6 +126,7 @@
       lookup.off('remove', this._remove, this);
 
       this.members._remove(key);
+      return lookup;
     }
   });
 

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -94,7 +94,6 @@
   exports.LookupGroup = ProtectedLookup.extend({
     constructor: function(lookups) {
       Lookup.prototype.constructor.call(this);
-      _.bindAll(this, '_add', '_remove');
 
       // Having the members lookup as protected might feel a bit wierd, since
       // we need to access its protected methods externally. However, this
@@ -112,18 +111,18 @@
       var items = lookup.items();
       for (var k in items) { this._add(k, items[k]); }
 
-      lookup.on('add', this._add);
-      lookup.on('remove', this._remove);
+      lookup.on('add', this._add, this);
+      lookup.on('remove', this._remove, this);
 
       this.members._add(key, lookup);
     },
 
     unsubscribe: function(key) {
       var lookup = this.members.get(key);
-      lookup.keys().forEach(this._remove);
+      lookup.keys().forEach(this._remove, this);
 
-      lookup.off('add', this._add);
-      lookup.off('remove', this._remove);
+      lookup.off('add', this._add, this);
+      lookup.off('remove', this._remove, this);
 
       this.members._remove(key);
     }
@@ -145,13 +144,12 @@
   exports.ViewCollection = ProtectedLookup.extend({
     constructor: function(collection) {
       Lookup.prototype.constructor.call(this);
-      _.bindAll(this, '_add', '_remove');
 
       this.models = collection;
-      this.models.each(this._add);
+      this.models.each(this._add, this);
 
-      this.models.on('add', this._add);
-      this.models.on('remove', this._remove);
+      this.models.on('add', this._add, this);
+      this.models.on('remove', this._remove, this);
     },
 
     // Override to specialise how the view is created

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -40,8 +40,12 @@
     },
 
     keys: function() { return _.keys(this._items); },
+
     values: function() { return _.values(this._items); },
+
     items: function() { return _.clone(this._items); },
+
+    has: function(k) { return _.has(this._items, k); },
 
     get: function(key) { return this._items[key]; },
 
@@ -61,6 +65,69 @@
     }
   });
 
+  // A protected form of a lookup who's collection of items can only be
+  // added/removed from internally. Intended to be used as an extendable,
+  // abstract structure.
+  var ProtectedLookup = exports.ProtectedLookup = Lookup.extend({
+    _add: Lookup.prototype.add,
+    _remove: Lookup.prototype.remove,
+
+    add: function() {
+      throw new GoError("ProtectedLookups cannot be added to externally");
+    },
+
+    remove: function() {
+      throw new GoError("ProtectedLookups cannot be removed from externally");
+    }
+  });
+
+  // A self-maintained, 'flattened' collection of all the items of lookups
+  // subscribed to it.
+  //
+  // Arguments:
+  //   - lookups: key-lookup pairs for the initial members to subscribe.
+  //
+  // Events emitted:
+  //   - 'add' (key, value) - Emitted when an item is added
+  //   - 'remove' (key, value) - Emitted when an item is removed
+  exports.LookupGroup = ProtectedLookup.extend({
+    constructor: function(lookups) {
+      Lookup.prototype.constructor.call(this);
+      _.bindAll(this, '_add', '_remove');
+
+      // Having the members lookup as protected might feel a bit wierd, since
+      // we need to access its protected methods externally. However, this
+      // allows places that use a `LookupGroup` to check things directly
+      // on the members lookup, for eg: `lookup.members.has(k)`, instead of us
+      // needing to bloat `LookupGroup` with methods to proxy access to the
+      // lookup methods.
+      this.members = new ProtectedLookup();
+
+      lookups = lookups || {};
+      for (var k in lookups) { this.subscribe(k, lookups[k]); }
+    },
+
+    subscribe: function(key, lookup) {
+      var items = lookup.items();
+      for (var k in items) { this._add(k, items[k]); }
+
+      lookup.on('add', this._add);
+      lookup.on('remove', this._remove);
+
+      this.members._add(key, lookup);
+    },
+
+    unsubscribe: function(key) {
+      var lookup = this.members.get(key);
+      lookup.keys().forEach(this._remove);
+
+      lookup.off('add', this._add);
+      lookup.off('remove', this._remove);
+
+      this.members._remove(key);
+    }
+  });
+
   // Accepts a collection of models and maintains a corresponding collection of
   // views. New views are created when models are added to the collection, old
   // views are removed when models are removed from the collection. Views can
@@ -74,10 +141,10 @@
   // Events emitted:
   //   - 'add' (id, view) - Emitted when a view is added
   //   - 'remove' (id, view) - Emitted when a view is removed
-  exports.ViewCollection = Lookup.extend({
+  exports.ViewCollection = ProtectedLookup.extend({
     constructor: function(collection) {
       Lookup.prototype.constructor.call(this);
-      _.bindAll(this);
+      _.bindAll(this, '_add', '_remove');
 
       this.models = collection;
       this.models.each(this._add);
@@ -89,22 +156,14 @@
     // Override to specialise how the view is created
     create: function(model) { return new Backbone.View({model: model}); },
 
-    add: function() {
-      throw new GoError("ViewCollections cannot be added to externally");
-    },
-
-    remove: function() {
-      throw new GoError("ViewCollections cannot be removed from externally");
-    },
-
     _add: function(model) {
       var view = this.create(model);
-      Lookup.prototype.add.call(this, model.id, view);
+      ProtectedLookup.prototype._add.call(this, model.id, view);
       view.render();
     },
 
     _remove: function(model) {
-      var view = Lookup.prototype.remove.call(this, model.id);
+      var view = ProtectedLookup.prototype._remove.call(this, model.id);
       if (view && typeof view.destroy === 'function') { view.destroy(); }
       return view;
     },

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -76,8 +76,6 @@
   //   - 'remove' (id, view) - Emitted when a view is removed
   exports.ViewCollection = Lookup.extend({
     constructor: function(collection) {
-      var self = this;
-
       Lookup.prototype.constructor.call(this);
       _.bindAll(this);
 

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -70,6 +70,7 @@
   // abstract structure.
   var ProtectedLookup = exports.ProtectedLookup = Lookup.extend({
     _add: Lookup.prototype.add,
+
     _remove: Lookup.prototype.remove,
 
     add: function() {

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -136,7 +136,7 @@ describe("go.components.structures", function() {
 
     describe(".subscribe", function() {
       it("should add all the lookup's items to the group", function() {
-        group.subscribe('c', new Lookup({g: 7, h: 8}));
+        assert.equal(group.subscribe('c', new Lookup({g: 7, h: 8})), group);
         assert.equal(group.get('g'), 7);
         assert.equal(group.get('h'), 8);
       });
@@ -176,7 +176,7 @@ describe("go.components.structures", function() {
 
     describe(".unsubscribe", function() {
       it("should remove all the lookup's items from the group", function() {
-        group.unsubscribe('b');
+        assert.equal(group.unsubscribe('b'), lookupB);
         assert(!group.has('d'));
         assert(!group.has('e'));
         assert(!group.has('f'));

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -2,7 +2,7 @@ describe("go.components.structures", function() {
   var structures = go.components.structures;
 
   describe(".Extendable", function() {
-    var Extendable = go.components.structures.Extendable;
+    var Extendable = structures.Extendable;
 
     it("should set up the prototype chain correctly", function() {
       var Parent = Extendable.extend(),
@@ -62,6 +62,13 @@ describe("go.components.structures", function() {
       });
     });
 
+    describe(".has", function() {
+      it("should determine whether an item exists in the lookup", function() {
+        assert.deepEqual(lookup.has('a'), true);
+        assert.deepEqual(lookup.has('d'), false);
+      });
+    });
+
     describe(".items", function() {
       it("should get a shallow copy of the lookup's items", function() {
         var items = lookup.items();
@@ -110,6 +117,100 @@ describe("go.components.structures", function() {
         });
 
         lookup.remove('c');
+      });
+    });
+  });
+
+  describe(".LookupGroup", function() {
+    var Lookup = structures.Lookup,
+        LookupGroup = structures.LookupGroup,
+        lookupA,
+        lookupB,
+        group;
+
+    beforeEach(function() {
+      lookupA = new Lookup({a: 1, b: 2, c: 3});
+      lookupB = new Lookup({d: 4, e: 5, f: 6});
+      group = new LookupGroup({'a': lookupA, 'b': lookupB});
+    });
+
+    describe(".subscribe", function() {
+      it("should add all the lookup's items to the group", function() {
+        group.subscribe('c', new Lookup({g: 7, h: 8}));
+        assert.equal(group.get('g'), 7);
+        assert.equal(group.get('h'), 8);
+      });
+
+      it("should bind the lookup's adds to the groups own adds",
+         function(done) {
+        var lookupC = new Lookup({g: 7, h: 8});
+        group.subscribe('c', lookupC);
+
+        lookupC.on('add', function(key, value) {
+          assert.equal(group.get('i'), 9);
+          done();
+        });
+
+        lookupC.add('i', 9);
+      });
+
+      it("should bind the lookup's removes to the groups own removes",
+         function(done) {
+        var lookupC = new Lookup({g: 7, h: 8});
+        group.subscribe('c', lookupC);
+
+        lookupC.on('remove', function(key, value) {
+          assert(!group.has('g'));
+          done();
+        });
+
+        lookupC.remove('g');
+      });
+
+      it("should add lookup to the group's member lookup", function() {
+        var lookupC = new Lookup({g: 7, h: 8});
+        group.subscribe('c', lookupC);
+        assert.equal(group.members.get('c'), lookupC);
+      });
+    });
+
+    describe(".unsubscribe", function() {
+      it("should remove all the lookup's items from the group", function() {
+        group.unsubscribe('b');
+        assert(!group.has('d'));
+        assert(!group.has('e'));
+        assert(!group.has('f'));
+      });
+
+      it("should unbind the lookup's adds from the groups own adds",
+         function(done) {
+        group.unsubscribe('b');
+
+        lookupB.on('add', function(key, value) {
+          assert(!group.has('i'));
+          done();
+        });
+
+        lookupB.add('i', 9);
+      });
+
+      it("should unbind the lookup's removes from the groups own removes",
+         function(done) {
+        group.unsubscribe('b');
+        group.subscribe('c', new Lookup({d: 'four'}));
+
+        lookupB.on('remove', function(key, value) {
+          // assert that the item is still there
+          assert.equal(group.get('d'), 'four');
+          done();
+        });
+
+        lookupB.remove('d');
+      });
+
+      it("should remove the lookup from the group's member lookup", function() {
+        group.unsubscribe('b');
+        assert(!group.members.has('b'));
       });
     });
   });


### PR DESCRIPTION
We need to add a `LookupGroup` structure that keeps track of the `Lookup`s subscribed to it. When items are added to any of the subscribed lookups, the items will automatically be added to the lookup group. In other words, `LookupGroup` can be thought of as a self-maintaining, 'flattened' collection of the all items of its members.

This has a very important use case for the plumbing component in particular. A state view can keep endpoints of different types, and has a `ViewCollection` for each endpoint type. Using a `LookupGroup`, each state view has a self-maintained collection of all the endpoints it contains.

Then, at the top level (the state diagram view), we can use a `LookupGroup` to keep track of all the endpoints in the diagram (all the state views' endpoints), without ever needing to maintain this collection. This is especially necessary to route connection events to the relevant endpoints, since jsPlumb does not trigger events on its endpoint objects when connections occur (something we really need).
