### PR TITLE
Refactor subview structures out of plumbing components

### DIFF
--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -160,7 +160,7 @@
     },
 
     render: function() {
-      this.values().forEach(function(v) { v.render(); });
+      this.each(function(v) { v.render(); });
     }
   });
 
@@ -170,12 +170,93 @@
     render: ViewCollection.prototype.render
   });
 
+  // A collection of subviews mapping to an attribute on a view's model.
+  //
+  // Options:
+  // - view: The parent view for this collection of subviews
+  // - attr: The attr on the parent view's model which holds the associated
+  // collection or model
+  // - [type]: The view type to instantiate for each new view.
+  var SubviewCollection = ViewCollection.extend({
+    // Override to change the default options used on initialisation
+    defaults: {type: Backbone.View},
+
+    // Override to change the options passed to each new view
+    opts: {},
+
+    constructor: function(options) {
+      _(options).defaults(_(this).result('defaults'));
+      this.view = options.view;
+      this.attr = options.attr;
+      this.type = options.type;
+
+      ViewCollection
+        .prototype
+        .constructor
+        .call(this, this._models());
+    },
+
+    _models: function() {
+      var modelOrCollection = this.view.model.get(this.attr);
+
+      // If we were given a single model instead of a collection, create a
+      // singleton collection with the model so we can work with things
+      // uniformly
+      return modelOrCollection instanceof Backbone.Model
+        ? new Backbone.Collection([modelOrCollection])
+        : modelOrCollection;
+    },
+
+    create: function(model) {
+      var opts = _(this).result('opts');
+      opts.model = model;
+
+      return new this.type(opts);
+    }
+  });
+
+  // A self-maintaining, 'flattened' lookup of subview collections defined by a
+  // schema.
+  //
+  // Arguments:
+  // - view: The parent view of the group
+  var SubviewCollectionGroup = ViewCollectionGroup.extend({
+    // Override to change the subview collection type
+    SubviewCollection: SubviewCollection,
+
+    // Override to change the subview schema
+    schema: [{attr: 'subviews', type: Backbone.View}],
+
+    constructor: function(view) {
+      ViewCollectionGroup
+        .prototype
+        .constructor
+        .call(this);
+
+      this.view = view;
+      this.schema = _(this).result('schema');
+      this.schema.forEach(this.subscribe, this);
+    },
+
+    subscribe: function(options) {
+      options.view = this.view;
+      var collection = new this.SubviewCollection(options);
+
+      return ViewCollectionGroup
+        .prototype
+        .subscribe
+        .call(this, options.attr, collection);
+    }
+  });
+
   _.extend(exports, {
     Extendable: Extendable,
     Eventable: Eventable,
     Lookup: Lookup,
     LookupGroup: LookupGroup,
     ViewCollection: ViewCollection,
-    ViewCollectionGroup: ViewCollectionGroup
+    ViewCollectionGroup: ViewCollectionGroup,
+    SubviewCollection: SubviewCollection,
+    SubviewCollectionGroup: SubviewCollectionGroup
   });
 })(go.components.structures = {});

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -342,4 +342,112 @@ describe("go.components.structures", function() {
       });
     });
   });
+
+  var SubviewCollection = structures.SubviewCollection;
+
+  var SubthingView = Backbone.View.extend();
+
+  var SubthingViewCollection = SubviewCollection.extend({
+    defaults: function() { return {type: SubthingView}; },
+    opts: function() { return {id: this.size()}; }
+  });
+
+  describe(".SubviewCollection", function() {
+    var view,
+        subviews;
+
+    beforeEach(function() {
+      var model = new Backbone.Model({
+        subthings: new Backbone.Collection([
+          {id: 'a'},
+          {id: 'b'},
+          {id: 'c'}
+        ]),
+        lonelySubthing: new Backbone.Model({id: 'd'})
+      });
+
+      view = new Backbone.View({model: model});
+
+      subviews = new SubthingViewCollection({
+        view: view,
+        attr: 'subthings'
+      });
+    });
+
+    it("should be useable with model type attributes", function() {
+      subviews = new SubthingViewCollection({
+        view: view,
+        attr: 'lonelySubthing'
+      });
+
+      assert.deepEqual(subviews.keys(), ['d']);
+    });
+
+    it("should be useable with collection type attributes", function() {
+      subviews = new SubthingViewCollection({
+        view: view,
+        attr: 'subthings'
+      });
+
+      assert.deepEqual(subviews.keys(), ['a', 'b', 'c']);
+    });
+
+    describe(".create", function() {
+      it("should create subviews of the collection's type", function() {
+        subviews.each(function(v) { assert.instanceOf(v, SubthingView); });
+      });
+
+      it("should create the view with options defined by the collection",
+      function() {
+        subviews.each(function(v, i) { assert.equal(v.id, i); });
+      });
+    });
+  });
+
+  describe(".SubviewCollectionGroup", function() {
+    var view,
+        subviews;
+
+    var SubviewCollectionGroup = structures.SubviewCollectionGroup;
+
+    var SubthingViewCollections = SubviewCollectionGroup.extend({
+      SubviewCollection: SubthingViewCollection,
+
+      schema: [
+        {attr: 'subthings'},
+        {attr: 'lonelySubthing'}]
+    });
+
+    beforeEach(function() {
+      var model = new Backbone.Model({
+        subthings: new Backbone.Collection([
+          {id: 'a'},
+          {id: 'b'},
+          {id: 'c'}
+        ]),
+        lonelySubthing: new Backbone.Model({id: 'd'})
+      });
+
+      view = new Backbone.View({model: model});
+      subviews = new SubthingViewCollections(view);
+    });
+
+    it("should set up the subviews according to the schema", function() {
+      assert.deepEqual(subviews.keys(), ['a', 'b', 'c', 'd']);
+
+      assert.deepEqual(
+        subviews
+          .members
+          .get('subthings')
+          .keys(),
+        ['a', 'b', 'c']);
+
+      assert.deepEqual(
+        subviews
+          .members
+          .get('lonelySubthing')
+          .keys(),
+        ['d']);
+    });
+  });
 });


### PR DESCRIPTION
`SubviewCollection` and `SubviewCollectionGroup` can be created as generic reuseable structures, out of refactored pieces of the plumbing components. As a side effect, this will take away some of the current bloat in the plumbing components.
