### PR TITLE
Move toy dialogue state view and model out of tests

### DIFF
--- a/go/base/static/js/src/campaign/dialogue/models.js
+++ b/go/base/static/js/src/campaign/dialogue/models.js
@@ -18,6 +18,7 @@
     collectionType: 'go.campaign.dialogue.models.DialogueStateModelCollection',
 
     subModelTypes: {
+      dummy: 'go.campaign.dialogue.models.DummyStateModel',
       choice: 'go.campaign.dialogue.models.ChoiceStateModel',
       freetext: 'go.campaign.dialogue.models.FreeTextStateModel',
       end: 'go.campaign.dialogue.models.EndStateModel'
@@ -32,6 +33,18 @@
   var DialogueStateModelCollection = Backbone.Collection.extend({
     model: DialogueStateModel,
     comparator: function(state) { return state.get('ordinal'); }
+  });
+
+  var DummyStateModel = DialogueStateModel.extend({
+    relations: [{
+      type: Backbone.HasOne,
+      key: 'entry_endpoint',
+      relatedModel: DialogueEndpointModel
+    }, {
+      type: Backbone.HasOne,
+      key: 'exit_endpoint',
+      relatedModel: DialogueEndpointModel
+    }]
   });
 
   var ChoiceStateModel = DialogueStateModel.extend({
@@ -107,6 +120,7 @@
     ChoiceEndpointModel: ChoiceEndpointModel,
 
     DialogueStateModel: DialogueStateModel,
+    DummyStateModel: DummyStateModel,
     ChoiceStateModel: ChoiceStateModel,
     FreeTextStateModel: FreeTextStateModel,
     EndStateModel: EndStateModel

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -64,6 +64,7 @@
     endpointCollectionType: AligningEndpointCollection,
 
     subtypes: {
+      dummy: 'go.campaign.dialogue.states.dummy.DummyStateView',
       choice: 'go.campaign.dialogue.states.choice.ChoiceStateView',
       freetext: 'go.campaign.dialogue.states.freetext.FreeTextStateView',
       end: 'go.campaign.dialogue.states.end.EndStateView'

--- a/go/base/static/js/test/runner.html
+++ b/go/base/static/js/test/runner.html
@@ -77,6 +77,7 @@
     <script src="../src/campaign/dialogue/models.js"></script>
     <script src="../src/campaign/dialogue/connections.js"></script>
     <script src="../src/campaign/dialogue/states/states.js"></script>
+    <script src="../src/campaign/dialogue/states/dummy.js"></script>
     <script src="../src/campaign/dialogue/states/choice.js"></script>
     <script src="../src/campaign/dialogue/states/freetext.js"></script>
     <script src="../src/campaign/dialogue/states/end.js"></script>

--- a/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
@@ -54,15 +54,15 @@ describe("go.campaign.dialogue.states", function() {
   });
 
   describe(".DialogueStateView", function() {
-    var ToyStateModel = dialogue.testHelpers.ToyStateModel;
+    var DummyStateModel = dialogue.models.DummyStateModel;
 
     var state;
 
     beforeEach(function() {
-      var model = new ToyStateModel({
+      var model = new DummyStateModel({
         uuid: 'luke-the-state',
-        name: 'Toy Message 1',
-        type: 'toy',
+        name: 'Dummy Message 1',
+        type: 'dummy',
         entry_endpoint: {uuid: 'lukes-entry-endpoint'},
         exit_endpoint: {uuid: 'lukes-exit-endpoint'}
       });
@@ -143,7 +143,7 @@ describe("go.campaign.dialogue.states", function() {
   });
 
   describe(".DialogueStateCollection", function() {
-    var ToyStateView = dialogue.testHelpers.ToyStateView,
+    var DummyStateView = dialogue.states.dummy.DummyStateView,
         DialogueStateCollection = states.DialogueStateCollection;
 
     var collection;
@@ -158,7 +158,7 @@ describe("go.campaign.dialogue.states", function() {
     describe(".reset", function() {
       it("should remove the old state", function(){
         assert(collection.has('state3'));
-        collection.reset(collection.get('state3'), 'toy');
+        collection.reset(collection.get('state3'), 'dummy');
         assert(!collection.has('state3'));
       });
 
@@ -167,13 +167,13 @@ describe("go.campaign.dialogue.states", function() {
         var old = collection.get('state3');
 
         collection.on('add', function(id, state) {
-          assert(state instanceof ToyStateView);
+          assert(state instanceof DummyStateView);
           assert.equal(state.model.get('ordinal'), 3);
           done();
         });
 
         old.model.set('ordinal', 3);
-        collection.reset(old, 'toy');
+        collection.reset(old, 'dummy');
       });
     });
   });

--- a/go/base/static/js/test/tests/campaign/dialogue/testHelpers.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/testHelpers.js
@@ -4,50 +4,7 @@
 (function(exports) {
   var dialogue = go.campaign.dialogue,
       DialogueModel = dialogue.models.DialogueModel,
-      DialogueStateModel = dialogue.models.DialogueStateModel,
-      DialogueEndpointModel = dialogue.models.DialogueEndpointModel,
       DialogueDiagramView = dialogue.diagram.DialogueDiagramView;
-
-  var states = dialogue.states,
-      DialogueStateView = states.DialogueStateView,
-      DialogueStateEditView = states.DialogueStateEditView,
-      DialogueStatePreviewView = states.DialogueStatePreviewView;
-
-  var ToyStateModel = DialogueStateModel.extend({
-    relations: [{
-      type: Backbone.HasOne,
-      key: 'entry_endpoint',
-      relatedModel: DialogueEndpointModel
-    }, {
-      type: Backbone.HasOne,
-      key: 'exit_endpoint',
-      relatedModel: DialogueEndpointModel
-    }]
-  });
-
-  var ToyStateEditView = DialogueStateEditView.extend({
-    template: _.template("toy edit mode: <%= model.name %>")
-  });
-
-  var ToyStatePreviewView = DialogueStatePreviewView.extend({
-    template: _.template("toy preview mode: <%= model.name %>")
-  });
-
-  // A state view type that does nothing. Useful for testing.
-  var ToyStateView = DialogueStateView.extend({
-    editModeType: ToyStateEditView,
-    previewModeType: ToyStatePreviewView,
-
-    endpointSchema: [
-      {attr: 'entry_endpoint', side: 'left'},
-      {attr: 'exit_endpoint', side: 'right'}]
-  });
-
-  // Make a toy state subtype to use for testing
-  DialogueStateModel.prototype.subModelTypes.toy
-    = 'go.campaign.dialogue.testHelpers.ToyStateModel';
-
-  DialogueStateView.prototype.subtypes.toy = ToyStateView;
 
   var modelData = {
     conversation: 'conversation-key',
@@ -76,8 +33,8 @@
       text: 'Thank you for taking our survey'
     }, {
       uuid: 'state4',
-      name: 'Toy Message 1',
-      type: 'toy',
+      name: 'Dummy Message 1',
+      type: 'dummy',
       entry_endpoint: {uuid: 'endpoint6'},
       exit_endpoint: {uuid: 'endpoint7'}
     }],
@@ -110,11 +67,6 @@
   };
 
   _.extend(exports, {
-    ToyStateModel: ToyStateModel,
-    ToyStateEditView: ToyStateEditView,
-    ToyStatePreviewView: ToyStatePreviewView,
-    ToyStateView: ToyStateView,
-
     setUp: setUp,
     tearDown: tearDown,
     modelData: modelData,


### PR DESCRIPTION
We add a toy state model and view subtype to dialogue states for tests. This happens after `DialogueStateModel`'s submodel's are added to `Backbone.Relational.store`, so the store ends up not knowing about the toy dialogue state subtype.

This means we need to move the toy submodel and view out of the test code. Since the toy model and view are used when testing out basic dialogue state functionality, it wouldn't hurt to keep these in the actual code outside of the tests.
