### PR TITLE
Add routing table retrieval and updating functions to Go API.

### DIFF
--- a/go/api/go_api/api_types.py
+++ b/go/api/go_api/api_types.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+# -*- test-case-name: go.api.go_api.tests.test_api_types -*-
+
+"""Types for the JSON RPC API for Vumi Go."""
+
+from vumi.rpc import Unicode, List, Dict, Tag
+
+
+class CampaignType(Dict):
+    def __init__(self, *args, **kw):
+        kw['required_fields'] = {
+            'key': Unicode(),
+            'name': Unicode(),
+        }
+        super(CampaignType, self).__init__(*args, **kw)
+
+    @classmethod
+    def format_campaign(cls, campaign):
+        return {
+            'key': campaign["key"],
+            'name': campaign["name"],
+        }
+
+
+class EndpointType(Dict):
+    """Description of an endpoint.
+
+    The following fields are required:
+
+    * uuid: 'endpoint-uuid-1'
+    * name: 'default'
+    """
+    def __init__(self, *args, **kw):
+        kw['required_fields'] = {
+            'uuid': Unicode(),
+            'name': Unicode(),
+        }
+        super(EndpointType, self).__init__(*args, **kw)
+
+    @classmethod
+    def format_endpoint(cls, uuid, name):
+        return {'uuid': uuid, 'name': name}
+
+
+class ConversationType(Dict):
+    def __init__(self, *args, **kw):
+        """Description of a conversation.
+
+        The following fields are required:
+
+        * uuid: 'routing-block-uuid-2',
+        * type: 'bulk-message',
+        * name: 'bulk-message-1',
+        * description: 'Some Bulk Message App',
+        * endpoints: [{uuid: 'endpoint-uuid-4', name: 'default'}]
+        """
+        kw['required_fields'] = {
+            'uuid': Unicode(),
+            'type': Unicode(),
+            'name': Unicode(),
+            'description': Unicode(),
+            'endpoints': List(item_type=EndpointType()),
+        }
+        super(ConversationType, self).__init__(*args, **kw)
+
+    @classmethod
+    def format_conversation(cls, conv):
+        return {
+            'uuid': conv.key,
+            'type': conv.conversation_type,
+            'name': conv.name,
+            'description': conv.description,
+            'endpoints': [
+                # TODO: add additional endpoints once we know how to list them
+                EndpointType.format_endpoint(
+                    uuid=u"%s:%s" % (conv.key, u'default'), name=u"default")
+            ],
+        }
+
+
+class ChannelType(Dict):
+    """Description of a channel.
+
+    The following keys are required:
+
+    * uuid: 'channel-uuid-1',
+    * tag: ['apposit_sms', '*121#'],
+    * name: '*121#',
+    * description: 'Apposit Sms: *121#',
+    * endpoints: [{uuid: 'endpoint-uuid-1', name: 'default'}]
+    """
+    def __init__(self, *args, **kw):
+        kw['required_fields'] = {
+            'uuid': Unicode(),
+            'tag': Tag(),
+            'name': Unicode(),
+            'description': Unicode(),
+            'endpoints': List(item_type=EndpointType()),
+        }
+        super(ChannelType, self).__init__(*args, **kw)
+
+    @classmethod
+    def format_channel(cls, tag):
+        pool, tagname = tag
+        uuid = u":".join(tag)
+        return {
+            'uuid': uuid, 'tag': tag, 'name': tagname,
+            'description': u"%s: %s" % (
+                pool.replace('_', ' ').title(), tagname),
+            'endpoints': [
+                EndpointType.format_endpoint(
+                    uuid=u"%s:%s" % (uuid, u'default'), name=u"default")
+            ]
+        }
+
+
+class RoutingBlockType(Dict):
+    """Description of a routing block.
+
+    The following keys are required:
+
+    * uuid: 'routing-block-uuid-1',
+    * type: 'keyword',
+    * name: 'keyword-routing-block',
+    * description: 'Keyword',
+    * channel_endpoints: [{uuid: 'endpoint-uuid-2', name: 'default'}],
+    * conversation_endpoints: [{uuid: 'endpoint-uuid-3', name: 'default'}]
+    """
+    def __init__(self, *args, **kw):
+        kw['required_fields'] = {
+            'uuid': Unicode(),
+            'type': Unicode(),
+            'name': Unicode(),
+            'description': Unicode(),
+            'channel_endpoints': List(item_type=EndpointType()),
+            'conversation_endpoints': List(item_type=EndpointType()),
+        }
+        super(RoutingBlockType, self).__init__(*args, **kw)
+
+    @classmethod
+    def format_routing_block(cls, uuid, rb_type, name, description,
+                             channel_endpoints, conversation_endpoints):
+        return {
+            'uuid': uuid, 'type': rb_type, 'name': name,
+            'description': description, 'channel_endpoints': channel_endpoints,
+            'conversation_endpoints': conversation_endpoints,
+        }
+
+
+class RoutingEntryType(Dict):
+    """Description of an entry in a routing table.
+
+    The following keys are required:
+
+    * source: {uuid: 'endpoint-uuid-1'},
+    * target: {uuid: 'endpoint-uuid-2'}
+    """
+    def __init__(self, *args, **kw):
+        uuid_dict = Dict(required_fields={'uuid': Unicode()})
+        kw['required_fields'] = {
+            'source': uuid_dict,
+            'target': uuid_dict,
+        }
+        super(RoutingEntryType, self).__init__(*args, **kw)
+
+    def format_entry(self, source_uuid, target_uuid):
+        return {
+            'source': {'uuid': source_uuid},
+            'target': {'uuid': target_uuid},
+        }
+
+
+class RoutingType(Dict):
+    """Description of a campaign routing table.
+
+    The following keys are required:
+
+    * channels: A list of `ChannelType` values.
+    * routing_blocks: A list of `RoutingBlockType` values.
+    * conversations: A list of `ConversationType` values.
+    * routing_entries: A list of `RoutingEntryType` values.
+    """
+
+    def __init__(self, *args, **kw):
+        kw['required_fields'] = {
+            'channels': List(item_type=ChannelType()),
+            'routing_blocks': List(item_type=RoutingBlockType()),
+            'conversations': List(item_type=ConversationType()),
+            'routing_entries': List(item_type=RoutingEntryType()),
+        }
+        super(RoutingType, self).__init__(*args, **kw)
+
+    @classmethod
+    def format_routing(cls, channels, routing_blocks, conversations,
+                       routing_entries):
+        return {
+            'channels': channels,
+            'routing_blocks': routing_blocks,
+            'conversations': conversations,
+            'routing_entries': routing_entries,
+        }

--- a/go/api/go_api/api_types.py
+++ b/go/api/go_api/api_types.py
@@ -29,8 +29,9 @@ class EndpointType(Dict):
 
     The following fields are required:
 
-    * uuid: 'endpoint-uuid-1'
-    * name: 'default'
+    * uuid: Unique identifier for the endpoint. Usually
+            `<connector-id>:<endpoint-name>`.
+    * name: Name of the endpoint, e.g. 'default'.
     """
     def __init__(self, *args, **kw):
         kw['required_fields'] = {
@@ -50,11 +51,13 @@ class ConversationType(Dict):
 
         The following fields are required:
 
-        * uuid: 'routing-block-uuid-2',
-        * type: 'bulk-message',
-        * name: 'bulk-message-1',
-        * description: 'Some Bulk Message App',
-        * endpoints: [{uuid: 'endpoint-uuid-4', name: 'default'}]
+        * uuid: The conversation key.
+        * type: The conversation type, e.g. 'bulk-message'.
+        * name: The conversation name, e.g. 'My Bulk Sender'.
+        * description: The conversation description, e.g.
+                       'Some Bulk Message App'.
+        * endpoints: A list of `EndpointType` dictionaries, e.g.
+                     `[{uuid: 'endpoint-uuid-4', name: 'default'}]`.
         """
         kw['required_fields'] = {
             'uuid': Unicode(),
@@ -86,11 +89,13 @@ class ChannelType(Dict):
 
     The following keys are required:
 
-    * uuid: 'channel-uuid-1',
-    * tag: ['apposit_sms', '*121#'],
-    * name: '*121#',
-    * description: 'Apposit Sms: *121#',
-    * endpoints: [{uuid: 'endpoint-uuid-1', name: 'default'}]
+    * uuid: The channel key.
+    * tag: A two-element list of the tag pool and tag name, e.g.
+           `['apposit_sms', '*121#']`.
+    * name: The channel name, often the same as the tag name, e.g. '*121#'.
+    * description: The channel description, e.g. 'Apposit Sms: *121#'.
+    * endpoints: A list of `EndpointType` dictionaries, e.g.
+                 `[{uuid: 'endpoint-uuid-1', name: 'default'}]`.
     """
     def __init__(self, *args, **kw):
         kw['required_fields'] = {
@@ -123,12 +128,19 @@ class RoutingBlockType(Dict):
 
     The following keys are required:
 
-    * uuid: 'routing-block-uuid-1',
-    * type: 'keyword',
-    * name: 'keyword-routing-block',
-    * description: 'Keyword',
-    * channel_endpoints: [{uuid: 'endpoint-uuid-2', name: 'default'}],
-    * conversation_endpoints: [{uuid: 'endpoint-uuid-3', name: 'default'}]
+    * uuid: The routing block key.
+    * type: The routing block type, e.g. 'keyword'.
+    * name: The routing block name, e.g. 'My Keyword Routing Block'.
+    * description: The routing block description,
+                   e.g.'A description of this routing block'.
+    * channel_endpoints: The endpoints that can be connected to channels
+                         (i.e. the endpoints on the left).
+                         A list of `EndpointType` dictionaries, e.g.
+                         `[{uuid: 'endpoint-uuid-2', name: 'default'}]`.
+    * conversation_endpoints: The endpoints that can be connected to
+                              conversations (i.e. the endpoints on the right).
+                              A list of `EndpointType` dictionaries, e.g.
+                              `[{uuid: 'endpoint-uuid-3', name: 'default'}]`.
     """
     def __init__(self, *args, **kw):
         kw['required_fields'] = {
@@ -156,8 +168,10 @@ class RoutingEntryType(Dict):
 
     The following keys are required:
 
-    * source: {uuid: 'endpoint-uuid-1'},
-    * target: {uuid: 'endpoint-uuid-2'}
+    * source: A dictionary containing the uuid of the source endpoint, e.g.
+              `{uuid: 'endpoint-uuid-1'}`.
+    * target: A dictionary containing the uuid of the destination endpoint,
+              e.g. `{uuid: 'endpoint-uuid-2'}`.
     """
     def __init__(self, *args, **kw):
         uuid_dict = Dict(required_fields={'uuid': Unicode()})

--- a/go/api/go_api/go_api.py
+++ b/go/api/go_api/go_api.py
@@ -4,55 +4,23 @@
 """JSON RPC API for Vumi Go front-end and others."""
 
 from twisted.application.internet import StreamServerEndpointService
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, succeed, DeferredList
 
 from txjsonrpc.jsonrpc import addIntrospection
 from txjsonrpc.web.jsonrpc import JSONRPC
 
 from vumi.config import ConfigDict, ConfigText, ConfigServerEndpoint
-from vumi.rpc import signature, Unicode, List, Dict
+from vumi.rpc import signature, Unicode, List
 from vumi.transports.httprpc import httprpc
 from vumi.utils import build_web_site
 from vumi.worker import BaseWorker
 
+from go.api.go_api.api_types import (
+    CampaignType, ConversationType, ChannelType, RoutingBlockType,
+    RoutingEntryType, RoutingType)
 from go.api.go_api.auth import GoUserRealm, GoUserAuthSessionWrapper
+from go.vumitools.account import RoutingTableHelper
 from go.vumitools.api import VumiApi
-
-
-class ConversationType(Dict):
-    def __init__(self, *args, **kw):
-        kw['required_fields'] = {
-            'key': Unicode(),
-            'name': Unicode(),
-            'description': Unicode(),
-            'conversation_type': Unicode(),
-        }
-        super(ConversationType, self).__init__(*args, **kw)
-
-    @classmethod
-    def format_conversation(cls, conv):
-        return {
-            'key': conv.key,
-            'name': conv.name,
-            'description': conv.description,
-            'conversation_type': conv.conversation_type,
-        }
-
-
-class CampaignType(Dict):
-    def __init__(self, *args, **kw):
-        kw['required_fields'] = {
-            'key': Unicode(),
-            'name': Unicode(),
-        }
-        super(CampaignType, self).__init__(*args, **kw)
-
-    @classmethod
-    def format_campaign(cls, campaign):
-        return {
-            'key': campaign["key"],
-            'name': campaign["name"],
-        }
 
 
 class GoApiServer(JSONRPC):
@@ -61,8 +29,43 @@ class GoApiServer(JSONRPC):
         self.user_account_key = user_account_key
         self.vumi_api = vumi_api
 
-    def _format_conversation_list(self, convs):
-        return [ConversationType.format_conversation(c) for c in convs]
+    def _conversations(self, user_api):
+        def format_conversations(convs):
+            return [ConversationType.format_conversation(c) for c in convs]
+
+        d = user_api.active_conversations()
+        d.addCallback(format_conversations)
+        return d
+
+    def _channels(self, user_api):
+        def endpoints_to_channels(endpoints):
+            return [ChannelType.format_channel(tag) for tag in endpoints]
+
+        d = user_api.list_endpoints()
+        d.addCallback(endpoints_to_channels)
+        return d
+
+    def _routing_blocks(self, user_api):
+        def format_routing_blocks(routing_blocks):
+            return [RoutingBlockType.format_routing_block(rb)
+                    for rb in routing_blocks]
+
+        d = succeed([])  # TODO: complete once routing blocks exist
+        d.addCallback(format_routing_blocks)
+        return d
+
+    def _routing_entries(self, user_api):
+        def format_routing_entries(routing_table):
+            routing_table = RoutingTableHelper(routing_table)
+            return [RoutingEntryType.format_entry(
+                source_uuid=u"%s:%s" % (src_conn, src_endp),
+                target_uuid=u"%s:%s" % (dst_conn, dst_endp))
+                for src_conn, src_endp, dst_conn, dst_endp
+                in routing_table.entries()]
+
+        d = user_api.get_routing_table()
+        d.addCallback(format_routing_entries)
+        return d
 
     @signature(returns=List("List of campaigns.",
                             item_type=CampaignType()))
@@ -76,12 +79,73 @@ class GoApiServer(JSONRPC):
     @signature(campaign_key=Unicode("Campaign key."),
                returns=List("List of conversations.",
                             item_type=ConversationType()))
-    def jsonrpc_active_conversations(self, campaign_key):
+    def jsonrpc_conversations(self, campaign_key):
         """List the active conversations under a particular campaign.
            """
         user_api = self.vumi_api.get_user_api(campaign_key)
-        d = user_api.active_conversations()
-        d.addCallback(self._format_conversation_list)
+        return self._conversations(user_api)
+
+    @signature(campaign_key=Unicode("Campaign key."),
+               returns=List("List of channels.",
+                            item_type=ChannelType()))
+    def jsonrpc_channels(self, campaign_key):
+        """List the active channels under a particular campaign.
+           """
+        user_api = self.vumi_api.get_user_api(campaign_key)
+        return self._channels(user_api)
+
+    @signature(campaign_key=Unicode("Campaign key."),
+               returns=List("List of routing blocks.",
+                            item_type=ChannelType()))
+    def jsonrpc_routing_blocks(self, campaign_key):
+        """List the active routing blocks under a particular campaign.
+           """
+        user_api = self.vumi_api.get_user_api(campaign_key)
+        return self._routing_blocks(user_api)
+
+    @signature(campaign_key=Unicode("Campaign key."),
+               returns=RoutingType("Description of the routing table."))
+    def jsonrpc_routing_table(self, campaign_key):
+        user_api = self.vumi_api.get_user_api(campaign_key)
+        deferreds = []
+        deferreds.append(self._channels(user_api))
+        deferreds.append(self._routing_blocks(user_api))
+        deferreds.append(self._conversations(user_api))
+        deferreds.append(self._routing_entries(user_api))
+
+        def construct_json(results):
+            for success, result  in results:
+                if not success:
+                    result.raiseException()
+            results = [r[1] for r in results]
+            channels, routing_blocks, conversations, routing_entries = results
+            return RoutingType.format_routing(
+                channels, routing_blocks, conversations, routing_entries)
+
+        d = DeferredList(deferreds, consumeErrors=True)
+        d.addCallback(construct_json)
+        return d
+
+    @signature(campaign_key=Unicode("Campaign key."),
+               routing=RoutingType("Description of the new routing table."))
+    def jsonrpc_update_routing_table(self, campaign_key, routing):
+        user_api = self.vumi_api.get_user_api(campaign_key)
+        deferreds = []
+        deferreds.append(self._channels(user_api))
+        deferreds.append(self._routing_blocks(user_api))
+        deferreds.append(self._conversations(user_api))
+
+        def check_routing_table(result):
+            # TODO: checks
+            pass
+
+        def save_routing_table(result):
+            # TODO: save
+            pass
+
+        d = DeferredList(deferreds, consumeErrors=True)
+        d.addCallback(check_routing_table)
+        d.addCallback(save_routing_table)
         return d
 
 

--- a/go/api/go_api/go_api.py
+++ b/go/api/go_api/go_api.py
@@ -61,7 +61,7 @@ class GoApiServer(JSONRPC):
                 source_uuid=u"%s:%s" % (src_conn, src_endp),
                 target_uuid=u"%s:%s" % (dst_conn, dst_endp))
                 for src_conn, src_endp, dst_conn, dst_endp
-                in sorted(routing_table.entries())]
+                in routing_table.entries()]
 
         d = user_api.get_routing_table()
         d.addCallback(format_routing_entries)

--- a/go/api/go_api/go_api.py
+++ b/go/api/go_api/go_api.py
@@ -61,7 +61,7 @@ class GoApiServer(JSONRPC):
                 source_uuid=u"%s:%s" % (src_conn, src_endp),
                 target_uuid=u"%s:%s" % (dst_conn, dst_endp))
                 for src_conn, src_endp, dst_conn, dst_endp
-                in routing_table.entries()]
+                in sorted(routing_table.entries())]
 
         d = user_api.get_routing_table()
         d.addCallback(format_routing_entries)
@@ -104,8 +104,21 @@ class GoApiServer(JSONRPC):
         return self._routing_blocks(user_api)
 
     @signature(campaign_key=Unicode("Campaign key."),
-               returns=RoutingType("Description of the routing table."))
+               returns=List("List of routing table entries.",
+                            item_type=RoutingEntryType()))
+    def jsonrpc_routing_entries(self, campaign_key):
+        """List the routing entries from a particular campaign's routing table.
+           """
+        user_api = self.vumi_api.get_user_api(campaign_key)
+        return self._routing_entries(user_api)
+
+    @signature(campaign_key=Unicode("Campaign key."),
+               returns=RoutingType(
+                   "Complete description of the routing table."))
     def jsonrpc_routing_table(self, campaign_key):
+        """List the channels, conversations, routing blocks and routing table
+        entries that make up a campaign's routing.
+        """
         user_api = self.vumi_api.get_user_api(campaign_key)
         deferreds = []
         deferreds.append(self._channels(user_api))

--- a/go/api/go_api/tests/test_api_types.py
+++ b/go/api/go_api/tests/test_api_types.py
@@ -1,0 +1,47 @@
+"""Tests for go.api.go_api.api_types"""
+
+from twisted.trial.unittest import TestCase
+
+from vumi.rpc import RpcCheckError
+
+from go.api.go_api.api_types import (
+    ConversationType, CampaignType)
+
+
+class ConversationTypeTestCase(TestCase):
+
+    def _conv_dict(self, without=(), **kw):
+        conv_dict = kw.copy()
+        conv_dict.setdefault('key', u'conv-1')
+        conv_dict.setdefault('name', u'Conversation One')
+        conv_dict.setdefault('description', u'A Dummy Conversation')
+        conv_dict.setdefault('conversation_type', u'jsbox')
+        for key in without:
+            del conv_dict[key]
+        return conv_dict
+
+    def test_check(self):
+        conv_type = ConversationType()
+        conv_type.check('name', self._conv_dict())
+        for key in ['key', 'name', 'description', 'conversation_type']:
+            self.assertRaises(
+                RpcCheckError, conv_type.check, 'name',
+                self._conv_dict(without=(key,)))
+
+
+class CampaignTypeTestCase(TestCase):
+    def _campaign_dict(self, without=(), **kw):
+        campaign_dict = kw.copy()
+        campaign_dict.setdefault('key', u'campaign-1')
+        campaign_dict.setdefault('name', u'Campaign One')
+        for key in without:
+            del campaign_dict[key]
+        return campaign_dict
+
+    def test_check(self):
+        campaign_type = CampaignType()
+        campaign_type.check('name', self._campaign_dict())
+        for key in ['key', 'name']:
+            self.assertRaises(
+                RpcCheckError, campaign_type.check, 'name',
+                self._campaign_dict(without=(key,)))

--- a/go/api/go_api/tests/test_api_types.py
+++ b/go/api/go_api/tests/test_api_types.py
@@ -5,43 +5,113 @@ from twisted.trial.unittest import TestCase
 from vumi.rpc import RpcCheckError
 
 from go.api.go_api.api_types import (
-    ConversationType, CampaignType)
+    CampaignType, EndpointType, ConversationType, ChannelType,
+    RoutingBlockType, RoutingEntryType, RoutingType)
 
 
-class ConversationTypeTestCase(TestCase):
+class BaseTypeTest(TestCase):
+    DEFAULTS = {}
 
-    def _conv_dict(self, without=(), **kw):
-        conv_dict = kw.copy()
-        conv_dict.setdefault('key', u'conv-1')
-        conv_dict.setdefault('name', u'Conversation One')
-        conv_dict.setdefault('description', u'A Dummy Conversation')
-        conv_dict.setdefault('conversation_type', u'jsbox')
+    def mk_dict(self, without=(), **kw):
+        value = self.DEFAULTS.copy()
+        value.update(kw)
         for key in without:
-            del conv_dict[key]
-        return conv_dict
+            del value[key]
+        return value
 
-    def test_check(self):
-        conv_type = ConversationType()
-        conv_type.check('name', self._conv_dict())
-        for key in ['key', 'name', 'description', 'conversation_type']:
+    def basic_checks(self, check_type):
+        check_type.check('name', self.mk_dict())
+        for key in self.DEFAULTS:
             self.assertRaises(
-                RpcCheckError, conv_type.check, 'name',
-                self._conv_dict(without=(key,)))
+                RpcCheckError, check_type.check, 'name',
+                self.mk_dict(without=(key,)))
 
 
-class CampaignTypeTestCase(TestCase):
-    def _campaign_dict(self, without=(), **kw):
-        campaign_dict = kw.copy()
-        campaign_dict.setdefault('key', u'campaign-1')
-        campaign_dict.setdefault('name', u'Campaign One')
-        for key in without:
-            del campaign_dict[key]
-        return campaign_dict
+class CampaignTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'key': u'campaign-1',
+        u'name': u'Campaign One',
+    }
 
-    def test_check(self):
-        campaign_type = CampaignType()
-        campaign_type.check('name', self._campaign_dict())
-        for key in ['key', 'name']:
-            self.assertRaises(
-                RpcCheckError, campaign_type.check, 'name',
-                self._campaign_dict(without=(key,)))
+    def test_basic_checks(self):
+        self.basic_checks(CampaignType())
+
+
+class EndpointTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'uuid': u'endpoint-1',
+        u'name': u'Endpoint 1',
+    }
+
+    def test_basic_checks(self):
+        self.basic_checks(EndpointType())
+
+
+class ConversationTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'uuid': u'conv-1',
+        u'type': u'jsbox',
+        u'name': u'Conversation One',
+        u'description': u'A Dummy Conversation',
+        u'endpoints': [
+            {u'uuid': u'endpoint-uuid-1', u'name': u'default'}
+        ],
+    }
+
+    def test_basic_checks(self):
+        self.basic_checks(ConversationType())
+
+
+class ChannelTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'uuid': u'channel-1',
+        u'tag': [u'apposit_sms', u'*121#'],
+        u'name': u'*121#',
+        u'description': u'Apposit Sms: *121#',
+        u'endpoints': [
+            {u'uuid': u'endpoint-uuid-1', u'name': u'default'}
+        ],
+    }
+
+    def test_basic_checks(self):
+        self.basic_checks(ChannelType())
+
+
+class RoutingBlockTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'uuid': u'routing-block-uuid-1',
+        u'type': u'keyword',
+        u'name': u'keyword-routing-block',
+        u'description': u'Keyword',
+        u'channel_endpoints': [
+            {u'uuid': u'endpoint-uuid-2', u'name': u'default'}
+        ],
+        u'conversation_endpoints': [
+            {u'uuid': u'endpoint-uuid-3', u'name': u'default'}
+        ],
+    }
+
+    def test_basic_checks(self):
+        self.basic_checks(RoutingBlockType())
+
+
+class RoutingEntryTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'source': {u'uuid': u'endpoint-uuid-1'},
+        u'target': {u'uuid': u'endpoint-uuid-2'},
+    }
+
+    def test_basic_checks(self):
+        self.basic_checks(RoutingEntryType())
+
+
+class RoutingTypeTestCase(BaseTypeTest):
+    DEFAULTS = {
+        u'channels': [ChannelTypeTestCase.DEFAULTS],
+        u'routing_blocks': [RoutingBlockTypeTestCase.DEFAULTS],
+        u'conversations': [ConversationTypeTestCase.DEFAULTS],
+        u'routing_entries': [RoutingEntryTypeTestCase.DEFAULTS],
+    }
+
+    def test_basic_checks(self):
+        self.basic_checks(RoutingType())

--- a/go/api/go_api/tests/test_go_api.py
+++ b/go/api/go_api/tests/test_go_api.py
@@ -236,9 +236,9 @@ class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
         d = self.proxy.callRemote(
                 "update_routing_table", self.campaign_key, routing_table)
         yield self.assert_faults(
-            d, 400, u"Source channel endpoint {u'uuid':"
+            d, 400, u"Source outbound-receiving endpoint {u'uuid':"
             " u'TRANSPORT_TAG:pool:tag1:default'}"
-            " should link to a conversation endpoint"
+            " should link to an inbound-receiving endpoint"
             " but links to {u'uuid': u'bar'}")
 
     @inlineCallbacks
@@ -251,9 +251,9 @@ class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
         d = self.proxy.callRemote(
                 "update_routing_table", self.campaign_key, routing_table)
         yield self.assert_faults(
-            d, 400, u"Source channel endpoint"
+            d, 400, u"Source outbound-receiving endpoint"
             " {u'uuid': u'TRANSPORT_TAG:pool:tag1:default'} should link"
-            " to a conversation endpoint but links to {u'uuid':"
+            " to an inbound-receiving endpoint but links to {u'uuid':"
             " u'TRANSPORT_TAG:pool:tag1:default'}")
 
     @inlineCallbacks
@@ -267,9 +267,9 @@ class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
         d = self.proxy.callRemote(
                 "update_routing_table", self.campaign_key, routing_table)
         yield self.assert_faults(
-            d, 400, u"Source conversation endpoint"
+            d, 400, u"Source inbound-receiving endpoint"
             " {u'uuid': %r} should link"
-            " to a channel endpoint but links to {u'uuid': %r}"
+            " to an outbound-receiving endpoint but links to {u'uuid': %r}"
             % (endpoint_uuid, endpoint_uuid))
 
     @inlineCallbacks

--- a/go/api/go_api/tests/test_go_api.py
+++ b/go/api/go_api/tests/test_go_api.py
@@ -129,6 +129,7 @@ class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
         conv, tag = yield self._setup_simple_routing_table()
         result = yield self.proxy.callRemote(
             "routing_entries", self.campaign_key)
+        result.sort(key=lambda x: x['source']['uuid'])
         self.assertEqual(result, [
             {
                 u'source': {u'uuid': u'CONVERSATION:jsbox:%s:default'
@@ -147,6 +148,7 @@ class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
         conv, tag = yield self._setup_simple_routing_table()
         result = yield self.proxy.callRemote(
             "routing_table", self.campaign_key)
+        result['routing_entries'].sort(key=lambda x: x['source']['uuid'])
         self.assertEqual(result, {
             u'channels': [
                 {

--- a/go/vumitools/account/models.py
+++ b/go/vumitools/account/models.py
@@ -84,6 +84,15 @@ class RoutingTableHelper(object):
     def lookup_target(self, src_conn, src_endpoint):
         return self.routing_table.get(src_conn, {}).get(src_endpoint)
 
+    def entries(self):
+        """Iterate over entries in the routing table.
+
+        Yield tuples of (src_conn, src_endpoint, dst_conn, dst_endpoint).
+        """
+        for src_conn, endpoints in self.routing_table.iteritems():
+            for src_endp, (dst_conn, dst_endp) in endpoints.iteritems():
+                yield (src_conn, src_endp, dst_conn, dst_endp)
+
     def add_entry(self, src_conn, src_endpoint, dst_conn, dst_endpoint):
         connector_dict = self.routing_table.setdefault(src_conn, {})
         if src_endpoint in connector_dict:

--- a/go/vumitools/account/tests/test_models.py
+++ b/go/vumitools/account/tests/test_models.py
@@ -4,7 +4,7 @@ from vumi.tests.utils import UTCNearNow
 
 from go.vumitools.tests.utils import GoPersistenceMixin
 from go.vumitools.account.models import (
-    AccountStore, GoConnector, GoConnectorError)
+    AccountStore, RoutingTableHelper, GoConnector, GoConnectorError)
 from go.vumitools.account.old_models import AccountStoreVNone, AccountStoreV1
 
 
@@ -83,6 +83,20 @@ class UserAccountTestCase(GoPersistenceMixin, TestCase):
         self.assert_user_vnone(user_vnone)
         user = yield self.store.get_user(user_vnone.key)
         self.assert_user(user, tags=None, routing_table=None)
+
+
+class RoutingTableHelperTestCase(TestCase):
+    def test_entries(self):
+        rt = RoutingTableHelper({
+            "conn1": {
+                "default1.1": ["conn2", "default2"],
+                "default1.2": ["conn3", "default3"],
+            }
+        })
+        self.assertEqual(sorted(rt.entries()), [
+            ("conn1", "default1.1", "conn2", "default2"),
+            ("conn1", "default1.2", "conn3", "default3"),
+        ])
 
 
 class GoConnectorTestCase(TestCase):


### PR DESCRIPTION
This is needed by the routing table jsPlumb UI. We need at least a method for:
- Retrieving the routing table and channels, routing blocks and endpoints.
- Saving an updated routing table (and validating it).

Example JSON for routing table retrieval:

``` javascript
var routing = {
  campaign_id: 'campaign-1',
  channels: [{
    uuid: 'channel-uuid-1',
    tag: ['apposit_sms', '*121#'],
    name: '*121#',
    description: 'Apposit Sms: *121#',
    endpoints: [{uuid: 'endpoint-uuid-1', name: 'default'}]
  }],
  routing_blocks: [{
    uuid: 'routing-block-uuid-1',
    type: 'keyword',
    name: 'keyword-routing-block',
    description: 'Keyword',
    channel_endpoints: [{uuid: 'endpoint-uuid-2', name: 'default'}],
    conversation_endpoints: [{uuid: 'endpoint-uuid-3', name: 'default'}]
  }],
  conversations: [{
    uuid: 'routing-block-uuid-2',
    type: 'bulk-message',
    name: 'bulk-message-1',
    description: 'Some Bulk Message App',
    endpoints: [{uuid: 'endpoint-uuid-4', name: 'default'}]
  }],
  routing_entries: [{
    source: {uuid: 'endpoint-uuid-1'},
    target: {uuid: 'endpoint-uuid-2'}
  }]
};
```
