### PR TITLE
Messages from the opt-out worker fail to be routed

### DIFF
--- a/go/vumitools/account/models.py
+++ b/go/vumitools/account/models.py
@@ -171,6 +171,7 @@ class GoConnector(object):
     CONVERSATION = "CONVERSATION"
     ROUTING_BLOCK = "ROUTING_BLOCK"
     TRANSPORT_TAG = "TRANSPORT_TAG"
+    OPT_OUT = "OPT_OUT"
 
     # Directions for routing block entries
 
@@ -206,6 +207,10 @@ class GoConnector(object):
                    [tagpool, tagname])
 
     @classmethod
+    def for_opt_out(cls):
+        return cls(cls.OPT_OUT, [], [])
+
+    @classmethod
     def parse(cls, s):
         parts = s.split(":")
         ctype, parts = parts[0], parts[1:]
@@ -213,6 +218,7 @@ class GoConnector(object):
             cls.CONVERSATION: cls.for_conversation,
             cls.ROUTING_BLOCK: cls.for_routing_block,
             cls.TRANSPORT_TAG: cls.for_transport_tag,
+            cls.OPT_OUT: cls.for_opt_out,
         }
         if ctype not in constructors:
             raise GoConnectorError("Unknown connector type %r"

--- a/go/vumitools/account/models.py
+++ b/go/vumitools/account/models.py
@@ -172,6 +172,11 @@ class GoConnector(object):
     ROUTING_BLOCK = "ROUTING_BLOCK"
     TRANSPORT_TAG = "TRANSPORT_TAG"
 
+    # Directions for routing block entries
+
+    INBOUND = "INBOUND"
+    OUTBOUND = "OUTBOUND"
+
     def __init__(self, ctype, names, parts):
         self.ctype = ctype
         self._names = names
@@ -190,9 +195,10 @@ class GoConnector(object):
                    [conv_type, conv_key])
 
     @classmethod
-    def for_routing_block(cls, rblock_type, rblock_key):
-        return cls(cls.ROUTING_BLOCK, ["rblock_type", "rblock_key"],
-                   [rblock_type, rblock_key])
+    def for_routing_block(cls, rblock_type, rblock_key, direction):
+        return cls(cls.ROUTING_BLOCK,
+                   ["rblock_type", "rblock_key", "direction"],
+                   [rblock_type, rblock_key, direction])
 
     @classmethod
     def for_transport_tag(cls, tagpool, tagname):

--- a/go/vumitools/account/tests/test_models.py
+++ b/go/vumitools/account/tests/test_models.py
@@ -123,6 +123,11 @@ class GoConnectorTestCase(TestCase):
         self.assertEqual(c.tagname, "tag_1")
         self.assertEqual(str(c), "TRANSPORT_TAG:tagpool_1:tag_1")
 
+    def test_create_opt_out_connector(self):
+        c = GoConnector.for_opt_out()
+        self.assertEqual(c.ctype, GoConnector.OPT_OUT)
+        self.assertEqual(str(c), "OPT_OUT")
+
     def test_parse_conversation_connector(self):
         c = GoConnector.parse("CONVERSATION:conv_type_1:12345")
         self.assertEqual(c.ctype, GoConnector.CONVERSATION)
@@ -141,6 +146,10 @@ class GoConnectorTestCase(TestCase):
         self.assertEqual(c.ctype, GoConnector.TRANSPORT_TAG)
         self.assertEqual(c.tagpool, "tagpool_1")
         self.assertEqual(c.tagname, "tag_1")
+
+    def test_parse_opt_out_connector(self):
+        c = GoConnector.parse("OPT_OUT")
+        self.assertEqual(c.ctype, GoConnector.OPT_OUT)
 
     def test_parse_unknown_ctype(self):
         self.assertRaises(GoConnectorError, GoConnector.parse,

--- a/go/vumitools/account/tests/test_models.py
+++ b/go/vumitools/account/tests/test_models.py
@@ -108,11 +108,13 @@ class GoConnectorTestCase(TestCase):
         self.assertEqual(str(c), "CONVERSATION:conv_type_1:12345")
 
     def test_create_routing_block_connector(self):
-        c = GoConnector.for_routing_block("rb_type_1", "12345")
+        c = GoConnector.for_routing_block("rb_type_1", "12345",
+                                          GoConnector.INBOUND)
         self.assertEqual(c.ctype, GoConnector.ROUTING_BLOCK)
         self.assertEqual(c.rblock_type, "rb_type_1")
         self.assertEqual(c.rblock_key, "12345")
-        self.assertEqual(str(c), "ROUTING_BLOCK:rb_type_1:12345")
+        self.assertEqual(c.direction, GoConnector.INBOUND)
+        self.assertEqual(str(c), "ROUTING_BLOCK:rb_type_1:12345:INBOUND")
 
     def test_create_transport_tag_connector(self):
         c = GoConnector.for_transport_tag("tagpool_1", "tag_1")
@@ -128,10 +130,11 @@ class GoConnectorTestCase(TestCase):
         self.assertEqual(c.conv_key, "12345")
 
     def test_parse_routing_block_connector(self):
-        c = GoConnector.parse("ROUTING_BLOCK:rb_type_1:12345")
+        c = GoConnector.parse("ROUTING_BLOCK:rb_type_1:12345:OUTBOUND")
         self.assertEqual(c.ctype, GoConnector.ROUTING_BLOCK)
         self.assertEqual(c.rblock_type, "rb_type_1")
         self.assertEqual(c.rblock_key, "12345")
+        self.assertEqual(c.direction, GoConnector.OUTBOUND)
 
     def test_parse_transport_tag_connector(self):
         c = GoConnector.parse("TRANSPORT_TAG:tagpool_1:tag_1")

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -303,6 +303,25 @@ class GoWorkerMixin(object):
         if outbound_message:
             returnValue(outbound_message.msg)
 
+    @inlineCallbacks
+    def find_inboundmessage_for_reply(self, reply):
+        user_message_id = reply.get('in_reply_to')
+        if user_message_id is None:
+            log.error('Received reply without in_reply_to: %s' % (reply,))
+            return
+
+        msg = yield self.vumi_api.mdb.inbound_messages.load(user_message_id)
+        if msg is None:
+            log.error('Unable to find message for reply: %s' % (reply,))
+
+        returnValue(msg)
+
+    @inlineCallbacks
+    def find_message_for_reply(self, reply):
+        inbound_message = yield self.find_inboundmessage_for_reply(reply)
+        if inbound_message:
+            returnValue(inbound_message.msg)
+
     def event_for_message(self, message, event_type, content):
         msg_mdh = self.get_metadata_helper(message)
         return VumiApiEvent.event(msg_mdh.get_account_key(),

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -27,7 +27,7 @@ class AccountRoutingTableDispatcherConfig(RoutingTableDispatcher.CONFIG_CLASS,
         "Mapping from conversation_type to connector name.",
         static=True, required=True)
     router_connector_mapping = ConfigDict(
-        "Mapping from routing block type to connector name.",
+        "Mapping from router_type to connector name.",
         static=True, required=True)
     opt_out_connector = ConfigText(
         "Connector to publish opt-out messages on.",

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -90,10 +90,10 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
     worker_name = 'account_routing_table_dispatcher'
 
     # connector types
-    CONVERSATION = "CONVERSATION"
-    ROUTING_BLOCK = "ROUTING_BLOCK"
-    TRANSPORT = "TRANSPORT"
-    OPT_OUT = "OPT_OUT"
+    CONVERSATION = GoConnector.CONVERSATION
+    ROUTING_BLOCK = GoConnector.ROUTING_BLOCK
+    TRANSPORT_TAG = GoConnector.TRANSPORT_TAG
+    OPT_OUT = GoConnector.OPT_OUT
 
     # directions
     INBOUND = GoConnector.INBOUND
@@ -169,7 +169,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
             return self.ROUTING_BLOCK
         elif connector_name == self.opt_out_connector:
             return self.OPT_OUT
-        return self.TRANSPORT
+        return self.TRANSPORT_TAG
 
     def get_application_connector(self, conversation_type):
         return self.application_connector_mapping.get(conversation_type)
@@ -273,7 +273,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
         msg_mdh = self.get_metadata_helper(msg)
 
         if direction == self.INBOUND:
-            allowed_types = (self.TRANSPORT, self.ROUTING_BLOCK)
+            allowed_types = (self.TRANSPORT_TAG, self.ROUTING_BLOCK)
         else:
             allowed_types = (self.CONVERSATION, self.ROUTING_BLOCK)
 
@@ -292,7 +292,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
                 router_info['router_type'], router_info['router_key'],
                 self.router_direction(direction)))
 
-        elif connector_type == self.TRANSPORT:
+        elif connector_type == self.TRANSPORT_TAG:
             src_conn = str(GoConnector.for_transport_tag(*msg_mdh.tag))
 
         else:
@@ -353,7 +353,8 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
         connector_type = self.connector_type(connector_name)
 
-        if connector_type == self.TRANSPORT and msg_mdh.is_optout_message():
+        if (connector_type == self.TRANSPORT_TAG
+                and msg_mdh.is_optout_message()):
             self.publish_inbound_optout(config, msg)
             return
 

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -46,7 +46,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
     Provides routing dispatching for Vumi Go accounts.
 
     Broadly, the strategy is to determine a user account key for the message
-    and look up it's assocaited routing table. The user account key is
+    and look up its associated routing table. The user account key is
     determined either based on the tag (if the message is inbound from
     a transport) or retrieved from the Vumi Go metadata.
 

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -280,6 +280,10 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
                 raise UnroutableMessageError(
                     "No transport name found for tagpool %r"
                     % conn.tagpool, msg)
+            if self.connector_type(transport_name) != self.TRANSPORT_TAG:
+                raise UnroutableMessageError(
+                    "Transport name %r found in tagpool metadata for pool"
+                    " %r is invalid." % (transport_name, conn.tagpool), msg)
             dst_connector_name = transport_name
 
         elif conn.ctype == conn.OPT_OUT:
@@ -288,8 +292,8 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
         else:
             raise UnroutableMessageError(
                 "Serious error. Reached apparently unreachable state"
-                " in which destination connector type is both valid"
-                " but unknown. Bad connector is: %s" % conn, msg)
+                " in which destination connector type is valid but"
+                " unknown. Bad connector is: %s" % conn, msg)
 
         self.push_hop(msg, str(conn), target[1])
         returnValue((dst_connector_name, target[1]))

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -3,7 +3,7 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.dispatchers.endpoint_dispatchers import RoutingTableDispatcher
-from vumi.config import ConfigList, ConfigDict, ConfigText
+from vumi.config import ConfigDict, ConfigText
 from vumi.message import TransportEvent
 from vumi import log
 
@@ -12,96 +12,217 @@ from go.vumitools.middleware import OptOutMiddleware
 from go.vumitools.account import GoConnector
 
 
+class RoutingError(Exception):
+    """Raised when an error occurs during routing."""
+
+
+class UnroutableMessageError(RoutingError):
+    """Raised when a message is unroutable."""
+    def __init__(self, reason, msg):
+        super(RoutingError, self).__init__(reason, msg)
+
+
 class AccountRoutingTableDispatcherConfig(RoutingTableDispatcher.CONFIG_CLASS,
                                           GoWorkerConfigMixin):
     application_connector_mapping = ConfigDict(
-        "Mapping from conversation_type to connector name.", static=True)
+        "Mapping from conversation_type to connector name.",
+        static=True, required=True)
+    router_connector_mapping = ConfigDict(
+        "Mapping from routing block type to connector name.",
+        static=True, required=True)
     opt_out_connector = ConfigText(
-        "Connector to publish opt-out messages on.", static=True)
-    message_tag = ConfigList("Tag for the message, if any.")
-    tagpool_metadata = ConfigDict(
-        "Tagpool metadata for the tag attached to the message if any.")
-    conversation_info = ConfigDict(
-        "Conversation info for the tag attached to the message if any.")
-    user_account_key = ConfigText("UserAccount key.")
+        "Connector to publish opt-out messages on.",
+        static=True, required=True)
+    user_account_key = ConfigText(
+        "Key of the user account the message is from.",
+        required=True)
 
 
 class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
+    """
+
+    inbound:
+      * from transport:
+      * from routing block:
+      * to routing block
+      * to conversation
+      * to opt out
+
+    outbound:
+      * from conversation:
+      * from routing block:
+      * from opt out:
+      * to routing block
+      * to transport
+
+    event:
+      * trace back path of outbound message
+      * from transport:
+      * from routing blwock:
+      * to routing block
+      * to conversation
+      * to opt out
+
+    from transport:
+      * tag used to determine account id
+
+    from routing block:
+      * account info in message
+
+    from conversation:
+      * account info in message
+
+    from opt out:
+      * account info in message
+
+    also stores messages in the appropriate batch
+    for conversations and routing blocks
+    (storage middleware does this at the transport
+     for transports)
+
+    TODO: decide what happens at transports to tags
+    without an associated batch / account
+    (I guess we should log an error and put them in
+     a generic batch bucket for later analysis).
+    """
+
     CONFIG_CLASS = AccountRoutingTableDispatcherConfig
     worker_name = 'account_routing_table_dispatcher'
 
-    def setup_dispatcher(self):
-        # This assumes RoutingTableDispatcher.setup_dispatcher() is empty.
-        return self._go_setup_worker()
+    # connector types
+    CONVERSATION = "CONVERSATION"
+    ROUTING_BLOCK = "ROUTING_BLOCK"
+    TRANSPORT = "TRANSPORT"
+    OPT_OUT = "OPT_OUT"
 
+    @inlineCallbacks
+    def setup_dispatcher(self):
+        yield super(AccountRoutingTableDispatcher, self).setup_dispatcher()
+        yield self._go_setup_worker()
+        config = self.get_static_config()
+        self.router_connector_mapping = config.router_connector_mapping
+        self.router_connectors = set(
+            config.router_connector_mapping.itervalues())
+        self.application_connector_mapping = (
+            config.application_connector_mapping)
+        self.application_connectors = set(
+            config.application_connector_mapping.itervalues())
+
+    @inlineCallbacks
     def teardown_dispatcher(self):
-        # This assumes RoutingTableDispatcher.teardown_dispatcher() is empty.
-        return self._go_teardown_worker()
+        yield super(AccountRoutingTableDispatcher, self).teardown_dispatcher()
+        yield self._go_teardown_worker()
 
     @inlineCallbacks
     def get_config(self, msg):
-        if isinstance(msg, TransportEvent):
-            msg = yield self.find_message_for_event(msg)
+        """Determine the config (primarily the routing table) for the given
+        event or transport user message.
 
-        config_dict = self.config.copy()
-        user_account_key = None
+        If the message is an event, we first look up the original message.
+
+        For a given message there are two cases. Either it already has
+        a user account key in the Vumi Go helper metadata, or it is from
+        a transport and has a tag.
+        """
+        if isinstance(msg, TransportEvent):
+            event = msg
+            msg = yield self.find_message_for_event(event)
+            if msg is None:
+                raise UnroutableMessageError(
+                    "Could not find transport user message for event", event)
 
         msg_mdh = self.get_metadata_helper(msg)
 
-        # TODO: Better way to look up account for either tag or conversation.
-        if msg_mdh.tag is not None:
-            tagpool_md = yield self.vumi_api.tpm.get_metadata(msg_mdh.tag[0])
-            config_dict['tagpool_metadata'] = tagpool_md
-            config_dict['message_tag'] = msg_mdh.tag
+        if msg_mdh.has_user_account():
+            user_account_key = msg_mdh.get_account_key()
+        elif msg_mdh.tag is not None:
             tag_info = yield self.vumi_api.mdb.get_tag_info(tuple(msg_mdh.tag))
             user_account_key = tag_info.metadata['user_account']
-
-        if user_account_key is None:
-            user_account_key = msg_mdh.get_account_key()
+        else:
+            raise UnroutableMessageError(
+                "Could not determine user account key", msg)
 
         user_api = self.get_user_api(user_account_key)
         routing_table = yield user_api.get_routing_table()
-        config_dict['routing_table'] = routing_table
 
-        config_dict['conversation_info'] = msg_mdh.get_conversation_info()
-        config_dict['user_account_key'] = user_account_key.decode('utf-8')
+        config_dict = self.config.copy()
+        config_dict['user_account_key'] = user_account_key
+        config_dict['routing_table'] = routing_table
 
         returnValue(self.CONFIG_CLASS(config_dict))
 
-    def get_application_connector(self, conversation_type):
-        mapping = self.get_static_config().application_connector_mapping or {}
-        return mapping.get(conversation_type, conversation_type)
+    def connector_type(self, connector_name):
+        if connector_name in self.application_connectors:
+            return self.CONVERSATION
+        elif connector_name in self.routing_connectors:
+            return self.ROUTING_BLOCK
+        elif connector_name == self.opt_out_connector:
+            return self.OPT_OUT
+        return self.TRANSPORT
 
-    def handle_opt_out(self, msg):
-        return self.publish_inbound(
-            msg, self.get_static_config().opt_out_connector, 'default')
+    def get_application_connector(self, conversation_type):
+        return self.application_connector_mapping.get(conversation_type)
+
+    def get_router_connector(self, router_type):
+        return self.router_connector_mapping.get(router_type)
 
     def process_inbound(self, config, msg, connector_name):
-        log.debug("Processing inbound: %s" % (msg,))
-        if not config.message_tag:
-            log.warning("No tag found for inbound message: %s" % (msg,))
-            return
+        """Process an inbound message.
 
+        Inbound messages can be from:
+
+        * transports (these might be opt-out messages)
+        * routing blocks
+
+        And may go to:
+
+        * routing blocks
+        * conversations
+        * the opt-out worker
+        """
+        log.debug("Processing inbound: %r" % (msg,))
         msg_mdh = self.get_metadata_helper(msg)
         msg_mdh.set_user_account(config.user_account_key)
 
-        if OptOutMiddleware.is_optout_message(msg):
-            return self.handle_opt_out(msg)
+        connector_type = self.connector_type(connector_name)
 
-        src_conn = str(GoConnector.for_transport_tag(config.message_tag[0],
-                                                     config.message_tag[1]))
+        if connector_type == self.TRANSPORT and msg_mdh.is_optout_message():
+            return self.publish_inbound(
+                msg, config.opt_out_connector, 'default')
+
+        if connector_type == self.TRANSPORT:
+            src_conn = str(GoConnector.for_transport_tag(*msg_mdh.tag))
+        elif connector_type == self.ROUTER:
+            src_conn = str(GoConnector.for_routing_block())
+        else:
+            raise UnroutableMessageError(
+                "Inbound message from a source other than a transport"
+                "or routing block. Source was: %r" % connector_name, msg)
+
         target = self.find_target(config, msg, src_conn)
         if target is None:
             log.debug("No target found for message from '%s': %s" % (
                 connector_name, msg))
             return
 
-        conn = GoConnector.parse(target[0])
-        assert conn.ctype == conn.CONVERSATION
-        msg_mdh.set_conversation_info(conn.conv_type, conn.conv_key)
+        dst_conn = GoConnector.parse(target[0])
+        if dst_conn.ctype == dst_conn.CONVERSATION:
+            msg_mdh.set_conversation_info(
+                dst_conn.conv_type, dst_conn.conv_key)
+            dst_connector_name = self.get_application_connector(
+                dst_conn.conv_type)
+        elif dst_conn.ctype == dst_conn.ROUTING_BLOCK:
+            msg_mdh.set_router_info(
+                dst_conn.rblock_type, dst_conn.rblock_key)
+            dst_connector_name = self.get_router_connector(
+                dst_conn.rblock_type)
+        else:
+                raise UnroutableMessageError(
+                "Inbound message being routed towards invalid target."
+                " Source was: %r. Target was: %r."
+                % (connector_name, target[0]), msg)
 
-        conv_connector = self.get_application_connector(conn.conv_type)
-        return self.publish_inbound(msg, conv_connector, target[1])
+        return self.publish_inbound(msg, dst_connector_name, target[1])
 
     def process_outbound(self, config, msg, connector_name):
         log.debug("Processing outbound: %s" % (msg,))
@@ -109,6 +230,9 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
             log.warning(
                 "No conversation info found for outbound message: %s" % (msg,))
             return
+
+        if OptOutMiddleware.is_optout_message(msg):
+            return self.handle_outbound_opt_out(msg)
 
         conv_conn = str(GoConnector.for_conversation(
             config.conversation_info['conversation_type'],

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -89,13 +89,13 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
     CONFIG_CLASS = AccountRoutingTableDispatcherConfig
     worker_name = 'account_routing_table_dispatcher'
 
-    # connector types
+    # connector types (references to GoConnector constants for convenience)
     CONVERSATION = GoConnector.CONVERSATION
     ROUTING_BLOCK = GoConnector.ROUTING_BLOCK
     TRANSPORT_TAG = GoConnector.TRANSPORT_TAG
     OPT_OUT = GoConnector.OPT_OUT
 
-    # directions
+    # directions (references to GoConnector constants for convenience)
     INBOUND = GoConnector.INBOUND
     OUTBOUND = GoConnector.OUTBOUND
 

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -109,8 +109,8 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
     @inlineCallbacks
     def teardown_dispatcher(self):
-        yield super(AccountRoutingTableDispatcher, self).teardown_dispatcher()
         yield self._go_teardown_worker()
+        yield super(AccountRoutingTableDispatcher, self).teardown_dispatcher()
 
     @inlineCallbacks
     def get_config(self, msg):

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -84,6 +84,17 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
     * for routing blocks, conversations and the opt-out worker:
       * the user account id is read from the Vumi Go helper_metadata.
+
+    When messages are published the following helper_metadata
+    is included:
+
+    * for transports: tag pool and tag name
+    * for routing blocks: user_account, router_type, router_key
+    * for conversations: user_account, conversation_type, conversation_key
+    * for the opt-out worker: user_account
+
+    Messages received from these sources are expected to include the same
+    metadata.
     """
 
     CONFIG_CLASS = AccountRoutingTableDispatcherConfig

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -8,7 +8,6 @@ from vumi.message import TransportEvent
 from vumi import log
 
 from go.vumitools.app_worker import GoWorkerMixin, GoWorkerConfigMixin
-from go.vumitools.middleware import OptOutMiddleware
 from go.vumitools.account import GoConnector
 
 

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -128,7 +128,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_inbound(msg, 'sphex')
         self.assert_rkeys_used('sphex.inbound', 'app1.inbound')
         self.with_md(msg, conv=('app1', 'conv1'),
-                     hops=[['app1', 'default']])
+                     hops=[['CONVERSATION:app1:conv1', 'default']])
         self.assertEqual([msg], self.get_dispatched_inbound('app1'))
 
         self.clear_all_dispatched()
@@ -136,7 +136,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_inbound(msg, 'sphex')
         self.assert_rkeys_used('sphex.inbound', 'app1.inbound')
         self.with_md(msg, conv=('app1', 'conv1'), endpoint='other',
-                     hops=[['app1', 'other']])
+                     hops=[['CONVERSATION:app1:conv1', 'other']])
         self.assertEqual([msg], self.get_dispatched_inbound('app1'))
 
         self.clear_all_dispatched()
@@ -144,7 +144,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_inbound(msg, 'sphex')
         self.assert_rkeys_used('sphex.inbound', 'app2.inbound')
         self.with_md(msg, conv=('app2', 'conv2'),
-                     hops=[['app2', 'default']])
+                     hops=[['CONVERSATION:app2:conv2', 'default']])
         self.assertEqual([msg], self.get_dispatched_inbound('app2'))
 
     @inlineCallbacks
@@ -166,7 +166,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_inbound(msg, 'router_ro')
         self.assert_rkeys_used('router_ro.inbound', 'app1.inbound')
         self.with_md(msg, conv=("app1", "conv1"),
-                     hops=[['app1', 'default']])
+                     hops=[['CONVERSATION:app1:conv1', 'default']])
         self.assertEqual([msg], self.get_dispatched_inbound('app1'))
 
         self.clear_all_dispatched()
@@ -175,7 +175,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_inbound(msg, 'router_ro')
         self.assert_rkeys_used('router_ro.inbound', 'app2.inbound')
         self.with_md(msg, conv=("app2", "conv2"), endpoint='yet-another',
-                     hops=[['app2', 'yet-another']])
+                     hops=[['CONVERSATION:app2:conv2', 'yet-another']])
         self.assertEqual([msg], self.get_dispatched_inbound('app2'))
 
     @inlineCallbacks
@@ -186,7 +186,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_outbound(reply, 'optout')
         self.assert_rkeys_used('optout.outbound', 'sphex.outbound')
         self.with_md(reply, tag=tag, user_account=self.user_account_key,
-                     hops=[['sphex', 'default']])
+                     hops=[['TRANSPORT_TAG:pool1:1234', 'default']])
         self.assertEqual([reply], self.get_dispatched_outbound('sphex'))
 
     @inlineCallbacks
@@ -196,7 +196,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_outbound(msg, 'app1')
         self.assert_rkeys_used('app1.outbound', 'sphex.outbound')
         self.with_md(msg, tag=("pool1", "1234"),
-                     hops=[['sphex', 'default']])
+                     hops=[['TRANSPORT_TAG:pool1:1234', 'default']])
         self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
 
         self.clear_all_dispatched()
@@ -204,7 +204,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_outbound(msg, 'app2')
         self.assert_rkeys_used('app2.outbound', 'sphex.outbound')
         self.with_md(msg, tag=("pool1", "9012"),
-                     hops=[['sphex', 'default']])
+                     hops=[['TRANSPORT_TAG:pool1:9012', 'default']])
         self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
 
         self.clear_all_dispatched()
@@ -213,7 +213,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_outbound(msg, 'app1')
         self.assert_rkeys_used('app1.outbound', 'sphex.outbound')
         self.with_md(msg, tag=("pool1", "5678"), endpoint='default',
-                     hops=[['sphex', 'default']])
+                     hops=[['TRANSPORT_TAG:pool1:5678', 'default']])
         self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
 
     @inlineCallbacks
@@ -223,7 +223,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_outbound(msg, 'router_ri')
         self.assert_rkeys_used('router_ri.outbound', 'sphex.outbound')
         self.with_md(msg, tag=("pool1", "1234"),
-                     hops=[['sphex', 'default']])
+                     hops=[['TRANSPORT_TAG:pool1:1234', 'default']])
         self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
 
         self.clear_all_dispatched()
@@ -232,7 +232,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_outbound(msg, 'router_ri')
         self.assert_rkeys_used('router_ri.outbound', 'sphex.outbound')
         self.with_md(msg, tag=("pool1", "5678"), endpoint='default',
-                     hops=[['sphex', 'default']])
+                     hops=[['TRANSPORT_TAG:pool1:5678', 'default']])
         self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
 
     @inlineCallbacks
@@ -241,28 +241,28 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         self.vumi_api = dispatcher.vumi_api
 
         msg, ack = yield self.mk_msg_ack(hops=[
-            ['app1', 'default'],
+            ['CONVERSATION:app1:conv1', 'default'],
         ])
         yield self.dispatch_event(ack, 'sphex')
         self.assert_rkeys_used('sphex.event', 'app1.event')
-        self.with_md(ack, hops=[['app1', 'default']])
+        self.with_md(ack, hops=[['CONVERSATION:app1:conv1', 'default']])
         self.assertEqual([ack], self.get_dispatched_events('app1'))
 
         self.clear_all_dispatched()
         msg, ack = yield self.mk_msg_ack(endpoint='other', hops=[
-            ['app1', 'other'],
+            ['CONVERSATION:app1:conv1', 'other'],
         ])
         yield self.dispatch_event(ack, 'sphex')
         self.assert_rkeys_used('sphex.event', 'app1.event')
         self.with_md(ack, endpoint='other',
-                     hops=[['app1', 'other']])
+                     hops=[['CONVERSATION:app1:conv1', 'other']])
         self.assertEqual([ack], self.get_dispatched_events('app1'))
 
         self.clear_all_dispatched()
         msg, ack = yield self.mk_msg_ack(hops=[
-            ['app2', 'default'],
+            ['CONVERSATION:app2:conv2', 'default'],
         ])
         yield self.dispatch_event(ack, 'sphex')
         self.assert_rkeys_used('sphex.event', 'app2.event')
-        self.with_md(ack, hops=[['app2', 'default']])
+        self.with_md(ack, hops=[['CONVERSATION:app2:conv2', 'default']])
         self.assertEqual([ack], self.get_dispatched_events('app2'))

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -1,6 +1,7 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from go.vumitools.routing import AccountRoutingTableDispatcher
+from go.vumitools.routing import (
+    AccountRoutingTableDispatcher, RoutingMetadata)
 from go.vumitools.tests.utils import AppWorkerTestCase
 from go.vumitools.utils import MessageMetadataHelper
 
@@ -99,8 +100,9 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         if tag is not None:
             md.set_tag(tag)
         if hops is not None:
-            routes = msg['routing_metadata'].setdefault('hops', [])
-            routes[:] = hops
+            rmeta = RoutingMetadata(msg)
+            for src, dst in zip(hops[:-1], hops[1:]):
+                rmeta.push_hop(src, dst)
         return msg
 
     def assert_rkeys_used(self, *rkeys):

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -156,7 +156,7 @@ class TestRoutingTableDispatcher(AppWorkerTestCase):
         yield self.dispatch_inbound(msg, 'sphex')
         self.assert_rkeys_used('sphex.inbound', 'optout.inbound')
         self.with_md(msg, user_account=self.user_account_key,
-                     hops=[['optout', 'default']])
+                     hops=[['OPT_OUT', 'default']])
         self.assertEqual([msg], self.get_dispatched_inbound('optout'))
 
     @inlineCallbacks

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -1,6 +1,7 @@
 # -*- test-case-name: go.vumitools.tests.test_utils -*-
 
 from vumi.middleware.tagger import TaggingMiddleware
+from go.vumitools.middleware import OptOutMiddleware
 
 
 class MessageMetadataHelper(object):
@@ -88,3 +89,35 @@ class MessageMetadataHelper(object):
         self._go_metadata.update({
             'user_account': user_account,
         })
+
+    def is_optout_message(self):
+        return OptOutMiddleware.is_optout_message(self.message)
+
+    def get_router_key(self):
+        # TODO: Better exception.
+        return self._go_metadata['router_key']
+
+    def get_router(self):
+        return self.get_user_api().get_router(
+            self.get_router_key())
+
+    def get_router_info(self):
+        router_info = {}
+
+        for field in ['user_account', 'router_type', 'router_key']:
+            if field in self._go_metadata:
+                router_info[field] = self._go_metadata[field]
+
+        if len(router_info) != 3:
+            return None
+        return router_info
+
+    def set_router_info(self, router_type, router_key):
+        self._go_metadata.update({
+            'router_type': router_type,
+            'router_key': router_key,
+        })
+
+    def set_tag(self, tag):
+        TaggingMiddleware.add_tag_to_msg(self.message)
+        self.tag = TaggingMiddleware.map_msg_to_tag(self.message)

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -119,5 +119,5 @@ class MessageMetadataHelper(object):
         })
 
     def set_tag(self, tag):
-        TaggingMiddleware.add_tag_to_msg(self.message)
+        TaggingMiddleware.add_tag_to_msg(self.message, tag)
         self.tag = TaggingMiddleware.map_msg_to_tag(self.message)


### PR DESCRIPTION
Typical error message:

```
No conversation info found for outbound message: <Message payload="{
    'transport_name': u'safaricom_sna_smpp_transport',
    'in_reply_to': u'f722a7d8-51b6-422a-ad74-45805105abd5',
    'group': None,
    'from_addr': u'XXXXX',
    'timestamp': datetime.datetime(2013, 6, 1, 6, 16, 19, 746126),
    'to_addr': u'+XXXXXXXXXXXX',
    'content': u'You have opted out',
    'routing_metadata': {u'endpoint_name': u'default'},
    ...
```
