### PR TITLE
Client side needs a ViewCollectionGroup

### DIFF
--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -164,9 +164,9 @@
     create: function(model) { return new Backbone.View({model: model}); },
 
     _add: function(model, options) {
+      _.defaults(options, this.addDefaults);
       var view = this.create(model);
       ProtectedLookup.prototype._add.call(this, model.id, view);
-      view.render();
       if (options.render) { view.render(); }
     },
 
@@ -179,5 +179,11 @@
     render: function() {
       this.values().forEach(function(v) { v.render(); });
     }
+  });
+
+  // A self-maintaining, 'flattened' lookup of the views in a group of view
+  // collections.
+  exports.ViewCollectionGroup = LookupGroup.extend({
+    render: ViewCollection.prototype.render
   });
 })(go.components.structures = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -184,6 +184,6 @@
   // A self-maintaining, 'flattened' lookup of the views in a group of view
   // collections.
   exports.ViewCollectionGroup = LookupGroup.extend({
-    render: ViewCollection.prototype.render
+    render: exports.ViewCollection.prototype.render
   });
 })(go.components.structures = {});


### PR DESCRIPTION
`ViewCollectionGroup` should extend `LookupGroup`, and offer a `render()` function property that allows rendering of each view of its members.

This has use cases in the plumbing component. For example, this allows collections of endpoint views to be contained in a single group and rendered collectively.
