### PR TITLE
A 'following' endpoint is needed for the dialogue screen

### DIFF
--- a/go/base/static/js/src/components/plumbing/endpoints.js
+++ b/go/base/static/js/src/components/plumbing/endpoints.js
@@ -86,9 +86,7 @@
   // Derived components
   // ------------------
 
-  // An endpoint view type which resides on a side of the state, and
-  // can be positioned along the side based on a parameter t.
-  var ParametricEndpointView = EndpointView.extend({
+  var PositionableEndpointView = EndpointView.extend({
     defaults: {
       side: 'left',
       offset: function() {
@@ -105,8 +103,26 @@
 
       this.side = options.side;
       this.offset = options.offset;
-      this.positioner = this.positioners[this.side];
+    },
 
+    // Override to specialise how the endpoint is positioned
+    position: function() { return _(this).result('offset'); },
+
+    render: function() {
+      EndpointView.prototype.render.call(this);
+
+      this.$el
+        .css('position', 'absolute')
+        .css(this.position());
+    }
+  });
+
+  // An endpoint view type which resides on a side of the state, and
+  // can be positioned along the side based on a parameter t.
+  var ParametricEndpointView = PositionableEndpointView.extend({
+    initialize: function(options) {
+      PositionableEndpointView.prototype.initialize.call(this, options);
+      this.positioner = this.positioners[this.side];
       this.t = 0.5;
     },
 
@@ -151,15 +167,12 @@
       return this;
     },
 
-    position: function() { return this.positioner(this.t); },
+    position: function() { return this.positioner(this.t); }
+  });
 
-    render: function() {
-      EndpointView.prototype.render.call(this);
-
-      this.$el
-        .css('position', 'absolute')
-        .css(this.position());
-    }
+  // An endpoint view type which resides on a side of the state, and
+  // and follows the vertical position of one the state's child elements.
+  var FollowingEndpointView = PositionableEndpointView.extend({
   });
 
   // Automatically aligns its endpoints to be evenly spaced on one side of the
@@ -215,6 +228,7 @@
     EndpointView: EndpointView,
     EndpointViewCollection: EndpointViewCollection,
 
+    PositionableEndpointView: PositionableEndpointView,
     ParametricEndpointView: ParametricEndpointView,
     AligningEndpointCollection: AligningEndpointCollection
   });

--- a/go/base/static/js/test/tests/components/plumbing/endpoints.test.js
+++ b/go/base/static/js/test/tests/components/plumbing/endpoints.test.js
@@ -208,6 +208,88 @@ describe("go.components.plumbing (endpoints)", function() {
     });
   });
 
+  describe(".FollowingEndpointView", function() {
+    var FollowingEndpointView = plumbing.FollowingEndpointView;
+
+    var state,
+        endpoint,
+        $target;
+
+    beforeEach(function() {
+      $target = $('<span></span').attr('id', 'target');
+
+      state = diagram.states.get('x');
+      state.$el.append($target);
+
+      endpoint = new FollowingEndpointView({
+        state: state,
+        target: '#target',
+        collection: state.endpoints.members.get('endpoints'),
+        model: new EndpointModel({id: 'x4'})
+      });
+
+      state
+        .render()
+        .$el
+        .width(200)
+        .height(300)
+        .css('position', 'absolute');
+
+      $target
+        .width(20)
+        .height(40)
+        .css({position: 'absolute', top: 10, left: 20});
+
+      endpoint
+        .$el
+        .width(20)
+        .height(10);
+    });
+
+    describe(".positioners", function() {
+      var positioners;
+
+      beforeEach(function() {
+        positioners = endpoint.positioners;
+      });
+
+      describe(".left", function() {
+        it("should find the position on the left corresponding to the target",
+        function() {
+          assert.deepEqual(
+            positioners.left.call(endpoint),
+            {left: -10, top: 25});
+        });
+      });
+
+      describe(".right", function() {
+        it("should find the position on the right corresponding to the target ",
+        function() {
+          assert.deepEqual(
+            positioners.right.call(endpoint),
+            {left: 190, top: 25});
+        });
+      });
+    });
+
+    describe(".render", function() {
+      it("should follow to its target", function() {
+        endpoint.render();
+
+        assert.deepEqual(
+          endpoint.$el.position(),
+          {top: 25, left: -10});
+
+        $target.css({top: 20, left: 25});
+        endpoint.render();
+
+        assert.deepEqual(
+          endpoint.$el.position(),
+          {top: 35, left: -10});
+      });
+    });
+  });
+
   describe(".AligningEndpointCollection", function() {
     var EndpointModel = stateMachine.EndpointModel,
         ParametricEndpointView = plumbing.ParametricEndpointView;

--- a/go/base/static/js/test/tests/components/plumbing/endpoints.test.js
+++ b/go/base/static/js/test/tests/components/plumbing/endpoints.test.js
@@ -69,6 +69,51 @@ describe("go.components.plumbing (endpoints)", function() {
     });
   });
 
+  describe(".PositionableEndpointView", function() {
+    var PositionableEndpointView = plumbing.PositionableEndpointView;
+
+    var ToyEndpointView = PositionableEndpointView.extend({
+      reposition: function(p) { this.p = p; },
+      position: function() { return this.p; }
+    });
+
+    var state,
+        endpoint;
+
+    beforeEach(function() {
+      state = diagram.states.get('x');
+
+      endpoint = new ToyEndpointView({
+        state: state,
+        collection: state.endpoints.members.get('endpoints'),
+        model: new EndpointModel({id: 'x4'})
+      });
+
+      state
+        .render()
+        .$el
+        .offset({top: 100, left: 200});
+    });
+
+    describe(".render", function() {
+      it("should position the endpoint relative to the state", function() {
+        endpoint.reposition({top: -25, left: -50});
+        endpoint.render();
+
+        assert.deepEqual(
+          endpoint.$el.offset(),
+          {top: 75, left: 150});
+
+        endpoint.reposition({top: -30, left: -50});
+        endpoint.render();
+
+        assert.deepEqual(
+          endpoint.$el.offset(),
+          {top: 70, left: 150});
+      });
+    });
+  });
+
   describe(".ParametricEndpointView", function() {
     var EndpointModel = stateMachine.EndpointModel,
         ParametricEndpointView = plumbing.ParametricEndpointView;
@@ -79,17 +124,17 @@ describe("go.components.plumbing (endpoints)", function() {
     beforeEach(function() {
       state = diagram.states.get('x');
 
-      state
-        .render()
-        .$el
-        .width(200)
-        .height(300);
-
       endpoint = new ParametricEndpointView({
         state: state,
         collection: state.endpoints.members.get('endpoints'),
         model: new EndpointModel({id: 'x4'})
       });
+
+      state
+        .render()
+        .$el
+        .width(200)
+        .height(300);
 
       endpoint
         .$el


### PR DESCRIPTION
We need an endpoint type that follows the vertical position of a state's child element.
