### PR TITLE
Add means to specify address type when sending messages that aren't replies.

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -10,6 +10,7 @@ class BulkSendAction(ConversationAction):
         return self.send_command(
             'bulk_send', batch_id=self._conv.get_latest_batch_key(),
             msg_options={}, content=action_data['message'],
+            delivery_class=self._conv.delivery_class,
             dedupe=action_data['dedupe'])
 
 

--- a/go/apps/bulk_message/tests/test_new_views.py
+++ b/go/apps/bulk_message/tests/test_new_views.py
@@ -276,6 +276,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.get_batches()[0].key, msg_options={},
+            delivery_class=self.conversation.delivery_class,
             content='I am ham, not spam.', dedupe=True))
 
     def test_action_bulk_send_no_dedupe(self):
@@ -294,6 +295,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.get_batches()[0].key, msg_options={},
+            delivery_class=self.conversation.delivery_class,
             content='I am ham, not spam.', dedupe=False))
 
 

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -120,6 +120,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
+                delivery_class=conversation.delivery_class,
                 batch_id=batch.key, msg_options=msg_options, dedupe=False))
 
     def test_start_with_deduplication(self):
@@ -480,6 +481,7 @@ class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
+                delivery_class=conversation.delivery_class,
                 batch_id=batch.key, msg_options=msg_options, dedupe=True))
 
         # check token was consumed so it can't be re-used to send the

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -69,7 +69,7 @@ class BulkMessageApplication(GoApplicationWorker):
     @inlineCallbacks
     def process_command_bulk_send(self, user_account_key, conversation_key,
                                   batch_id, msg_options, content, dedupe,
-                                  **extra_params):
+                                  delivery_class, **extra_params):
 
         conv = yield self.get_conversation(user_account_key, conversation_key)
         if conv is None:
@@ -79,9 +79,9 @@ class BulkMessageApplication(GoApplicationWorker):
 
         to_addresses = []
         for contacts_batch in (
-                yield conv.get_opted_in_contact_bunches(conv.delivery_class)):
+                yield conv.get_opted_in_contact_bunches(delivery_class)):
             for contact in (yield contacts_batch):
-                to_addresses.append(contact.addr_for(conv.delivery_class))
+                to_addresses.append(contact.addr_for(delivery_class))
         if dedupe:
             to_addresses = set(to_addresses)
 

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -143,6 +143,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
+                delivery_class=conversation.delivery_class,
                 batch_id=batch.key, msg_options=msg_options))
 
     def test_send_fails(self):

--- a/go/apps/multi_surveys/vumi_app.py
+++ b/go/apps/multi_surveys/vumi_app.py
@@ -135,7 +135,7 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
     @inlineCallbacks
     def process_command_send_survey(self, user_account_key, conversation_key,
                                     batch_id, msg_options, is_client_initiated,
-                                    **extra_params):
+                                    delivery_class, **extra_params):
 
         if is_client_initiated:
             log.debug('Conversation %r is client initiated, no need to notify '
@@ -145,9 +145,9 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
         conv = yield self.get_conversation(user_account_key, conversation_key)
 
         for contacts in (yield conv.get_opted_in_contact_bunches(
-                conv.delivery_class)):
+                delivery_class)):
             for contact in (yield contacts):
-                to_addr = contact.addr_for(conv.delivery_class)
+                to_addr = contact.addr_for(delivery_class)
                 yield self.start_survey(to_addr, conv, **msg_options)
 
     def process_command_initial_action_hack(self, *args, **kwargs):

--- a/go/apps/sequential_send/tests/test_views.py
+++ b/go/apps/sequential_send/tests/test_views.py
@@ -136,6 +136,7 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
+                delivery_class=conversation.delivery_class,
                 batch_id=batch.key, msg_options=msg_options, dedupe=False))
 
     def test_send_fails(self):

--- a/go/apps/subscription/tests/test_views.py
+++ b/go/apps/subscription/tests/test_views.py
@@ -101,6 +101,7 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
+                delivery_class=conversation.delivery_class,
                 batch_id=batch.key, msg_options=msg_options))
 
     def test_send_fails(self):

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -9,7 +9,8 @@ class SendSurveyAction(ConversationAction):
     def perform_action(self, action_data):
         return self.send_command(
             'send_survey', batch_id=self._conv.get_latest_batch_key(),
-            msg_options={}, is_client_initiated=False)
+            msg_options={}, is_client_initiated=False,
+            delivery_class=self._conv.delivery_class)
 
 
 class DownloadUserDataAction(ConversationAction):

--- a/go/apps/surveys/tests/test_new_views.py
+++ b/go/apps/surveys/tests/test_new_views.py
@@ -143,6 +143,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.get_batches()[0].key, msg_options={},
+            delivery_class=self.conversation.delivery_class,
             is_client_initiated=False))
 
     def test_group_selection(self):

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -153,6 +153,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
+                delivery_class=conversation.delivery_class,
                 batch_id=batch.key, msg_options=msg_options))
 
     def test_send_fails(self):

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -166,6 +166,7 @@ class TestSurveyApplication(AppWorkerTestCase):
             batch_id=batch_id,
             msg_options={},
             is_client_initiated=False,
+            delivery_class=conversation.delivery_class,
         )
 
     @inlineCallbacks

--- a/go/apps/surveys/vumi_app.py
+++ b/go/apps/surveys/vumi_app.py
@@ -107,7 +107,7 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
     @inlineCallbacks
     def process_command_send_survey(self, user_account_key, conversation_key,
                                     batch_id, msg_options, is_client_initiated,
-                                    **extra_params):
+                                    delivery_class, **extra_params):
 
         if is_client_initiated:
             log.debug('Conversation %r is client initiated, no need to notify '
@@ -121,9 +121,9 @@ class SurveyApplication(PollApplication, GoApplicationMixin):
             return
 
         for contacts in (yield conv.get_opted_in_contact_bunches(
-                conv.delivery_class)):
+                delivery_class)):
             for contact in (yield contacts):
-                to_addr = contact.addr_for(conv.delivery_class)
+                to_addr = contact.addr_for(delivery_class)
                 # Set some fake msg_options in case we didn't get real ones.
                 msg_options.setdefault('from_addr', None)
                 msg_options.setdefault('transport_name', None)

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -256,6 +256,7 @@ class ConversationWrapper(object):
                 batch_id=batch_id,
                 msg_options=msg_options,
                 is_client_initiated=is_client_initiated,
+                delivery_class=self.c.delivery_class,
                 **extra_params)
 
     @Manager.calls_manager


### PR DESCRIPTION
In #440 a lot of the delivery_class things got cleaned up but we now need a way for the user to specify the address type to use when sending messages to contacts. Options are:
- Specifying the address type in the message sending form (I think this is my preferred method currently because it allows the user to specify the address type each time).
- Including the address type in the conversation config (this requires the user to know to update the config before sending messages to a new type of address so I'm less keen on this).
