### PR TITLE
Cancel button is broken for ChoiceStateEditView

### DIFF
--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -120,7 +120,6 @@
         model.set(this.modelBackup);
       }
 
-      this.state.preview();
       return this;
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -114,11 +114,7 @@
 
     cancel: function() {
       var model = this.state.model;
-
-      if (this.modelBackup) {
-        model.set(this.modelBackup, {remove: true});
-      }
-
+      if (this.modelBackup) { model.set(this.modelBackup); }
       return this;
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -116,8 +116,7 @@
       var model = this.state.model;
 
       if (this.modelBackup) {
-        model.clear();
-        model.set(this.modelBackup);
+        model.set(this.modelBackup, {remove: true});
       }
 
       return this;

--- a/go/base/static/js/src/components/plumbing/states.js
+++ b/go/base/static/js/src/components/plumbing/states.js
@@ -37,8 +37,6 @@
         schemaDefaults: {type: this.endpointType},
         collectionType: this.endpointCollectionType
       });
-
-      this.model.on('change', this.render, this);
     },
 
     destroy: function() {

--- a/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
@@ -167,7 +167,7 @@ describe("go.campaign.dialogue.states", function() {
           ordinal: 3
         });
 
-        state.model.set('name', 'New Dummy');
+        state.$('.name').val('New Dummy');
         editMode.$('.save').click();
 
         assert.deepEqual(state.model.toJSON(), {


### PR DESCRIPTION
Clicking cancel confuses the choice endpoints, since they lose their target element temporarily.
