### PR TITLE
Reduce reliance on delivery_class

### DIFF
--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -60,7 +60,8 @@ class TestBulkMessageApplication(AppWorkerTestCase):
     @inlineCallbacks
     def get_opted_in_contacts(self, conversation):
         contacts = []
-        for bunch in (yield conversation.get_opted_in_contact_bunches()):
+        for bunch in (yield conversation.get_opted_in_contact_bunches(
+                conversation.delivery_class)):
             contacts.extend((yield bunch))
         returnValue(sorted(contacts, key=lambda c: c.msisdn))
 

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -78,7 +78,8 @@ class BulkMessageApplication(GoApplicationWorker):
             return
 
         to_addresses = []
-        for contacts_batch in (yield conv.get_opted_in_contact_bunches()):
+        for contacts_batch in (
+                yield conv.get_opted_in_contact_bunches(conv.delivery_class)):
             for contact in (yield contacts_batch):
                 to_addresses.append(contact.addr_for(conv.delivery_class))
         if dedupe:

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -235,7 +235,7 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
         self.assertNotEqual(sent_msg['message_id'], msg['message_id'])
         self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
         self.assertEqual(sent_msg['to_addr'], msg['to_addr'])
-        self.assertEqual(sent_msg['from_addr'], 'tag1')
+        self.assertEqual(sent_msg['from_addr'], None)
 
     @inlineCallbacks
     def test_invalid_in_reply_to(self):

--- a/go/apps/multi_surveys/tests/test_vumi_app.py
+++ b/go/apps/multi_surveys/tests/test_vumi_app.py
@@ -140,7 +140,7 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
             surname=u'Contact', msisdn=u'27831234568', groups=[self.group])
         yield self.create_survey(self.conversation)
         with LogCatcher() as log:
-            yield self.start_conversation(self.conversation)
+            yield self.start_conversation_old_style(self.conversation)
             self.assertEqual(log.errors, [])
 
         [msg1, msg2] = yield self.wait_for_dispatched_messages(2)
@@ -191,7 +191,7 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
         yield self.create_contact(u'First', u'Contact',
             msisdn=u'27831234567', groups=[self.group])
         yield self.create_survey(self.conversation)
-        yield self.start_conversation(self.conversation)
+        yield self.start_conversation_old_style(self.conversation)
         yield self.complete_survey(self.default_polls)
 
     @inlineCallbacks
@@ -199,7 +199,7 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
         yield self.create_contact(u'First', u'Contact',
             msisdn=u'27831234567', groups=[self.group])
         yield self.create_survey(self.conversation)
-        yield self.start_conversation(self.conversation)
+        yield self.start_conversation_old_style(self.conversation)
         start_at = 0
         for i in range(1):
             msgs = yield self.complete_survey(self.default_polls,
@@ -229,7 +229,7 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
         yield self.create_contact(u'First', u'Contact',
             msisdn=u'27831234567', groups=[self.group])
         yield self.create_survey(self.conversation)
-        yield self.start_conversation(self.conversation)
+        yield self.start_conversation_old_style(self.conversation)
         start_at = 0
         for i in range(3):
             msgs = yield self.complete_survey(self.default_polls,
@@ -245,7 +245,7 @@ class TestMultiSurveyApplication(AppWorkerTestCase):
             surname=u'Contact', msisdn=u'27831234561', groups=[self.group])
         yield self.create_survey(self.conversation)
         with LogCatcher() as log:
-            yield self.start_conversation(self.conversation)
+            yield self.start_conversation_old_style(self.conversation)
             self.assertEqual(log.errors, [])
 
         # First run through to the second poll

--- a/go/apps/multi_surveys/views.py
+++ b/go/apps/multi_surveys/views.py
@@ -228,7 +228,7 @@ def people(request, conversation_key):
     if request.method == 'POST':
         if conversation.is_client_initiated():
             try:
-                conversation.start()
+                conversation.old_start()
             except ConversationSendError as error:
                 if str(error) == 'No spare messaging tags.':
                     error = 'You have maxed out your available ' \
@@ -280,7 +280,7 @@ def start(request, conversation_key):
     conversation = conversation_or_404(request.user_api, conversation_key)
     if request.method == 'POST':
         try:
-            conversation.start()
+            conversation.old_start()
         except ConversationSendError as error:
             messages.add_message(request, messages.ERROR, str(error))
             return redirect(reverse('multi_survey:start', kwargs={

--- a/go/apps/multi_surveys/vumi_app.py
+++ b/go/apps/multi_surveys/vumi_app.py
@@ -144,7 +144,8 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
 
         conv = yield self.get_conversation(user_account_key, conversation_key)
 
-        for contacts in (yield conv.get_opted_in_contact_bunches()):
+        for contacts in (yield conv.get_opted_in_contact_bunches(
+                conv.delivery_class)):
             for contact in (yield contacts):
                 to_addr = contact.addr_for(conv.delivery_class)
                 yield self.start_survey(to_addr, conv, **msg_options)

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -305,7 +305,7 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         rt = yield self.user_api.get_routing_table()
         self.assertEqual(len(rt), 0)
         yield self.user_api.acquire_specific_tag((u'pool', u'tag1'))
-        yield self.start_conversation(
+        yield self.start_conversation_old_style(
             conv, no_batch_tag=True, acquire_tag=False)
         rt = yield self.user_api.get_routing_table()
         self.assertEqual(len(rt), 1)

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -143,7 +143,8 @@ class SequentialSendApplication(GoApplicationWorker):
         conv.set_go_helper_metadata(
             message_options.setdefault('helper_metadata', {}))
 
-        for contacts in (yield conv.get_opted_in_contact_bunches()):
+        for contacts in (yield conv.get_opted_in_contact_bunches(
+                conv.delivery_class)):
             for contact in (yield contacts):
                 index_key = 'scheduled_message_index_%s' % (conv.key,)
                 message_index = int(contact.extra[index_key] or '0')

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -114,7 +114,7 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
         yield self.contact_store.groups.enable_search()
         self.contact = yield self.contact_store.new_contact(
                                                         msisdn=u'+27761234567')
-        yield self.conversation.start()
+        yield self.conversation.old_start()
         [self.tag] = yield self.conversation.get_tags()
         self.msg_options = yield self.conversation.make_message_options(
             self.tag)

--- a/go/apps/subscription/tests/test_vumi_app.py
+++ b/go/apps/subscription/tests/test_vumi_app.py
@@ -42,14 +42,13 @@ class TestSubscriptionApplication(AppWorkerTestCase):
             'reply_copy': reply_copy,
             }
         self.conv = yield self.create_conversation(
-            delivery_tag_pool=u'pool', delivery_class=self.transport_type,
-            config={
+            delivery_tag_pool=u'pool', config={
                 'handlers': [
                     mkhandler('foo', 'foo', 'subscribe', 'Subscribed to foo.'),
                     mkhandler('bar', 'bar', 'subscribe', 'Subscribed to bar.'),
                     mkhandler('stop', 'foo', 'unsubscribe', ''),
                     mkhandler('stop', 'bar', 'unsubscribe', 'Unsubscribed.'),
-                    ]})
+                ]})
         yield self.start_conversation(self.conv)
 
     @inlineCallbacks

--- a/go/apps/subscription/vumi_app.py
+++ b/go/apps/subscription/vumi_app.py
@@ -35,8 +35,9 @@ class SubscriptionApplication(GoApplicationWorker):
         user_api = self.get_user_api(msg_mdh.get_account_key())
         conv = yield msg_mdh.get_conversation()
 
+        # Assume `transport_type` is what `delivery_class` would be.
         contact = yield user_api.contact_store.contact_for_addr(
-            conv.delivery_class, message['from_addr'], create=True)
+            message['transport_type'], message['from_addr'], create=True)
         # We're guaranteed to have a contact here, because we create one if we
         # can't find an existing one.
 

--- a/go/apps/subscription/vumi_app.py
+++ b/go/apps/subscription/vumi_app.py
@@ -35,9 +35,9 @@ class SubscriptionApplication(GoApplicationWorker):
         user_api = self.get_user_api(msg_mdh.get_account_key())
         conv = yield msg_mdh.get_conversation()
 
-        # Assume `transport_type` is what `delivery_class` would be.
+        delivery_class = user_api.delivery_class_for_msg(message)
         contact = yield user_api.contact_store.contact_for_addr(
-            message['transport_type'], message['from_addr'], create=True)
+            delivery_class, message['from_addr'], create=True)
         # We're guaranteed to have a contact here, because we create one if we
         # can't find an existing one.
 

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -76,9 +76,7 @@ class TestSurveyApplication(AppWorkerTestCase):
         # Make the contact store searchable
         yield self.user_api.contact_store.contacts.enable_search()
 
-        self.conversation = yield self.create_conversation(
-            delivery_tag_pool=u'pool',
-            delivery_class=self.transport_type)
+        self.conversation = yield self.create_conversation()
         self.conversation.add_group(self.group)
         yield self.conversation.save()
 
@@ -135,7 +133,7 @@ class TestSurveyApplication(AppWorkerTestCase):
         returnValue(msgs[-1 * nr_of_messages:])
 
     @inlineCallbacks
-    def test_start(self):
+    def test_start_old_style(self):
         # We need to wait for process_command_send_survey() to finish
         # completely. Since it runs in response to an async command, we need to
         # wrap it in something that fires a deferred at the appropriate time.
@@ -150,13 +148,25 @@ class TestSurveyApplication(AppWorkerTestCase):
             surname=u'Contact', msisdn=u'+27831234568', groups=[self.group])
         yield self.create_survey(self.conversation)
         with LogCatcher() as log:
-            yield self.start_conversation(self.conversation)
+            yield self.start_conversation_old_style(self.conversation)
             self.assertEqual(log.errors, [])
 
         yield pcss_d
         [msg1, msg2] = self.get_dispatched_messages()
         self.assertEqual(msg1['content'], self.default_questions[0]['copy'])
         self.assertEqual(msg2['content'], self.default_questions[0]['copy'])
+
+    @inlineCallbacks
+    def send_send_survey_command(self, conversation):
+        batch_id = yield self.conversation.get_latest_batch_key()
+        yield self.dispatch_command(
+            "send_survey",
+            user_account_key=self.user_account.key,
+            conversation_key=conversation.key,
+            batch_id=batch_id,
+            msg_options={},
+            is_client_initiated=False,
+        )
 
     @inlineCallbacks
     def test_clearing_old_survey_data(self):
@@ -173,6 +183,7 @@ class TestSurveyApplication(AppWorkerTestCase):
 
         self.create_survey(self.conversation)
         yield self.start_conversation(self.conversation)
+        yield self.send_send_survey_command(self.conversation)
         yield self.submit_answers(self.default_questions,
             answers=[
                 '2',  # Yellow, skips the second question because of the check
@@ -259,6 +270,7 @@ class TestSurveyApplication(AppWorkerTestCase):
             msisdn=u'+27831234567', groups=[self.group])
         self.create_survey(self.conversation)
         yield self.start_conversation(self.conversation)
+        yield self.send_send_survey_command(self.conversation)
         yield self.complete_survey(self.default_questions)
 
     @inlineCallbacks
@@ -267,6 +279,7 @@ class TestSurveyApplication(AppWorkerTestCase):
             msisdn=u'+27831234567', groups=[self.group])
         self.create_survey(self.conversation)
         yield self.start_conversation(self.conversation)
+        yield self.send_send_survey_command(self.conversation)
         yield self.complete_survey(self.default_questions)
         # This participant should be empty
         poll_id = 'poll-%s' % (self.conversation.key,)

--- a/go/apps/surveys/views.py
+++ b/go/apps/surveys/views.py
@@ -144,7 +144,7 @@ def people(request, conversation_key):
     if request.method == 'POST':
         if conversation.is_client_initiated():
             try:
-                conversation.start()
+                conversation.old_start()
             except ConversationSendError as error:
                 if str(error) == 'No spare messaging tags.':
                     error = 'You have maxed out your available ' \
@@ -193,7 +193,7 @@ def start(request, conversation_key):
     conversation = conversation_or_404(request.user_api, conversation_key)
     if request.method == 'POST':
         try:
-            conversation.start()
+            conversation.old_start()
         except ConversationSendError as error:
             messages.add_message(request, messages.ERROR, str(error))
             return redirect(reverse('survey:start', kwargs={

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -36,14 +36,16 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
 
     @inlineCallbacks
     def consume_user_message(self, message):
+        contact = yield self.get_contact_for_message(message, create=True)
+        yield self._handle_survey_message(message, contact)
+
+    @inlineCallbacks
+    def _handle_survey_message(self, message, contact):
         helper_metadata = message['helper_metadata']
         go = helper_metadata.get('go')
         poll_id = 'poll-%s' % (go.get('conversation_key'),)
         helper_metadata['poll_id'] = poll_id
 
-        # Grab the contact's dynamic-extra values and update the participant
-        # with those before sending it to the PollApplication
-        contact = yield self.get_contact_for_message(message, create=True)
         participant = yield self.pm.get_participant(
             poll_id, message.user())
 
@@ -60,38 +62,10 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             if value and key not in participant.labels:
                 participant.set_label(key, value)
 
-        # NOTE:
-        #
-        # This is here because our SMS opt-out and our USSD opt-out's
-        # are not linked properly. Some bits and pieces are missing.
-        # The USSD opt-out happens through variables set in the
-        # contacts.extras[] dict, but the SMS is set in the contact_store.
-        # The USSD opt-out is fed back to the SMS/contact_store via
-        # the event handlers (specifically sna/handlers.py) and this
-        # hack links it the other way around again. We need the SMS
-        # contact_store opt-out status back to the participant's variables
-        # that vxpolls knows about.
-        #
-        # account_key = go.get('user_account')
-        # print 'account_key', account_key
-        # if account_key:
-        #     user_api = self.get_user_api(account_key)
-        #     contact_store = user_api.contact_store
-        #     is_opted_out = yield contact_store.contact_has_opted_out(
-        #         contact)
-        #     print 'participant', participant
-        #     if is_opted_out:
-        #         print '--- is opted out'
-        #         participant.set_label('opted_out', '2')
-        #         print 'opt-out set'
-        #         print participant.dump()
-        #     else:
-        #         print '--- is NOT opted out'
-
         yield self.pm.save_participant(poll_id, participant)
         yield super(SurveyApplication, self).consume_user_message(message)
 
-    def start_survey(self, to_addr, conversation, **msg_options):
+    def start_survey(self, to_addr, contact, conversation, **msg_options):
         log.debug('Starting %r -> %s' % (conversation, to_addr))
 
         # We reverse the to_addr & from_addr since we're faking input
@@ -100,9 +74,9 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
         conversation.set_go_helper_metadata(
             msg_options.setdefault('helper_metadata', {}))
         msg = TransportUserMessage(from_addr=to_addr, to_addr=from_addr,
-                content='', **msg_options)
+                                   content='', **msg_options)
 
-        return self.consume_user_message(msg)
+        return self._handle_survey_message(msg, contact)
 
     @inlineCallbacks
     def end_session(self, participant, poll, message):
@@ -150,7 +124,11 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
                 conv.delivery_class)):
             for contact in (yield contacts):
                 to_addr = contact.addr_for(conv.delivery_class)
-                yield self.start_survey(to_addr, conv, **msg_options)
+                # Set some fake msg_options in case we didn't get real ones.
+                msg_options.setdefault('from_addr', None)
+                msg_options.setdefault('transport_name', None)
+                msg_options.setdefault('transport_type', 'sms')
+                yield self.start_survey(to_addr, contact, conv, **msg_options)
 
     @inlineCallbacks
     def process_command_send_message(self, user_account_key, conversation_key,

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -146,7 +146,8 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
                 conversation_key, user_account_key))
             return
 
-        for contacts in (yield conv.get_opted_in_contact_bunches()):
+        for contacts in (yield conv.get_opted_in_contact_bunches(
+                conv.delivery_class)):
             for contact in (yield contacts):
                 to_addr = contact.addr_for(conv.delivery_class)
                 yield self.start_survey(to_addr, conv, **msg_options)

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -232,7 +232,8 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
                                             send_initial_action_hack=True):
         now = start_date or datetime.now().date()
         conversation = user_api.get_wrapped_conversation(conversation_key)
-        conversation.start(send_initial_action_hack=send_initial_action_hack)
+        conversation.old_start(
+            send_initial_action_hack=send_initial_action_hack)
 
         # Set the status manually, because it's in `starting', not `running'
         conversation.set_status_started()

--- a/go/base/management/commands/go_start_conversation.py
+++ b/go/base/management/commands/go_start_conversation.py
@@ -59,11 +59,11 @@ class Command(BaseCommand):
         if conversation.archived() or conversation.running():
             raise CommandError('Conversation already started.')
 
-        conversation.start(send_initial_action_hack=send_iah)
+        conversation.old_start(send_initial_action_hack=send_iah)
 
     def start_sequential_send(self, user_api, conversation, send_iah):
         if conversation.archived() or conversation.running():
             raise CommandError('Conversation already started.')
 
-        conversation.start(no_batch_tag=True, acquire_tag=False,
-                           send_initial_action_hack=send_iah)
+        conversation.old_start(no_batch_tag=True, acquire_tag=False,
+                               send_initial_action_hack=send_iah)

--- a/go/base/tests/test_go_account_stats.py
+++ b/go/base/tests/test_go_account_stats.py
@@ -44,7 +44,7 @@ class GoAccountStatsCommandTestCase(DjangoGoApplicationTestCase):
             u'delivery_tag_pool': u'longcode',
             })
         conv = self.user_api.wrap_conversation(self.mkconversation(**kwargs))
-        conv.start()
+        conv.old_start()
         return conv
 
     def test_command_summary(self):

--- a/go/base/tests/test_go_start_conversation.py
+++ b/go/base/tests/test_go_start_conversation.py
@@ -89,7 +89,7 @@ class GoStartConversationTestCase(DjangoGoApplicationTestCase):
         sender = DummyMessageSender()
         SyncMessageSender.return_value = sender
         conversation = self.get_conversation()
-        conversation.start()
+        conversation.old_start()
 
         # Set the status manually, because it's in `starting', not `running'
         conversation.set_status_started()

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -195,7 +195,7 @@ class StartConversationView(ConversationView):
         if self.conversation_initiator != 'client':
             params['dedupe'] = request.POST.get('dedupe') == '1'
         try:
-            conversation.start(**params)
+            conversation.old_start(**params)
         except ConversationSendError as error:
             messages.add_message(request, messages.ERROR, str(error))
             return self.redirect_to('start', conversation_key=conversation.key)
@@ -268,7 +268,7 @@ class ConfirmConversationView(ConversationView):
             try:
                 batch_id = conversation.get_latest_batch_key()
                 if token_manager.delete(user_token):
-                    conversation.start(batch_id=batch_id, **params)
+                    conversation.old_start(batch_id=batch_id, **params)
                     messages.info(request, '%s started succesfully!' %
                                   (self.conversation_display_name,))
                     success = True

--- a/go/conversation/conversation_views.py
+++ b/go/conversation/conversation_views.py
@@ -175,7 +175,7 @@ class StartConversationView(ConversationView):
         if self.conversation_views.conversation_initiator != 'client':
             params['dedupe'] = request.POST.get('dedupe') == '1'
         try:
-            conversation.start(**params)
+            conversation.old_start(**params)
         except ConversationSendError as error:
             messages.add_message(request, messages.ERROR, str(error))
             return self.redirect_to('start', conversation_key=conversation.key)
@@ -250,7 +250,7 @@ class ConfirmConversationView(ConversationView):
             try:
                 batch_id = conversation.get_latest_batch_key()
                 if token_manager.delete(user_token):
-                    conversation.start(batch_id=batch_id, **params)
+                    conversation.old_start(batch_id=batch_id, **params)
                     messages.info(request, '%s started succesfully!' % (
                         self.conv_def.conversation_display_name,))
                     success = True

--- a/go/conversation/templatetags/conversation_tags.py
+++ b/go/conversation/templatetags/conversation_tags.py
@@ -12,8 +12,6 @@ from go.conversation.forms import ReplyToMessageForm
 from go.base import message_store_client as ms_client
 from go.base.utils import page_range_window
 
-from vumi.message import TransportUserMessage
-
 
 register = template.Library()
 
@@ -121,13 +119,7 @@ def get_contact_for_message(user_api, message, direction='inbound'):
     # It falls back to the raw `transport_type` so that errors in
     # retrieving a contact return something useful for debugging (i.e.
     # the `transport_type` that failed to be looked up).
-    delivery_class = {
-        TransportUserMessage.TT_SMS: 'sms',
-        TransportUserMessage.TT_USSD: 'ussd',
-        TransportUserMessage.TT_XMPP: 'gtalk',
-        TransportUserMessage.TT_TWITTER: 'twitter',
-    }.get(message['transport_type'],
-          message['transport_type'])
+    delivery_class = user_api.delivery_class_for_msg(message)
     user = message.user() if direction == 'inbound' else message['to_addr']
     return user_api.contact_store.contact_for_addr(
         delivery_class, unicode(user), create=True)

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -71,7 +71,7 @@ class ConversationTestCase(DjangoGoApplicationTestCase):
             search('finished'), conversation.description)
 
         # now it should be running
-        conversation.start()
+        conversation.new_start()
         # Set the status manually, because it's in `starting', not `running'
         conversation = self.get_wrapped_conv()
         conversation.set_status_started()
@@ -93,7 +93,7 @@ class ConversationTestCase(DjangoGoApplicationTestCase):
         Test received_messages helper function
         """
         conversation = self.get_wrapped_conv()
-        conversation.start()
+        conversation.old_start()
         contacts = []
         for bunch in conversation.get_opted_in_contact_bunches(
                 conversation.delivery_class):
@@ -133,7 +133,7 @@ class ConversationTestCase(DjangoGoApplicationTestCase):
         Test that tags are released when a conversation is ended.
         """
         conversation = self.get_wrapped_conv()
-        conversation.start()
+        conversation.old_start()
         [message_batch] = conversation.get_batches()
         self.assertEqual(len(conversation.get_tags()), 1)
         conversation.end_conversation()

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -95,7 +95,8 @@ class ConversationTestCase(DjangoGoApplicationTestCase):
         conversation = self.get_wrapped_conv()
         conversation.start()
         contacts = []
-        for bunch in conversation.get_opted_in_contact_bunches():
+        for bunch in conversation.get_opted_in_contact_bunches(
+                conversation.delivery_class):
             contacts.extend(bunch)
         [contact] = contacts
         [batch] = conversation.get_batches()

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -71,7 +71,7 @@ class ConversationTestCase(DjangoGoApplicationTestCase):
             search('finished'), conversation.description)
 
         # now it should be running
-        conversation.new_start()
+        conversation.start()
         # Set the status manually, because it's in `starting', not `running'
         conversation = self.get_wrapped_conv()
         conversation.set_status_started()

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -31,6 +31,8 @@ from go.vumitools.token_manager import TokenManager
 from django.conf import settings
 from django.utils.datastructures import SortedDict
 
+from vumi.message import TransportUserMessage
+
 
 class TagpoolSet(object):
     """Holder for helper methods for retrieving tag pool information.
@@ -472,6 +474,17 @@ class VumiUserApi(object):
 
             yield user_account.save()
         yield self.api.tpm.release_tag(tag)
+
+    def delivery_class_for_msg(self, msg):
+        # Sometimes we need a `delivery_class` but we don't always have (or
+        # want) one. This builds one from `msg['transport_type']`.
+        return {
+            TransportUserMessage.TT_SMS: 'sms',
+            TransportUserMessage.TT_USSD: 'ussd',
+            TransportUserMessage.TT_XMPP: 'gtalk',
+            TransportUserMessage.TT_TWITTER: 'twitter',
+        }.get(msg['transport_type'],
+              msg['transport_type'])
 
 
 class VumiApi(object):

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -267,14 +267,12 @@ class GoWorkerMixin(object):
 
         go_metadata = helper_metadata.get('go', {})
         account_key = go_metadata.get('user_account', None)
-        conversation_key = go_metadata.get('conversation_key', None)
 
-        if account_key and conversation_key:
+        if account_key:
             user_api = self.get_user_api(account_key)
-            conv = yield user_api.get_wrapped_conversation(conversation_key)
-
+            delivery_class = user_api.delivery_class_for_msg(message)
             contact = yield user_api.contact_store.contact_for_addr(
-                conv.delivery_class, message.user(), create=create)
+                delivery_class, message.user(), create=create)
             returnValue(contact)
 
     def get_conversation(self, user_account_key, conversation_key):

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -67,6 +67,10 @@ class Contact(Model):
             self.groups.add_key(group)
 
     def addr_for(self, delivery_class):
+        if delivery_class is None:
+            # FIXME: Find a better way to do get delivery_class and get rid of
+            #        this hack.
+            return self.msisdn
         # TODO: delivery classes need to be defined somewhere
         if delivery_class in ('sms', 'ussd'):
             return self.msisdn

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -130,19 +130,19 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_count_replies(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         yield self.store_inbound((yield self.conv.get_latest_batch_key()))
         self.assertEqual((yield self.conv.count_replies()), 10)
 
     @inlineCallbacks
     def test_count_sent_messages(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         yield self.store_outbound((yield self.conv.get_latest_batch_key()))
         self.assertEqual((yield self.conv.count_sent_messages()), 10)
 
     @inlineCallbacks
     def test_count_inbound_uniques(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         yield self.store_inbound(
             (yield self.conv.get_latest_batch_key()), count=5)
         self.assertEqual((yield self.conv.count_inbound_uniques()), 5)
@@ -153,7 +153,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_count_outbound_uniques(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         yield self.store_outbound(
             (yield self.conv.get_latest_batch_key()), count=5)
         self.assertEqual((yield self.conv.count_outbound_uniques()), 5)
@@ -164,7 +164,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_received_messages(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20)
         received_messages = yield self.conv.received_messages()
@@ -175,7 +175,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_received_messages_include_sensitive(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20, helper_metadata={
             'go': {
@@ -188,7 +188,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_received_messages_include_sensitive_and_scrub(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20, helper_metadata={
             'go': {
@@ -207,7 +207,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_received_messages_dictionary(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         [msg] = yield self.store_inbound(batch_key, count=1)
         [reply] = yield self.conv.received_messages()
@@ -215,7 +215,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_sent_messages(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20)
         sent_messages = yield self.conv.sent_messages()
@@ -226,7 +226,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_sent_messages_include_sensitive(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20, helper_metadata={
             'go': {
@@ -239,7 +239,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_sent_messages_include_sensitive_and_scrub(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20, helper_metadata={
             'go': {
@@ -258,7 +258,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_sent_messages_dictionary(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         [msg] = yield self.store_outbound(batch_key, count=1)
         [sent_message] = yield self.conv.sent_messages()
@@ -266,7 +266,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_tags(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         self.assertEqual([], (yield self.conv.get_tags()))
 
     @inlineCallbacks
@@ -279,7 +279,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_progress_status(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         outbound = yield self.store_outbound(batch_key, count=10)
         yield self.store_event(outbound, 'ack', count=8)
@@ -302,7 +302,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_progress_percentage_acks(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         self.assertEqual((yield self.conv.get_progress_percentage()), 0)
         batch_key = yield self.conv.get_latest_batch_key()
         outbound = yield self.store_outbound(batch_key, count=10)
@@ -311,7 +311,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_progress_percentage_nacks(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         self.assertEqual((yield self.conv.get_progress_percentage()), 0)
         batch_key = yield self.conv.get_latest_batch_key()
         outbound = yield self.store_outbound(batch_key, count=10)
@@ -387,7 +387,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_inbound_throughput(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20, time_multiplier=0)
         # 20 messages in 5 minutes = 4 messages per minute
@@ -399,7 +399,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_outbound_throughput(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20, time_multiplier=0)
         # 20 messages in 5 minutes = 4 messages per minute
@@ -430,7 +430,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_find_inbound_messages_matching(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20)
         matching = yield self.do_search(self.conv, 'inbound', 'hello')
@@ -442,7 +442,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_find_inbound_messages_matching_flags(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20)
         matching = yield self.do_search(self.conv, 'inbound', 'HELLO',
@@ -454,7 +454,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_find_inbound_messages_matching_flags_custom_key(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_inbound(batch_key, count=20)
         matching = yield self.do_search(self.conv, 'inbound', 'FROM',
@@ -466,7 +466,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_find_outbound_messages_matching(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20)
         matching = yield self.do_search(self.conv, 'outbound', 'hello')
@@ -479,7 +479,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_find_outbound_messages_matching_flags(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20)
         matching = yield self.do_search(self.conv, 'outbound', 'HELLO',
@@ -491,7 +491,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_find_outbound_messages_matching_flags_custom_key(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20)
         matching = yield self.do_search(self.conv, 'outbound', 'TO', flags='i',
@@ -503,7 +503,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_aggregate_keys(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20, time_multiplier=12)
         inbound_aggregate = yield self.conv.get_aggregate_keys('inbound')
@@ -520,7 +520,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_aggregate_count(self):
-        yield self.conv.new_start()
+        yield self.conv.start()
         batch_key = yield self.conv.get_latest_batch_key()
         yield self.store_outbound(batch_key, count=20, time_multiplier=12)
         inbound_aggregate = yield self.conv.get_aggregate_count('inbound')

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -338,7 +338,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
         @inlineCallbacks
         def get_contacts():
-            bunches = yield self.conv.get_opted_in_contact_bunches()
+            bunches = yield self.conv.get_opted_in_contact_bunches(
+                self.conv.delivery_class)
             contacts = []
             for bunch in bunches:
                 contacts.extend((yield bunch))

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -179,8 +179,8 @@ class ConversationWrapper(object):
         return helper_metadata
 
     @Manager.calls_manager
-    def start(self, no_batch_tag=False, batch_id=None, acquire_tag=True,
-              send_initial_action_hack=True, **extra_params):
+    def old_start(self, no_batch_tag=False, batch_id=None, acquire_tag=True,
+                  send_initial_action_hack=True, **extra_params):
         """
         Send the start command to this conversations application worker.
 

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -259,13 +259,14 @@ class ConversationWrapper(object):
                 **extra_params)
 
     @Manager.calls_manager
-    def new_start(self):
+    def start(self):
         """Send the start command to this conversations application worker.
 
         This is used by the new conversation lifecycle and skips all the
         tagpool and initial_action silliness.
 
-        TODO: Replace the start() method above with this one.
+        TODO: Get rid of the old_start() method above and everything that
+              relies on it.
         """
         batches = yield self.get_batches()
         if not batches:

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -186,7 +186,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
             u"pool1", [u"1234", u"5678", u"9012"])
         yield self.user_api.acquire_specific_tag(tag2)
         yield self.user_api.new_conversation(
-            u'bulk_message', u'name', u'desc', {}, delivery_class=u'sms',
+            u'bulk_message', u'name', u'desc', {},
             delivery_tag_pool=tag1[0], delivery_tag=tag1[1])
         endpoints = yield self.user_api.list_conversation_endpoints()
         self.assertEqual(endpoints, set([tag1]))
@@ -205,7 +205,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
             u"pool1", [u"1234", u"5678", u"9012"])
         yield self.user_api.acquire_specific_tag(tag1)
         conv = yield self.user_api.new_conversation(
-            u'bulk_message', u'name', u'desc', {}, delivery_class=u'sms',
+            u'bulk_message', u'name', u'desc', {},
             delivery_tag_pool=tag1[0], delivery_tag=tag1[1])
         conv = self.user_api.wrap_conversation(conv)
         # We don't want to actually send commands here.
@@ -328,7 +328,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
             u"pool1", [u"1234", u"5678", u"9012"])
         yield self.user_api.acquire_specific_tag(tag1)
         conv = yield self.user_api.new_conversation(
-            u'bulk_message', u'name', u'desc', {}, delivery_class=u'sms',
+            u'bulk_message', u'name', u'desc', {},
             delivery_tag_pool=tag2[0], delivery_tag=tag2[1])
         conv = self.user_api.wrap_conversation(conv)
         # We don't want to actually send commands here.
@@ -385,7 +385,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
     def test_get_routing_table_migration_missing_entry(self):
         conv = yield self._setup_routing_table_test_conv()
         conv2 = yield self.user_api.new_conversation(
-            u'bulk_message', u'name', u'desc', {}, delivery_class=u'sms',
+            u'bulk_message', u'name', u'desc', {},
             delivery_tag_pool=u'pool1', delivery_tag=u'9012')
         conv2 = self.user_api.wrap_conversation(conv2)
         # We don't want to actually send commands here.

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -166,7 +166,8 @@ class TestTxVumiUserApi(AppWorkerTestCase):
                 all_addrs.append(contact.addr_for(conv.delivery_class))
         self.assertEqual(set(all_addrs), set(['+27760000000', '+27761234567']))
         optedin_addrs = []
-        for contacts in (yield conv.get_opted_in_contact_bunches()):
+        for contacts in (yield conv.get_opted_in_contact_bunches(
+                conv.delivery_class)):
             for contact in (yield contacts):
                 optedin_addrs.append(contact.addr_for(conv.delivery_class))
         self.assertEqual(optedin_addrs, ['+27760000000'])

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -211,7 +211,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         conv = self.user_api.wrap_conversation(conv)
         # We don't want to actually send commands here.
         conv.dispatch_command = lambda *args, **kw: None
-        yield conv.start(acquire_tag=False)
+        yield conv.old_start(acquire_tag=False)
 
         self.assertEqual(tag1, (conv.delivery_tag_pool, conv.delivery_tag))
         conv_endpoints = yield self.user_api.list_conversation_endpoints()
@@ -294,6 +294,27 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         self.assertEqual((yield self.user_api.acquire_tag(u"poolA")), None)
         yield self.assert_account_tags([list(tag1), list(tag2)])
 
+    def _set_routing_table(self, user, entries):
+        # Each entry is a tuple of (src, dst) where src and dst are
+        # conversations, tags or connector strings.
+        user.routing_table = {}
+        rt_helper = RoutingTableHelper(user.routing_table)
+
+        def mkconn(thing):
+            if isinstance(thing, basestring):
+                # Use it as-is.
+                return thing
+            elif isinstance(thing, tuple):
+                # It's a tag.
+                return str(GoConnector.for_transport_tag(thing[0], thing[1]))
+            else:
+                # Assume it's a conversation.
+                return str(GoConnector.for_conversation(
+                    thing.conversation_type, thing.key))
+
+        for src, dst in entries:
+            rt_helper.add_entry(mkconn(src), "default", mkconn(dst), "default")
+
     @inlineCallbacks
     def test_release_tag_with_routing_entries(self):
         [tag1] = yield self.setup_tagpool(u"pool1", [u"1234"])
@@ -304,13 +325,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         conv = yield self.user_api.new_conversation(
             u'bulk_message', u'name', u'desc', {})
         user = yield self.user_api.get_user_account()
-        rt_helper = RoutingTableHelper(user.routing_table)
-
-        tag_conn = str(GoConnector.for_transport_tag(tag1[0], tag1[1]))
-        conv_conn = str(
-            GoConnector.for_conversation(conv.conversation_type, conv.key))
-        rt_helper.add_entry(conv_conn, "default", tag_conn, "default")
-        rt_helper.add_entry(tag_conn, "default", conv_conn, "default")
+        self._set_routing_table(user, [(conv, tag1), (tag1, conv)])
         yield user.save()
 
         self.assertNotEqual({}, (yield self.user_api.get_routing_table()))
@@ -324,7 +339,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         self.assertEqual({}, routing_table)
 
     @inlineCallbacks
-    def _setup_routing_table_test_conv(self):
+    def _setup_routing_table_test_old_conv(self):
         tag1, tag2, tag3 = yield self.setup_tagpool(
             u"pool1", [u"1234", u"5678", u"9012"])
         yield self.user_api.acquire_specific_tag(tag1)
@@ -334,7 +349,25 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         conv = self.user_api.wrap_conversation(conv)
         # We don't want to actually send commands here.
         conv.dispatch_command = lambda *args, **kw: None
-        yield conv.start()
+        yield conv.old_start()
+
+        # Set the status manually, because it's in `starting', not `running'
+        conv.set_status_started()
+        yield conv.save()
+
+        returnValue(conv)
+
+    @inlineCallbacks
+    def _setup_routing_table_test_new_conv(self, routing_table=None):
+        tag1, tag2, tag3 = yield self.setup_tagpool(
+            u"pool1", [u"1234", u"5678", u"9012"])
+        yield self.user_api.acquire_specific_tag(tag1)
+        conv = yield self.user_api.new_conversation(
+            u'bulk_message', u'name', u'desc', {})
+        conv = self.user_api.wrap_conversation(conv)
+        # We don't want to actually send commands here.
+        conv.dispatch_command = lambda *args, **kw: None
+        yield conv.new_start()
 
         # Set the status manually, because it's in `starting', not `running'
         conv.set_status_started()
@@ -344,12 +377,16 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_routing_table(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_new_conv()
+        tag = (u'pool1', u'1234')
+        user = yield self.user_api.get_user_account()
+        self._set_routing_table(user, [(conv, tag), (tag, conv)])
+        yield user.save()
         routing_table = yield self.user_api.get_routing_table()
         self.assertEqual(routing_table, {
             u':'.join([u'CONVERSATION:bulk_message', conv.key]): {
-                u'default': [u'TRANSPORT_TAG:pool1:5678', u'default']},
-            u'TRANSPORT_TAG:pool1:5678': {
+                u'default': [u'TRANSPORT_TAG:pool1:1234', u'default']},
+            u'TRANSPORT_TAG:pool1:1234': {
                 u'default': [
                     u'CONVERSATION:bulk_message:%s' % conv.key, u'default']},
         })
@@ -362,7 +399,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_routing_table_migration(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_old_conv()
         # Pretend this is an old-style account that was migrated.
         user = yield self.user_api.get_user_account()
         user.routing_table = None
@@ -384,14 +421,14 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_get_routing_table_migration_missing_entry(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_old_conv()
         conv2 = yield self.user_api.new_conversation(
             u'bulk_message', u'name', u'desc', {},
             delivery_tag_pool=u'pool1', delivery_tag=u'9012')
         conv2 = self.user_api.wrap_conversation(conv2)
         # We don't want to actually send commands here.
         conv2.dispatch_command = lambda *args, **kw: None
-        yield conv2.start()
+        yield conv2.old_start()
 
         # Set the status manually, because it's in `starting', not `running'
         conv2.set_status_started()
@@ -422,24 +459,21 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_routing_table_validation_valid(self):
-        yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_new_conv()
+        tag = (u'pool1', u'1234')
         user = yield self.user_api.get_user_account()
+        self._set_routing_table(user, [(conv, tag), (tag, conv)])
+        yield user.save()
         yield self.user_api.validate_routing_table(user)
 
     @inlineCallbacks
     def test_routing_table_invalid_src_conn_tag(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_new_conv()
+        tag = (u'pool1', u'1234')
+        badtag = (u'badpool', u'bad')
         user = yield self.user_api.get_user_account()
-        user.routing_table = {
-            u':'.join(['CONVERSATION:bulk_message', conv.key]): {
-                'default': [u'TRANSPORT_TAG:pool1:5678', u'default']},
-            u'TRANSPORT_TAG:badpool:bad': {
-                u'default': [
-                    u':'.join(['CONVERSATION:bulk_message', conv.key]),
-                    'default'
-                ],
-            },
-        }
+        self._set_routing_table(user, [(conv, tag), (badtag, conv)])
+        yield user.save()
         try:
             yield self.user_api.validate_routing_table(user)
             self.fail("Expected VumiError, got no exception.")
@@ -448,18 +482,12 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_routing_table_invalid_dst_conn_tag(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_new_conv()
+        tag = (u'pool1', u'1234')
+        badtag = (u'badpool', u'bad')
         user = yield self.user_api.get_user_account()
-        user.routing_table = {
-            u':'.join(['CONVERSATION:bulk_message', conv.key]): {
-                'default': [u'TRANSPORT_TAG:badpool:bad', u'default']},
-            u'TRANSPORT_TAG:pool1:5678': {
-                u'default': [
-                    u':'.join(['CONVERSATION:bulk_message', conv.key]),
-                    'default'
-                ],
-            },
-        }
+        self._set_routing_table(user, [(conv, badtag), (tag, conv)])
+        yield user.save()
         try:
             yield self.user_api.validate_routing_table(user)
             self.fail("Expected VumiError, got no exception.")
@@ -468,18 +496,12 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_routing_table_invalid_src_conn_conv(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_new_conv()
+        tag = (u'pool1', u'1234')
+        badconv = 'CONVERSATION:bulk_message:badkey'
         user = yield self.user_api.get_user_account()
-        user.routing_table = {
-            u'CONVERSATION:bulk_message:badkey': {
-                'default': [u'TRANSPORT_TAG:pool1:5678', u'default']},
-            u'TRANSPORT_TAG:pool1:5678': {
-                u'default': [
-                    u':'.join(['CONVERSATION:bulk_message', conv.key]),
-                    'default'
-                ],
-            },
-        }
+        self._set_routing_table(user, [(badconv, tag), (tag, conv)])
+        yield user.save()
         try:
             yield self.user_api.validate_routing_table(user)
             self.fail("Expected VumiError, got no exception.")
@@ -488,15 +510,12 @@ class TestTxVumiUserApi(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_routing_table_invalid_dst_conn_conv(self):
-        conv = yield self._setup_routing_table_test_conv()
+        conv = yield self._setup_routing_table_test_new_conv()
+        tag = (u'pool1', u'1234')
+        badconv = 'CONVERSATION:bulk_message:badkey'
         user = yield self.user_api.get_user_account()
-        user.routing_table = {
-            u':'.join(['CONVERSATION:bulk_message', conv.key]): {
-                'default': [u'TRANSPORT_TAG:pool1:5678', u'default']},
-            u'TRANSPORT_TAG:pool1:5678': {
-                u'default': [u'CONVERSATION:bulk_message:badkey', 'default'],
-            },
-        }
+        self._set_routing_table(user, [(conv, tag), (tag, badconv)])
+        yield user.save()
         try:
             yield self.user_api.validate_routing_table(user)
             self.fail("Expected VumiError, got no exception.")

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -367,7 +367,7 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         conv = self.user_api.wrap_conversation(conv)
         # We don't want to actually send commands here.
         conv.dispatch_command = lambda *args, **kw: None
-        yield conv.new_start()
+        yield conv.start()
 
         # Set the status manually, because it's in `starting', not `running'
         conv.set_status_started()

--- a/go/vumitools/tests/test_api_worker.py
+++ b/go/vumitools/tests/test_api_worker.py
@@ -168,7 +168,7 @@ class SendingEventDispatcherTestCase(AppWorkerTestCase):
             conversation_type=u'bulk_message', description=u'message',
             config={}, delivery_tag_pool=u'pool', delivery_class=u'sms')
 
-        yield conversation.start()
+        yield conversation.old_start()
 
         user_account.event_handler_config = [
             [[conversation.key, 'my_event'], [('handler1', {

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -193,7 +193,7 @@ class GoAppWorkerTestMixin(GoPersistenceMixin):
         old_cmds = len(self.get_dispatcher_commands())
         conv.c.delivery_tag_pool = tagpool
         yield conv.save()
-        yield conv.start(**kwargs)
+        yield conv.old_start(**kwargs)
         for cmd in self.get_dispatcher_commands()[old_cmds:]:
             yield self.dispatch_command(
                 cmd.payload['command'], *cmd.payload['args'],

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -202,7 +202,7 @@ class GoAppWorkerTestMixin(GoPersistenceMixin):
     @inlineCallbacks
     def start_conversation(self, conversation):
         old_cmds = len(self.get_dispatcher_commands())
-        yield conversation.new_start()
+        yield conversation.start()
         for cmd in self.get_dispatcher_commands()[old_cmds:]:
             yield self.dispatch_command(
                 cmd.payload['command'], *cmd.payload['args'],


### PR DESCRIPTION
There are a bunch of place we rely on a conversation's `delivery_class` field. Conversations are no longer guaranteed to have this.
