### PR TITLE
Client tests should unregister models from the Backbone.Relational store instead of resetting the store

### DIFF
--- a/go/base/static/js/test/tests/campaign/dialogue/models.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/models.test.js
@@ -2,7 +2,7 @@ describe("go.campaign.dialogue.models", function() {
   var models = go.campaign.dialogue.models;
 
   afterEach(function() {
-    Backbone.Relational.store.reset();
+    go.testHelpers.unregisterModels();
   });
 
   describe(".DialogueStateModel", function() {

--- a/go/base/static/js/test/tests/campaign/dialogue/testHelpers.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/testHelpers.js
@@ -100,7 +100,7 @@
   };
 
   var tearDown = function() {
-    Backbone.Relational.store.reset();
+    go.testHelpers.unregisterModels();
     jsPlumb.unbind();
     jsPlumb.detachEveryConnection();
     jsPlumb.deleteEveryEndpoint();

--- a/go/base/static/js/test/tests/campaign/routing/models.test.js
+++ b/go/base/static/js/test/tests/campaign/routing/models.test.js
@@ -6,7 +6,7 @@ describe("go.campaign.routing (models)", function() {
       fakeServer = testHelpers.rpc.fakeServer;
 
   afterEach(function() {
-    Backbone.Relational.store.reset();
+    go.testHelpers.unregisterModels();
   });
 
   describe(".CampaignRoutingModel", function() {

--- a/go/base/static/js/test/tests/campaign/routing/testHelpers.js
+++ b/go/base/static/js/test/tests/campaign/routing/testHelpers.js
@@ -90,7 +90,7 @@
   };
 
   var tearDown = function() {
-    Backbone.Relational.store.reset();
+    go.testHelpers.unregisterModels();
     jsPlumb.unbind();
     jsPlumb.detachEveryConnection();
     jsPlumb.deleteEveryEndpoint();

--- a/go/base/static/js/test/tests/components/plumbing/testHelpers.js
+++ b/go/base/static/js/test/tests/components/plumbing/testHelpers.js
@@ -219,7 +219,7 @@
   };
 
   var tearDown = function() {
-    Backbone.Relational.store.reset();
+    go.testHelpers.unregisterModels();
     jsPlumb.unbind();
     jsPlumb.detachEveryConnection();
     jsPlumb.deleteEveryEndpoint();

--- a/go/base/static/js/test/tests/components/stateMachine.test.js
+++ b/go/base/static/js/test/tests/components/stateMachine.test.js
@@ -2,7 +2,7 @@ describe("go.components.stateMachine", function() {
   var stateMachine = go.components.stateMachine;
 
   afterEach(function() {
-    Backbone.Relational.store.reset();
+    go.testHelpers.unregisterModels();
   });
 
   describe(".ConnectionModel", function() {

--- a/go/base/static/js/test/tests/testHelpers/testHelpers.js
+++ b/go/base/static/js/test/tests/testHelpers/testHelpers.js
@@ -20,10 +20,20 @@
       attrs);
   };
 
+  var unregisterModels = function() {
+    // Accessing an internal variable is not ideal, but Backbone.Relational
+    // doesn't offer a way to unregister all its store's models or access all
+    // its store's collections
+    var collections = Backbone.Relational.store._collections;
+    collections.forEach(function(c) { c.reset([], {remove: true}); });
+    Backbone.Relational.store._collections = [];
+  };
+
   _.extend(exports, {
     assertFails: assertFails,
     oneElExists: oneElExists,
     noElExists: noElExists,
-    assertModelAttrs: assertModelAttrs
+    assertModelAttrs: assertModelAttrs,
+    unregisterModels: unregisterModels
   });
 })(go.testHelpers = {});

--- a/go/base/static/js/test/tests/testHelpers/testHelpers.test.js
+++ b/go/base/static/js/test/tests/testHelpers/testHelpers.test.js
@@ -1,5 +1,6 @@
 describe("go.testHelpers", function() {
   var testHelpers = go.testHelpers,
+      unregisterModels = testHelpers.unregisterModels,
       assertFails = testHelpers.assertFails;
 
   beforeEach(function() {
@@ -11,7 +12,7 @@ describe("go.testHelpers", function() {
       "</div>"
     ].join(''));
 
-    Backbone.Relational.store.reset();
+    unregisterModels();
   });
 
   afterEach(function() {


### PR DESCRIPTION
We use `Backbone.Relational.store.reset()` to reset the store Backbone.Relational uses to keep track of models. We need to do this since tests will try create models with the same ids and attributes, and Backbone.Relational will complain.

The problem with doing this is that `Backbone.Relational.store.reset()` also resets the submodel types it keeps track of. This means that models with subtypes instantiated after a `Backbone.Relational.store.reset()` won't be instances of their subtype.

To solve this, we should be unregistering the models from the store after each test.
