### PR TITLE
GridView.p.render() should detach its rows instead of emptying itself

### DIFF
--- a/go/base/static/js/src/components/grid.js
+++ b/go/base/static/js/src/components/grid.js
@@ -183,10 +183,9 @@
     },
 
     render: function() {
-      this.rows.each(function(r) { r.$el.detach; });
+      this.rows.each(function(r) { r.$el.detach(); });
       this.resetRows();
 
-      this.$el.empty();
       this.rows.each(function(r) { this.$el.append(r.$el); }, this);
       this.rows.render();
 

--- a/go/base/static/js/src/components/grid.js
+++ b/go/base/static/js/src/components/grid.js
@@ -122,6 +122,7 @@
     initialize: function(options) {
       this.items = this._ensureViewCollection(options.items);
       this.sortableOptions = options.sortableOptions || this.sortableOptions;
+
       this.rowType = options.rowType || this.rowType;
       this.rowItemType = options.rowItemType || this.rowItemType;
       this.rowCollectionType = options.rowCollectionType
@@ -129,6 +130,8 @@
 
       this.items.on('add', this.render, this);
       this.items.on('remove', this.render, this);
+
+      this.resetRows();
     },
 
     _ensureViewCollection: function(obj) {
@@ -180,6 +183,7 @@
     },
 
     render: function() {
+      this.rows.each(function(r) { r.$el.detach; });
       this.resetRows();
 
       this.$el.empty();


### PR DESCRIPTION
When `GridView.prototype.render()` does a `this.$el.empty()`, all its' contained elements with jquery objects lose their data. This confuses jsPlumb.

We should instead be detaching each row, before re-appending the new rows later.
