### PR TITLE
Sequential Send UI only allows you to select the first conversation.

### DIFF
--- a/go/apps/sequential_send/views.py
+++ b/go/apps/sequential_send/views.py
@@ -99,7 +99,7 @@ class UsedTagConversationForm(VumiModelForm):
             display_name = conv.name
             delivery_classes.append((conv.key, [
                         (display_name, self.tag_options[conv.key])]))
-            return delivery_classes
+        return delivery_classes
 
     def delivery_class_widgets(self):
         # Backported hack from Django 1.4 to allow me to iterate


### PR DESCRIPTION
The `tagpools_by_delivery_class()` always returns the first result, not the aggregated result.
The bug is in the indentation at https://github.com/praekelt/vumi-go/blob/develop/go/apps/sequential_send/views.py#L102.

Cookies for @imsickofmaps for both hitting the bug and spotting the problem in the code.
