### PR TITLE
Rename plumb component view types to exclude the 'View' suffix

### DIFF
--- a/go/base/static/js/src/components/plumbing/connections.js
+++ b/go/base/static/js/src/components/plumbing/connections.js
@@ -8,7 +8,7 @@
       SubviewCollection = structures.SubviewCollection;
 
   var plumbing = go.components.plumbing,
-      EndpointView = plumbing.EndpointView;
+      Endpoint = plumbing.Endpoint;
 
   var idOfConnection = function(sourceId, targetId) {
     return sourceId + '-' + targetId;
@@ -18,7 +18,7 @@
   //
   // Options:
   // - diagram: The diagram this connection is part of
-  var ConnectionView = Backbone.View.extend({
+  var Connection = Backbone.View.extend({
     // Override to change what params are passed to jsPlumb
     plumbOptions: {},
 
@@ -68,11 +68,11 @@
   });
 
   // A collection of connections views that form part of a diagram view
-  var ConnectionViewCollection = SubviewCollection.extend({
+  var ConnectionCollection = SubviewCollection.extend({
     defaults: {
-      type: ConnectionView,
-      sourceType: EndpointView,
-      targetType: EndpointView
+      type: Connection,
+      sourceType: Endpoint,
+      targetType: Endpoint
     },
 
     opts: function() { return {diagram: this.diagram, collection: this}; },
@@ -95,7 +95,7 @@
 
   _.extend(exports, {
     idOfConnection: idOfConnection,
-    ConnectionView: ConnectionView,
-    ConnectionViewCollection: ConnectionViewCollection
+    Connection: Connection,
+    ConnectionCollection: ConnectionCollection
   });
 })(go.components.plumbing);

--- a/go/base/static/js/src/components/plumbing/diagrams.js
+++ b/go/base/static/js/src/components/plumbing/diagrams.js
@@ -10,13 +10,13 @@
 
   var plumbing = go.components.plumbing,
       idOfConnection = plumbing.idOfConnection,
-      StateView = plumbing.StateView,
-      ConnectionView = plumbing.ConnectionView,
-      StateViewCollection = plumbing.StateViewCollection,
-      ConnectionViewCollection = plumbing.ConnectionViewCollection;
+      State = plumbing.State,
+      Connection = plumbing.Connection,
+      StateCollection = plumbing.StateCollection,
+      ConnectionCollection = plumbing.ConnectionCollection;
 
   // Keeps track of all the endpoints in the state diagram
-  var DiagramViewEndpoints = ViewCollectionGroup.extend({
+  var DiagramEndpoints = ViewCollectionGroup.extend({
     constructor: function(diagram) {
       ViewCollectionGroup.prototype.constructor.call(this);
       this.diagram = diagram;
@@ -36,7 +36,7 @@
 
   // Keeps connections between connection models in sync with the jsPlumb
   // connections in the UI
-  var DiagramViewConnections = SubviewCollectionGroup.extend({
+  var DiagramConnections = SubviewCollectionGroup.extend({
     defaults: function() {
       // Get the default endpoint type for the diagram's default state type
       var endpointType = this.diagram
@@ -140,7 +140,7 @@
   });
 
   // Keeps track of all the states in a state diagram
-  var DiagramViewStates = SubviewCollectionGroup.extend({
+  var DiagramStates = SubviewCollectionGroup.extend({
     defaults: function() { return {type: this.diagram.stateType}; },
     schema: function() { return _(this.diagram).result('stateSchema'); },
 
@@ -153,34 +153,34 @@
 
   // The main view for the state diagram. Delegates interactions between
   // the states and their endpoints.
-  var DiagramView = Backbone.View.extend({
+  var Diagram = Backbone.View.extend({
     // Override to change how the states map to the diagram view's model
     stateSchema: [{attr: 'states'}],
 
     // Override to change the default state view type
-    stateType: StateView,
+    stateType: State,
 
     // Override to change the default state view collection type
-    stateCollectionType: StateViewCollection,
+    stateCollectionType: StateCollection,
 
     // Override to change how the connections map to the diagram view's model
     connectionSchema: [{attr: 'connections'}],
 
     // Override to change the connection view type
-    connectionType: ConnectionView,
+    connectionType: Connection,
 
     // Override to change the default connection view collection type
-    connectionCollectionType: ConnectionViewCollection,
+    connectionCollectionType: ConnectionCollection,
 
     initialize: function() {
       // Lookup/Manager of all the states in the diagram
-      this.states = new DiagramViewStates(this);
+      this.states = new DiagramStates(this);
 
       // Lookup/Manager of all the endpoints in the diagram
-      this.endpoints = new DiagramViewEndpoints(this);
+      this.endpoints = new DiagramEndpoints(this);
 
       // Lookup/Manager of all the connections in the diagram
-      this.connections = new DiagramViewConnections(this);
+      this.connections = new DiagramConnections(this);
     },
 
     render: function() {
@@ -192,11 +192,11 @@
 
   _.extend(exports, {
     // Components intended to be used and extended
-    DiagramView: DiagramView,
+    Diagram: Diagram,
 
     // Secondary components
-    DiagramViewEndpoints: DiagramViewEndpoints,
-    DiagramViewConnections: DiagramViewConnections,
-    DiagramViewStates: DiagramViewStates
+    DiagramEndpoints: DiagramEndpoints,
+    DiagramConnections: DiagramConnections,
+    DiagramStates: DiagramStates
   });
 })(go.components.plumbing);

--- a/go/base/static/js/src/components/plumbing/endpoints.js
+++ b/go/base/static/js/src/components/plumbing/endpoints.js
@@ -14,7 +14,7 @@
   //
   // Options:
   // - state: The view to which this endpoint is to be attached
-  var EndpointView = Backbone.View.extend({
+  var Endpoint = Backbone.View.extend({
     // Override to change what params are passed to jsPlumb
     plumbOptions: {},
 
@@ -60,8 +60,8 @@
   });
 
   // A collection of endpoint views attached to a state view
-  var EndpointViewCollection = SubviewCollection.extend({
-    defaults: {type: EndpointView},
+  var EndpointCollection = SubviewCollection.extend({
+    defaults: {type: Endpoint},
     opts: function() { return {state: this.view, collection: this}; }
   });
 
@@ -70,7 +70,7 @@
 
   // An endpoint view type which remains in the same position until it is
   // repositioned.
-  var StaticEndpoint = EndpointView.extend({
+  var StaticEndpoint = Endpoint.extend({
     defaults: {side: 'left'},
 
     anchors: {
@@ -81,7 +81,7 @@
     },
 
     constructor: function(options) {
-      EndpointView.prototype.constructor.call(this, options);
+      Endpoint.prototype.constructor.call(this, options);
       _(options).defaults(_(this).result('defaults'));
 
       this.side = options.side;
@@ -97,7 +97,7 @@
     },
 
     render: function() {
-      EndpointView.prototype.render.call(this);
+      Endpoint.prototype.render.call(this);
       this.plumbEndpoint.setAnchor(this.plumbAnchor);
       return this;
     }
@@ -106,11 +106,11 @@
   // Automatically aligns its endpoints to be evenly spaced on one side of the
   // state view.
   //
-  // NOTE: Must be used with `StateEndpointView` types, or its derivatives
-  var AligningEndpointCollection = EndpointViewCollection.extend({
+  // NOTE: Must be used with `StateEndpoint` types, or its derivatives
+  var AligningEndpointCollection = EndpointCollection.extend({
     addDefaults: _.defaults(
       {render: false},
-      EndpointViewCollection.prototype.addDefaults),
+      EndpointCollection.prototype.addDefaults),
 
     defaults: {
       type: StaticEndpoint,
@@ -148,13 +148,13 @@
 
     render: function() {
       this.realign();
-      EndpointViewCollection.prototype.render.call(this);
+      EndpointCollection.prototype.render.call(this);
     }
   });
 
   _.extend(exports, {
-    EndpointView: EndpointView,
-    EndpointViewCollection: EndpointViewCollection,
+    Endpoint: Endpoint,
+    EndpointCollection: EndpointCollection,
 
     StaticEndpoint: StaticEndpoint,
     AligningEndpointCollection: AligningEndpointCollection

--- a/go/base/static/js/src/components/plumbing/states.js
+++ b/go/base/static/js/src/components/plumbing/states.js
@@ -8,11 +8,11 @@
       SubviewCollectionGroup = structures.SubviewCollectionGroup;
 
   var plumbing = go.components.plumbing,
-      EndpointView = plumbing.EndpointView,
-      EndpointViewCollection = plumbing.EndpointViewCollection;
+      Endpoint = plumbing.Endpoint,
+      EndpointCollection = plumbing.EndpointCollection;
 
   // Keeps track of all the endpoints in the state view
-  var StateViewEndpoints = SubviewCollectionGroup.extend({
+  var StateEndpoints = SubviewCollectionGroup.extend({
     defaults: function() { return {type: this.state.endpointType}; },
     schema: function() { return _(this.state).result('endpointSchema'); },
 
@@ -23,16 +23,16 @@
     }
   });
 
-  var StateView = Backbone.View.extend({
+  var State = Backbone.View.extend({
     // A list of configuration objects, where each corresponds to a group of
     // endpoints or a single endpoint. Override to change the state schema.
     endpointSchema: [{attr: 'endpoints'}],
 
     // Override to change the default endpoint view type
-    endpointType: EndpointView,
+    endpointType: Endpoint,
 
     // Override to change the default endpoint view collection type
-    endpointCollectionType: EndpointViewCollection,
+    endpointCollectionType: EndpointCollection,
 
     id: function() { return this.model.id; },
 
@@ -44,7 +44,7 @@
       this.collection = options.collection;
 
       // Lookup of all the endpoints in this state
-      this.endpoints = new StateViewEndpoints(this);
+      this.endpoints = new StateEndpoints(this);
 
       this.model.on('change', this.render, this);
     },
@@ -62,17 +62,17 @@
   });
 
   // A collection of state views that form part of a diagram view
-  var StateViewCollection = SubviewCollection.extend({
-    defaults: {type: StateView},
+  var StateCollection = SubviewCollection.extend({
+    defaults: {type: State},
     opts: function() { return {diagram: this.view, collection: this}; }
   });
 
   _.extend(exports, {
     // Components intended to be used and extended
-    StateView: StateView,
-    StateViewCollection: StateViewCollection,
+    State: State,
+    StateCollection: StateCollection,
 
     // Secondary components
-    StateViewEndpoints: StateViewEndpoints
+    StateEndpoints: StateEndpoints
   });
 })(go.components.plumbing);

--- a/go/base/static/js/test/tests/components/plumbing/connections.test.js
+++ b/go/base/static/js/test/tests/components/plumbing/connections.test.js
@@ -16,9 +16,9 @@ describe("go.components.plumbing (connections)", function() {
     tearDown();
   });
 
-  describe(".ConnectionView", function() {
+  describe(".Connection", function() {
     var ConnectionModel = stateMachine.ConnectionModel,
-        ConnectionView = plumbing.ConnectionView;
+        Connection = plumbing.Connection;
 
     var diagram,
         x1,
@@ -51,7 +51,7 @@ describe("go.components.plumbing (connections)", function() {
 
     describe(".render", function() {
       it("should create the actual jsPlumb connection", function(done) {
-        var x1_y1 = new ConnectionView({
+        var x1_y1 = new Connection({
           diagram: diagram,
           model: new ConnectionModel({
             id: 'x1-y1',

--- a/go/base/static/js/test/tests/components/plumbing/diagrams.test.js
+++ b/go/base/static/js/test/tests/components/plumbing/diagrams.test.js
@@ -18,10 +18,10 @@ describe("go.components.plumbing (diagrams)", function() {
     tearDown();
   });
 
-  describe(".DiagramViewEndpoints", function() {
+  describe(".DiagramEndpoints", function() {
     var StateModel = stateMachine.StateModel,
-        StateView = plumbing.StateView,
-        DiagramViewEndpoints = plumbing.DiagramViewEndpoints;
+        State = plumbing.State,
+        DiagramEndpoints = plumbing.DiagramEndpoints;
 
     var endpoints,
         a1,
@@ -38,7 +38,7 @@ describe("go.components.plumbing (diagrams)", function() {
     };
 
     beforeEach(function() {
-      endpoints = new DiagramViewEndpoints(diagram);
+      endpoints = new DiagramEndpoints(diagram);
 
       var model = new StateModel({
         id: 'a3',
@@ -46,7 +46,7 @@ describe("go.components.plumbing (diagrams)", function() {
         right: [{id: 'a3R1'}, {id: 'a3R2'}]
       });
 
-      a3 = new StateView({diagram: diagram, model: model});
+      a3 = new State({diagram: diagram, model: model});
       a1 = diagram.states.get('a1');
     });
 
@@ -90,8 +90,8 @@ describe("go.components.plumbing (diagrams)", function() {
     });
   });
 
-  describe(".DiagramViewConnections", function() {
-    var DiagramViewConnections = plumbing.DiagramViewConnections;
+  describe(".DiagramConnections", function() {
+    var DiagramConnections = plumbing.DiagramConnections;
 
     var connections,
         leftToRight;
@@ -200,11 +200,11 @@ describe("go.components.plumbing (diagrams)", function() {
   });
 
   describe(".Diagram", function() {
-    var AppleStateView = testHelpers.AppleStateView,
-        BananaStateView = testHelpers.BananaStateView;
+    var AppleState = testHelpers.AppleState,
+        BananaState = testHelpers.BananaState;
 
-    var LeftToRightView = testHelpers.LeftToRightView,
-        RightToLeftView = testHelpers.RightToLeftView;
+    var LeftToRight = testHelpers.LeftToRight,
+        RightToLeft = testHelpers.RightToLeft;
 
     it("should keep track of all endpoints in the diagram", function() {
       assert.deepEqual(
@@ -223,10 +223,10 @@ describe("go.components.plumbing (diagrams)", function() {
       assert.deepEqual(rightToLeft.keys(), ['b1R2-a2L2']);
 
       leftToRight.each(
-        function(e) { assert.instanceOf(e, LeftToRightView); });
+        function(e) { assert.instanceOf(e, LeftToRight); });
 
       rightToLeft.each(
-        function(e) { assert.instanceOf(e, RightToLeftView); });
+        function(e) { assert.instanceOf(e, RightToLeft); });
 
       assert.deepEqual(
         diagram.connections.keys(),
@@ -240,8 +240,8 @@ describe("go.components.plumbing (diagrams)", function() {
       assert.deepEqual(apples.keys(), ['a1', 'a2']);
       assert.deepEqual(bananas.keys(), ['b1', 'b2']);
 
-      apples.each(function(e) { assert.instanceOf(e, AppleStateView); });
-      bananas.each(function(e) { assert.instanceOf(e, BananaStateView); });
+      apples.each(function(e) { assert.instanceOf(e, AppleState); });
+      bananas.each(function(e) { assert.instanceOf(e, BananaState); });
 
       assert.deepEqual(diagram.states.keys(), ['a1', 'a2', 'b1', 'b2']);
     });

--- a/go/base/static/js/test/tests/components/plumbing/endpoints.test.js
+++ b/go/base/static/js/test/tests/components/plumbing/endpoints.test.js
@@ -18,9 +18,9 @@ describe("go.components.plumbing (endpoints)", function() {
     tearDown();
   });
 
-  describe(".EndpointView", function() {
+  describe(".Endpoint", function() {
     var EndpointModel = stateMachine.EndpointModel,
-        EndpointView = plumbing.EndpointView;
+        Endpoint = plumbing.Endpoint;
 
     var x,
         x1;
@@ -41,7 +41,7 @@ describe("go.components.plumbing (endpoints)", function() {
 
     describe(".render", function() {
       it("should create the actual jsPlumb endpoint", function() {
-        var x4 = new EndpointView({
+        var x4 = new Endpoint({
           state: x,
           collection: x.endpoints.members.get('endpoints'),
           model: new EndpointModel({id: 'x4'})

--- a/go/base/static/js/test/tests/components/plumbing/helpers.js
+++ b/go/base/static/js/test/tests/components/plumbing/helpers.js
@@ -10,51 +10,51 @@
       StateMachineModel = stateMachine.StateMachineModel;
 
   var plumbing = go.components.plumbing,
-      EndpointView = plumbing.EndpointView,
-      StateView = plumbing.StateView,
-      ConnectionView = plumbing.ConnectionView,
-      DiagramView = plumbing.DiagramView;
+      Endpoint = plumbing.Endpoint,
+      State = plumbing.State,
+      Connection = plumbing.Connection,
+      Diagram = plumbing.Diagram;
 
   // Mocks
   // -----
 
-  var MockEndpointView = EndpointView.extend({
+  var MockEndpoint = Endpoint.extend({
     destroy: function() {
-      EndpointView.prototype.destroy.call(this);
+      Endpoint.prototype.destroy.call(this);
       this.destroyed = true;
       return this;
     },
 
     render: function() {
-      EndpointView.prototype.render.call(this);
+      Endpoint.prototype.render.call(this);
       this.rendered = true;
       return this;
     }
   });
 
-  var MockStateView = StateView.extend({
+  var MockState = State.extend({
     destroy: function() {
-      StateView.prototype.destroy.call(this);
+      State.prototype.destroy.call(this);
       this.destroyed = true;
       return this;
     },
 
     render: function() {
-      StateView.prototype.render.call(this);
+      State.prototype.render.call(this);
       this.rendered = true;
       return this;
     }
   });
 
-  var MockConnectionView = ConnectionView.extend({
+  var MockConnection = Connection.extend({
     destroy: function() {
-      ConnectionView.prototype.destroy.call(this);
+      Connection.prototype.destroy.call(this);
       this.destroyed = true;
       return this;
     },
 
     render: function() {
-      ConnectionView.prototype.render.call(this);
+      Connection.prototype.render.call(this);
       this.rendered = true;
       return this;
     }
@@ -63,13 +63,13 @@
   // Simple diagram example
   // ----------------------
 
-  var SimpleEndpointView = MockEndpointView.extend({});
+  var SimpleEndpoint = MockEndpoint.extend({});
 
-  var SimpleStateView = MockStateView.extend({
-    endpointType: SimpleEndpointView
+  var SimpleState = MockState.extend({
+    endpointType: SimpleEndpoint
   });
 
-  var SimpleDiagramView = DiagramView.extend({stateType: SimpleStateView});
+  var SimpleDiagram = Diagram.extend({stateType: SimpleState});
 
   var simpleModelData = {
     states: [{
@@ -94,7 +94,7 @@
   };
 
   var newSimpleDiagram = function() {
-    return new SimpleDiagramView({
+    return new SimpleDiagram({
       el: '#diagram',
       model: new StateMachineModel(simpleModelData)
     });
@@ -135,38 +135,38 @@
     }]
   });
 
-  var ComplexEndpointView = MockEndpointView.extend(),
-      LeftEndpointView = ComplexEndpointView.extend(),
-      RightEndpointView = ComplexEndpointView.extend();
+  var ComplexEndpoint = MockEndpoint.extend(),
+      LeftEndpoint = ComplexEndpoint.extend(),
+      RightEndpoint = ComplexEndpoint.extend();
 
-  var ComplexStateView = MockStateView.extend({
+  var ComplexState = MockState.extend({
     endpointSchema: [
-      {attr: 'left', type: LeftEndpointView},
-      {attr: 'right', type: RightEndpointView}]
+      {attr: 'left', type: LeftEndpoint},
+      {attr: 'right', type: RightEndpoint}]
   });
 
-  var AppleStateView = ComplexStateView.extend(),
-      BananaStateView = ComplexStateView.extend();
+  var AppleState = ComplexState.extend(),
+      BananaState = ComplexState.extend();
 
-  var ComplexConnectionView = MockConnectionView.extend(),
-      LeftToRightView = ComplexConnectionView.extend(),
-      RightToLeftView = ComplexConnectionView.extend();
+  var ComplexConnection = MockConnection.extend(),
+      LeftToRight = ComplexConnection.extend(),
+      RightToLeft = ComplexConnection.extend();
 
-  var ComplexDiagramView = DiagramView.extend({
+  var ComplexDiagram = Diagram.extend({
     stateSchema: [
-      {attr: 'apples', type: AppleStateView},
-      {attr: 'bananas', type: BananaStateView}
+      {attr: 'apples', type: AppleState},
+      {attr: 'bananas', type: BananaState}
     ],
     connectionSchema: [{
       attr: 'leftToRight',
-      type: LeftToRightView,
-      sourceType: LeftEndpointView,
-      targetType: RightEndpointView
+      type: LeftToRight,
+      sourceType: LeftEndpoint,
+      targetType: RightEndpoint
     }, {
       attr: 'rightToLeft',
-      type: RightToLeftView,
-      sourceType: RightEndpointView,
-      targetType: LeftEndpointView
+      type: RightToLeft,
+      sourceType: RightEndpoint,
+      targetType: LeftEndpoint
     }]
   });
 
@@ -205,7 +205,7 @@
   };
 
   var newComplexDiagram = function() {
-    return new ComplexDiagramView({
+    return new ComplexDiagram({
       el: '#diagram',
       model: new ComplexStateMachineModel(complexModelData)
     });
@@ -227,31 +227,31 @@
   };
 
   _.extend(exports, {
-    MockEndpointView: MockEndpointView,
-    MockStateView: MockStateView,
-    MockConnectionView: MockConnectionView,
+    MockEndpoint: MockEndpoint,
+    MockState: MockState,
+    MockConnection: MockConnection,
 
-    SimpleEndpointView: SimpleEndpointView,
-    SimpleStateView: SimpleStateView,
-    SimpleDiagramView: SimpleDiagramView,
+    SimpleEndpoint: SimpleEndpoint,
+    SimpleState: SimpleState,
+    SimpleDiagram: SimpleDiagram,
 
     simpleModelData: simpleModelData,
     newSimpleDiagram: newSimpleDiagram,
 
-    ComplexEndpointView: ComplexEndpointView,
-    LeftEndpointView: LeftEndpointView,
-    RightEndpointView: RightEndpointView,
+    ComplexEndpoint: ComplexEndpoint,
+    LeftEndpoint: LeftEndpoint,
+    RightEndpoint: RightEndpoint,
 
-    ComplexStateView: ComplexStateView,
-    AppleStateView: AppleStateView,
-    BananaStateView: BananaStateView,
+    ComplexState: ComplexState,
+    AppleState: AppleState,
+    BananaState: BananaState,
 
-    ComplexConnectionView: ComplexConnectionView,
-    LeftToRightView: LeftToRightView,
-    RightToLeftView: RightToLeftView,
+    ComplexConnection: ComplexConnection,
+    LeftToRight: LeftToRight,
+    RightToLeft: RightToLeft,
 
     ComplexStateMachineModel: ComplexStateMachineModel,
-    ComplexDiagramView: ComplexDiagramView,
+    ComplexDiagram: ComplexDiagram,
 
     complexModelData: complexModelData,
     newComplexDiagram: newComplexDiagram,

--- a/go/base/static/js/test/tests/components/plumbing/states.test.js
+++ b/go/base/static/js/test/tests/components/plumbing/states.test.js
@@ -15,9 +15,9 @@ describe("go.components.plumbing (states)", function() {
     tearDown();
   });
 
-  describe(".StateView", function() {
-    var LeftEndpointView = testHelpers.LeftEndpointView,
-        RightEndpointView = testHelpers.RightEndpointView;
+  describe(".State", function() {
+    var LeftEndpoint = testHelpers.LeftEndpoint,
+        RightEndpoint = testHelpers.RightEndpoint;
 
     var diagram,
         a1;
@@ -34,8 +34,8 @@ describe("go.components.plumbing (states)", function() {
       assert.deepEqual(left.keys(), ['a1L1', 'a1L2']);
       assert.deepEqual(right.keys(), ['a1R1', 'a1R2']);
 
-      left.each(function(e) { assert.instanceOf(e, LeftEndpointView); });
-      right.each(function(e) { assert.instanceOf(e, RightEndpointView); });
+      left.each(function(e) { assert.instanceOf(e, LeftEndpoint); });
+      right.each(function(e) { assert.instanceOf(e, RightEndpoint); });
 
       assert.deepEqual(
         a1.endpoints.keys(),


### PR DESCRIPTION
I'm suggesting that we exclude the 'View' suffix from the plumbing views. As the views get more and more specialised, we end up with complicated, overly verbose names like `MultiConnectionEndpointView` and `AligningEndpointViewCollection`. Removing the suffix, we can make things a bit simpler. We can ensure we maintain the disctinction between views and models by ensure we keep our `Model` suffix for models (for eg, `EndpointModel`). Since the views are more prone to specialisation, its probably a better decision to remove the suffix for views, as opposed to models.
