### PR TITLE
Define go.components.structures exports at the bottom of module

### DIFF
--- a/go/base/static/js/src/campaign/bulkMessage.js
+++ b/go/base/static/js/src/campaign/bulkMessage.js
@@ -25,6 +25,8 @@
             return this;
         }
     });
-    exports.TextareaView = TextareaView;
 
+    _.extend(exports, {
+      TextareaView: TextareaView
+    });
 })(go.campaign.bulkMessage = {});

--- a/go/base/static/js/src/components/states.js
+++ b/go/base/static/js/src/components/states.js
@@ -33,7 +33,7 @@
 (function(exports) {
   // Model for a 'placeholder' attached to a state that one end of a connection
   // can be hooked onto.
-  exports.EndpointModel = Backbone.RelationalModel.extend({
+  var EndpointModel = Backbone.RelationalModel.extend({
     relations: [{
       type: Backbone.HasOne,
       key: 'target',
@@ -43,7 +43,7 @@
   });
 
   // Model for a single state in a state machine
-  exports.StateModel = Backbone.RelationalModel.extend({
+  var StateModel = Backbone.RelationalModel.extend({
     relations: [{
       type: Backbone.HasMany,
       key: 'endpoints',
@@ -53,7 +53,7 @@
 
   // Model for a state machine. Holds a collection of states and keeps track of
   // the initial state (`state0`).
-  exports.StateMachineModel = Backbone.RelationalModel.extend({
+  var StateMachineModel = Backbone.RelationalModel.extend({
     relations: [{
       type: Backbone.HasMany,
       key: 'states',
@@ -64,5 +64,11 @@
       includeInJSON: 'id',
       relatedModel: 'go.components.states.StateModel'
     }]
+  });
+
+  _.extend(exports, {
+    EndpointModel: EndpointModel,
+    StateModel: StateModel,
+    StateMachineModel: StateMachineModel
   });
 })(go.components.states = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -164,9 +164,9 @@
     create: function(model) { return new Backbone.View({model: model}); },
 
     _add: function(model, options) {
+      _.defaults(options, this.addDefaults);
       var view = this.create(model);
       ProtectedLookup.prototype._add.call(this, model.id, view);
-      view.render();
       if (options.render) { view.render(); }
     },
 
@@ -179,5 +179,11 @@
     render: function() {
       this.values().forEach(function(v) { v.render(); });
     }
+  });
+
+  // A self-maintaining, 'flattened' lookup of the views in a group of view
+  // collections.
+  exports.ViewCollectionGroup = LookupGroup.extend({
+    render: ViewCollection.prototype.render
   });
 })(go.components.structures = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -184,6 +184,6 @@
   // A self-maintaining, 'flattened' lookup of the views in a group of view
   // collections.
   exports.ViewCollectionGroup = LookupGroup.extend({
-    render: ViewCollection.prototype.render
+    render: exports.ViewCollection.prototype.render
   });
 })(go.components.structures = {});

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -8,9 +8,9 @@
 
   // Acts as a 'base' for class-like objects which can be extended (with the
   // prototype chain set up automatically)
-  exports.Extendable = function () {};
+  var Extendable = function () {};
 
-  exports.Extendable.extend = function() {
+  Extendable.extend = function() {
     // Backbone has an internal `extend()` function which it assigns to its
     // structures. We need this function, so we arbitrarily choose
     // `Backbone.Model`, since it has the function we are looking for.
@@ -18,7 +18,7 @@
   };
 
   // A class-like object onto which events can be bound and emitted
-  exports.Eventable = exports.Extendable.extend(Backbone.Events);
+  var Eventable = Extendable.extend(Backbone.Events);
 
   // A structure that stores key-value pairs, provides helpful operations for
   // accessing the data, and emits events when items are added or removed.
@@ -31,7 +31,7 @@
   // Events emitted:
   //   - 'add' (key, value) - Emitted when an item is added
   //   - 'remove' (key, value) - Emitted when an item is removed
-  var Lookup = exports.Lookup = exports.Eventable.extend({
+  var Lookup = Eventable.extend({
     constructor: function(items) {
       this._items = {};
 
@@ -72,7 +72,7 @@
   // A protected form of a lookup who's collection of items can only be
   // added/removed from internally. Intended to be used as an extendable,
   // abstract structure.
-  var ProtectedLookup = exports.ProtectedLookup = Lookup.extend({
+  var ProtectedLookup = Lookup.extend({
     _add: Lookup.prototype.add,
 
     _remove: Lookup.prototype.remove,
@@ -95,7 +95,7 @@
   // Events emitted:
   //   - 'add' (key, value) - Emitted when an item is added
   //   - 'remove' (key, value) - Emitted when an item is removed
-  exports.LookupGroup = ProtectedLookup.extend({
+  var LookupGroup = ProtectedLookup.extend({
     constructor: function(lookups) {
       Lookup.prototype.constructor.call(this);
 
@@ -147,7 +147,7 @@
   // Events emitted:
   //   - 'add' (id, view) - Emitted when a view is added
   //   - 'remove' (id, view) - Emitted when a view is removed
-  exports.ViewCollection = ProtectedLookup.extend({
+  var ViewCollection = ProtectedLookup.extend({
     addDefaults: {render: true},
 
     constructor: function(collection) {
@@ -183,7 +183,16 @@
 
   // A self-maintaining, 'flattened' lookup of the views in a group of view
   // collections.
-  exports.ViewCollectionGroup = LookupGroup.extend({
-    render: exports.ViewCollection.prototype.render
+  var ViewCollectionGroup = LookupGroup.extend({
+    render: ViewCollection.prototype.render
+  });
+
+  _.extend(exports, {
+    Extendable: Extendable,
+    Eventable: Eventable,
+    Lookup: Lookup,
+    LookupGroup: LookupGroup,
+    ViewCollection: ViewCollection,
+    ViewCollectionGroup: ViewCollectionGroup
   });
 })(go.components.structures = {});

--- a/go/base/static/js/src/errors.js
+++ b/go/base/static/js/src/errors.js
@@ -3,7 +3,7 @@
 // Error infrastructure for Go
 
 (function(exports) {
-  var GoError = exports.GoError = function(message) {
+  var GoError = function(message) {
     if (message) { this.message = message; }
   };
 
@@ -34,5 +34,9 @@
         + (this.message ? ': ' + this.message : '')
         + ']';
     }
+  });
+
+  _.extend(exports, {
+    GoError: GoError
   });
 })(go.errors = {});

--- a/go/base/static/js/src/tables.js
+++ b/go/base/static/js/src/tables.js
@@ -2,7 +2,6 @@
 // =========
 
 (function(exports) {
-
     var init = function(selector) {
         $table = $(selector);
 
@@ -52,9 +51,7 @@
         });
     };
 
-    exports.init = init;
-
-
+    _.extend(exports, {
+      init: init
+    });
 })(go.tables = {});
-
-

--- a/go/base/static/js/src/utils.js
+++ b/go/base/static/js/src/utils.js
@@ -4,12 +4,12 @@
 
 (function(exports) {
   // Merges the passed in objects together into a single object
-  var merge = exports.merge = function() {
+  var merge = function() {
     Array.prototype.unshift.call(arguments, {});
     return _.extend.apply(this, arguments);
   };
 
-  exports.highlightActiveLinks = function() {
+  var highlightActiveLinks = function() {
     // find links in the document that match the current
     // windows url and set them as active.
 
@@ -19,4 +19,9 @@
 
     $('a[href="' + url + '"]').addClass('active');
   };
+
+  _.extend(exports, {
+    merge: merge,
+    highlightActiveLinks: highlightActiveLinks
+  });
 })(go.utils = {});


### PR DESCRIPTION
The `go.components.structures` module contains quite a few internal references, since each structure extends some other structure. It will simplify things if we defined the exports at the bottom of the module.
