### PR TITLE
Allow HTTP API concurrent connections setting to be configurable and clean-up HTTP authorization hook-up.

### DIFF
--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -306,7 +306,8 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_concurrency_limits(self):
-        concurrency = ConversationResource.CONCURRENCY_LIMIT
+        config = yield self.app.get_config(None)
+        concurrency = config.concurrency_limit
         queue = DeferredQueue()
         url = '%s/%s/messages.json' % (self.url, self.conversation.key)
         max_receivers = [self.client.stream(


### PR DESCRIPTION
Currently the number of concurrent connections per-account is a constant on the class. It would be useful if it was configurable via the `.yaml` config file.
