### PR TITLE
Remove go.components.structures.ProtectedLookup

### DIFF
--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -69,23 +69,6 @@
     }
   });
 
-  // A protected form of a lookup who's collection of items can only be
-  // added/removed from internally. Intended to be used as an extendable,
-  // abstract structure.
-  var ProtectedLookup = Lookup.extend({
-    _add: Lookup.prototype.add,
-
-    _remove: Lookup.prototype.remove,
-
-    add: function() {
-      throw new GoError("ProtectedLookups cannot be added to externally");
-    },
-
-    remove: function() {
-      throw new GoError("ProtectedLookups cannot be removed from externally");
-    }
-  });
-
   // A self-maintained, 'flattened' collection of all the items of lookups
   // subscribed to it.
   //
@@ -95,17 +78,10 @@
   // Events emitted:
   //   - 'add' (key, value) - Emitted when an item is added
   //   - 'remove' (key, value) - Emitted when an item is removed
-  var LookupGroup = ProtectedLookup.extend({
+  var LookupGroup = Lookup.extend({
     constructor: function(lookups) {
       Lookup.prototype.constructor.call(this);
-
-      // Having the members lookup as protected might feel a bit wierd, since
-      // we need to access its protected methods externally. However, this
-      // allows places that use a `LookupGroup` to check things directly
-      // on the members lookup, for eg: `lookup.members.has(k)`, instead of us
-      // needing to bloat `LookupGroup` with methods to proxy access to the
-      // lookup methods.
-      this.members = new ProtectedLookup();
+      this.members = new Lookup();
 
       lookups = lookups || {};
       for (var k in lookups) { this.subscribe(k, lookups[k]); }
@@ -113,23 +89,23 @@
 
     subscribe: function(key, lookup) {
       var items = lookup.items();
-      for (var k in items) { this._add(k, items[k]); }
+      for (var k in items) { this.add(k, items[k]); }
 
-      lookup.on('add', this._add, this);
-      lookup.on('remove', this._remove, this);
+      lookup.on('add', this.add, this);
+      lookup.on('remove', this.remove, this);
 
-      this.members._add(key, lookup);
+      this.members.add(key, lookup);
       return this;
     },
 
     unsubscribe: function(key) {
       var lookup = this.members.get(key);
-      lookup.keys().forEach(this._remove, this);
+      lookup.keys().forEach(this.remove, this);
 
-      lookup.off('add', this._add, this);
-      lookup.off('remove', this._remove, this);
+      lookup.off('add', this.add, this);
+      lookup.off('remove', this.remove, this);
 
-      this.members._remove(key);
+      this.members.remove(key);
       return lookup;
     }
   });
@@ -147,31 +123,31 @@
   // Events emitted:
   //   - 'add' (id, view) - Emitted when a view is added
   //   - 'remove' (id, view) - Emitted when a view is removed
-  var ViewCollection = ProtectedLookup.extend({
+  var ViewCollection = Lookup.extend({
     addDefaults: {render: true},
 
     constructor: function(collection) {
       Lookup.prototype.constructor.call(this);
 
       this.models = collection;
-      this.models.each(function(m) { this._add(m, {render: false}); }, this);
+      this.models.each(function(m) { this.add(m, {render: false}); }, this);
 
-      this.models.on('add', this._add, this);
-      this.models.on('remove', this._remove, this);
+      this.models.on('add', this.add, this);
+      this.models.on('remove', this.remove, this);
     },
 
     // Override to specialise how the view is created
     create: function(model) { return new Backbone.View({model: model}); },
 
-    _add: function(model, options) {
+    add: function(model, options) {
       _.defaults(options, this.addDefaults);
       var view = this.create(model);
-      ProtectedLookup.prototype._add.call(this, model.id, view);
+      Lookup.prototype.add.call(this, model.id, view);
       if (options.render) { view.render(); }
     },
 
-    _remove: function(model) {
-      var view = ProtectedLookup.prototype._remove.call(this, model.id);
+    remove: function(model) {
+      var view = Lookup.prototype.remove.call(this, model.id);
       if (view && typeof view.destroy === 'function') { view.destroy(); }
       return view;
     },


### PR DESCRIPTION
Having things that extend `ProtectedLookup` override its internal methods (`._add()` and `._remove()`) feels a bit wierd. It would probably be better to just use `Lookup`'s `.add()` and `.remove()`, and just expect the things that currently extend `ProtectedLookup` to be used correctly.
