### PR TITLE
Change LookupGroup to use listenTo() instead of on() for watching its member's adds()

### DIFF
--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -103,13 +103,6 @@
       // Lookup of item owners by item keys
       this._owners = {};
 
-      // Lookup of the add callbacks bound to member add events. We only need
-      // to bind callbacks for adds and not removes, since we need to know the
-      // owner of an item to be added, while with removes, we know already. We
-      // keep a lookup so we can unbind the add callbacks when the member is
-      // unsubscribed.
-      this._memberAdds = {};
-
       lookups = lookups || {};
       for (var k in lookups) { this.subscribe(k, lookups[k]); }
     },
@@ -139,22 +132,18 @@
 
     subscribe: function(key, lookup) {
       var add = _(this.onMemberAdd).bind(this, lookup);
-      this._memberAdds[key] = add;
-      this.members.add(key, lookup);
-
       lookup.eachItem(add);
-      lookup.on('add', add);
-      lookup.on('remove', this.onMemberRemove, this);
+
+      this.listenTo(lookup, 'add', add);
+      this.listenTo(lookup, 'remove', this.onMemberRemove, this);
+
+      this.members.add(key, lookup);
       return this;
     },
 
     unsubscribe: function(key) {
-      var lookup = this.members.get(key),
-          add = this._memberAdds[key];
-
-      delete this._memberAdds[key];
-      lookup.off('add', add);
-      lookup.off('remove', this.onMemberRemove, this);
+      var lookup = this.members.get(key);
+      this.stopListening(lookup);
 
       lookup.keys().forEach(this.onMemberRemove, this);
       this.members.remove(key);


### PR DESCRIPTION
This makes things easier, since we no longer need to keep track of each member's `add()` callbacks.
