### PR TITLE
Fix starting of web service inside Vumi Go API

### DIFF
--- a/go/api/go_api/tests/test_go_api.py
+++ b/go/api/go_api/tests/test_go_api.py
@@ -326,7 +326,7 @@ class GoApiWorkerTestCase(VumiWorkerTestCase, GoAppWorkerTestMixin):
             returnValue(worker)
         yield worker.startService()
 
-        port = worker.services[0]._waitingForPort.result
+        port = worker._web_service._waitingForPort.result
         addr = port.getHost()
 
         proxy = Proxy("http://%s:%d/api/" % (addr.host, addr.port),


### PR DESCRIPTION
Currently:
- The Vumi Go API naively adds a child service inside `setup_worker`. The worker service is already started at this point so that does nothing useful. :/
