### PR TITLE
Dialogue states don't always save fields to model

### DIFF
--- a/go/base/static/js/src/campaign/dialogue/states/choice.js
+++ b/go/base/static/js/src/campaign/dialogue/states/choice.js
@@ -27,7 +27,9 @@
 
     events: _({
       'click .new-choice': 'onNewChoice',
-      'click .choice .remove': 'onRemoveChoice'
+      'click .choice .remove': 'onRemoveChoice',
+      'change .choice input': 'onChoiceChange',
+      'change .text': 'onTextChange'
     }).defaults(DialogueStateEditView.prototype.events),
 
     initialize: function(options) {
@@ -51,13 +53,6 @@
       return this;
     },
 
-    newChoice: function() {
-      return this.state.endpoints.add(
-        'choice_endpoints',
-        {model: {uuid: uuid.v4()}},
-        {render: false});
-    },
-
     onActivate: function() {
       var choices = this.state.endpoints.members.get('choice_endpoints');
       if (!choices.size()) {
@@ -66,9 +61,13 @@
       }
     },
 
+    onTextChange: function(e) {
+      this.state.model.set('text', $(e.target).text(), {silent: true});
+      return this;
+    },
+
     onNewChoice: function(e) {
       e.preventDefault();
-      this.save();
       this.newChoice();
       this.state.render();
       jsPlumb.repaintEverything();
@@ -76,13 +75,28 @@
 
     onRemoveChoice: function(e) {
       e.preventDefault();
-      this.save();
 
       var $choice = $(e.target).parent();
       this.state.endpoints.remove($choice.attr('data-endpoint-id'));
 
       this.state.render();
       jsPlumb.repaintEverything();
+    },
+
+    onChoiceChange: function(e) {
+      var $choice = $(e.target).parent();
+
+      this.state.model
+        .get('choice_endpoints')
+        .get($choice.attr('data-endpoint-id'))
+        .set('label', $choice.find('input').prop('value'), {silent: true});
+    },
+
+    newChoice: function() {
+      return this.state.endpoints.add(
+        'choice_endpoints',
+        {model: {uuid: uuid.v4()}},
+        {render: false});
     }
   });
 

--- a/go/base/static/js/src/campaign/dialogue/states/choice.js
+++ b/go/base/static/js/src/campaign/dialogue/states/choice.js
@@ -37,22 +37,6 @@
       this.on('activate', this.onActivate, this);
     },
 
-    save: function() {
-      var model = this.state.model,
-          choices = model.get('choice_endpoints');
-
-      model.set('text', this.$('.text').val(), {silent: true});
-      this.$('.choice').each(function() {
-        var $choice = $(this);
-
-        choices
-          .get($choice.attr('data-endpoint-id'))
-          .set('label', $choice.find('input').prop('value'), {silent: true});
-      });
-
-      return this;
-    },
-
     onActivate: function() {
       var choices = this.state.endpoints.members.get('choice_endpoints');
       if (!choices.size()) {
@@ -62,7 +46,7 @@
     },
 
     onTextChange: function(e) {
-      this.state.model.set('text', $(e.target).text(), {silent: true});
+      this.state.model.set('text', $(e.target).val(), {silent: true});
       return this;
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/end.js
+++ b/go/base/static/js/src/campaign/dialogue/states/end.js
@@ -18,7 +18,7 @@
     }).defaults(DialogueStateEditView.prototype.events),
 
     onTextChange: function(e) {
-      this.state.model.set('text', $(e.target).text(), {silent: true});
+      this.state.model.set('text', $(e.target).val(), {silent: true});
       return this;
     }
   });

--- a/go/base/static/js/src/campaign/dialogue/states/end.js
+++ b/go/base/static/js/src/campaign/dialogue/states/end.js
@@ -13,8 +13,12 @@
   var EndStateEditView = DialogueStateEditView.extend({
     bodyTemplate: 'JST.campaign_dialogue_states_end_edit',
 
-    save: function() {
-      this.state.model.set('text', this.$('.text').val(), {silent: true});
+    events: _({
+      'change .text': 'onTextChange'
+    }).defaults(DialogueStateEditView.prototype.events),
+
+    onTextChange: function(e) {
+      this.state.model.set('text', $(e.target).text(), {silent: true});
       return this;
     }
   });

--- a/go/base/static/js/src/campaign/dialogue/states/freetext.js
+++ b/go/base/static/js/src/campaign/dialogue/states/freetext.js
@@ -18,7 +18,7 @@
     }).defaults(DialogueStateEditView.prototype.events),
 
     onTextChange: function(e) {
-      this.state.model.set('text', $(e.target).text(), {silent: true});
+      this.state.model.set('text', $(e.target).val(), {silent: true});
       return this;
     }
   });

--- a/go/base/static/js/src/campaign/dialogue/states/freetext.js
+++ b/go/base/static/js/src/campaign/dialogue/states/freetext.js
@@ -13,8 +13,12 @@
   var FreeTextStateEditView = DialogueStateEditView.extend({
     bodyTemplate: 'JST.campaign_dialogue_states_freetext_edit',
 
-    save: function() {
-      this.state.model.set('text', this.$('.text').val(), {silent: true});
+    events: _({
+      'change .text': 'onTextChange'
+    }).defaults(DialogueStateEditView.prototype.events),
+
+    onTextChange: function(e) {
+      this.state.model.set('text', $(e.target).text(), {silent: true});
       return this;
     }
   });

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -84,9 +84,10 @@
     tailTemplate: 'JST.campaign_dialogue_states_modes_edit_tail',
 
     events: {
-      'click .save': 'onSave',
+      'click .ok': 'onOk',
       'click .cancel': 'onCancel',
-      'change .type': 'onTypeChange'
+      'change .type': 'onTypeChange',
+      'change .name': 'onNameChange'
     },
 
     initialize: function(options) {
@@ -96,21 +97,8 @@
       this.on('activate', this.backupModel, this);
     },
 
-    // Keep a backup to restore the model for when the user cancels the edit
-    backupModel: function() {
-      this.modelBackup = this.state.model.toJSON();
-      return this;
-    },
-
-    _save: function() {
-      var name = this.$('.titlebar .name').val();
-      this.state.model.set('name', name, {silent: true});
-      this.save();
-    },
-
-    onSave: function(e) {
+    onOk: function(e) {
       e.preventDefault();
-      this._save();
       this.state.preview();
     },
 
@@ -131,7 +119,16 @@
         }.bind(this));
     },
 
-    save: function() { return this; },
+    onNameChange: function(e) {
+      this.state.model.set('name', $(e.target).val(), {silent: true});
+      return this;
+    },
+
+    // Keep a backup to restore the model for when the user cancels the edit
+    backupModel: function() {
+      this.modelBackup = this.state.model.toJSON();
+      return this;
+    },
 
     cancel: function() {
       var model = this.state.model;

--- a/go/base/static/js/test/tests/campaign/dialogue/states/choice.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/choice.test.js
@@ -64,7 +64,7 @@ describe("go.campaign.dialogue.states.choice", function() {
 
         editMode
           .$('.text')
-          .text('What is your favourite dinosaur?')
+          .val('What is your favourite dinosaur?')
           .change();
 
         assert.equal(

--- a/go/base/static/js/test/tests/campaign/dialogue/states/choice.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/choice.test.js
@@ -55,73 +55,21 @@ describe("go.campaign.dialogue.states.choice", function() {
       });
     });
 
-    describe(".save", function() {
-      it("should update the choice state's model", function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: "state1",
-          name: "Message 1",
-          type: "choice",
-          text: "What is your favourite colour?",
-          ordinal: 0,
-          entry_endpoint: {uuid: "endpoint0"},
-          choice_endpoints: [
-            {value: "value1", label: "Red", uuid: "endpoint1"},
-            {value: "value2", label: "Blue", uuid: "endpoint2"}]
-        });
+    describe("when '.text' has changed", function() {
+      it("should update the 'text' attribute of the state's model",
+      function() {
+        assert.equal(
+          state.model.get('text'),
+          'What is your favourite colour?');
 
-        editMode.$('.text').text('What is your favourite dinosaur?');
-        editMode.$('.choice input').eq(1).val('Diplodocus');
-        editMode.save();
+        editMode
+          .$('.text')
+          .text('What is your favourite dinosaur?')
+          .change();
 
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: "state1",
-          name: "Message 1",
-          type: "choice",
-          text: "What is your favourite dinosaur?",
-          ordinal: 0,
-          entry_endpoint: {uuid: "endpoint0"},
-          choice_endpoints: [
-            {value: "value1", label: "Red", uuid: "endpoint1"},
-            {value: "value2", label: "Diplodocus", uuid: "endpoint2"}]
-        });
-      });
-    });
-
-    describe("when the '.save' button is clicked", function() {
-      it("should update the choice state's model", function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: "state1",
-          name: "Message 1",
-          type: "choice",
-          text: "What is your favourite colour?",
-          ordinal: 0,
-          entry_endpoint: {uuid: "endpoint0"},
-          choice_endpoints: [
-            {value: "value1", label: "Red", uuid: "endpoint1"},
-            {value: "value2", label: "Blue", uuid: "endpoint2"}]
-        });
-
-        editMode.$('.text').text('What is your favourite dinosaur?');
-        editMode.$('.choice input').eq(1).val('Diplodocus');
-        editMode.$('.save').click();
-
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: "state1",
-          name: "Message 1",
-          type: "choice",
-          text: "What is your favourite dinosaur?",
-          ordinal: 0,
-          entry_endpoint: {uuid: "endpoint0"},
-          choice_endpoints: [
-            {value: "value1", label: "Red", uuid: "endpoint1"},
-            {value: "value2", label: "Diplodocus", uuid: "endpoint2"}]
-        });
-      });
-
-      it("should switch back to the preview view", function() {
-        assert.equal(state.modeName, 'edit');
-        editMode.$('.save').click();
-        assert.equal(state.modeName, 'preview');
+        assert.equal(
+          state.model.get('text'),
+          'What is your favourite dinosaur?');
       });
     });
 
@@ -175,6 +123,24 @@ describe("go.campaign.dialogue.states.choice", function() {
 
         assert(noElExists(
           editMode.$('.choice[data-endpoint-id="endpoint1"]')));
+      });
+    });
+
+    describe("when a '.choice input' has changed", function() {
+      it("should update the corresponding endpoint model's label attribute",
+      function() {
+        var endpoint = state.model
+          .get('choice_endpoints')
+          .get('endpoint2');
+
+        assert.equal(endpoint.get('label'), 'Blue');
+
+        editMode.$('.choice input')
+          .eq(1)
+          .val('Diplodocus')
+          .change();
+
+        assert.equal(endpoint.get('label'), 'Diplodocus');
       });
     });
   });

--- a/go/base/static/js/test/tests/campaign/dialogue/states/end.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/end.test.js
@@ -27,59 +27,21 @@ describe("go.campaign.dialogue.states.end", function() {
       state.edit();
     });
 
-    describe(".save", function() {
-      it("should update the end state's model", function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state3',
-          name: 'Ending 1',
-          type: 'end',
-          ordinal: 2,
-          text: 'Thank you for taking our survey',
-          entry_endpoint: {uuid: 'endpoint5'}
-        });
+    describe("when '.text' has changed", function() {
+      it("should update the 'text' attribute of the state's model",
+      function() {
+        assert.equal(
+          state.model.get('text'),
+          'Thank you for taking our survey');
 
-        editMode.$('.text').text('So Long, and Thanks for All the Fish');
-        editMode.save();
+        editMode
+          .$('.text')
+          .text('So Long, and Thanks for All the Fish')
+          .change();
 
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state3',
-          name: 'Ending 1',
-          type: 'end',
-          ordinal: 2,
-          text: 'So Long, and Thanks for All the Fish',
-          entry_endpoint: {uuid: 'endpoint5'}
-        });
-      });
-    });
-
-    describe("when the '.save' button is clicked", function() {
-      it("should update the end state's model", function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state3',
-          name: 'Ending 1',
-          type: 'end',
-          ordinal: 2,
-          text: 'Thank you for taking our survey',
-          entry_endpoint: {uuid: 'endpoint5'}
-        });
-
-        editMode.$('.text').text('So Long, and Thanks for All the Fish');
-        editMode.$('.save').click();
-
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state3',
-          name: 'Ending 1',
-          type: 'end',
-          ordinal: 2,
-          text: 'So Long, and Thanks for All the Fish',
-          entry_endpoint: {uuid: 'endpoint5'}
-        });
-      });
-
-      it("should switch back to the preview view", function() {
-        assert.equal(state.modeName, 'edit');
-        editMode.$('.save').click();
-        assert.equal(state.modeName, 'preview');
+        assert.equal(
+          state.model.get('text'),
+          'So Long, and Thanks for All the Fish');
       });
     });
   });

--- a/go/base/static/js/test/tests/campaign/dialogue/states/end.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/end.test.js
@@ -36,7 +36,7 @@ describe("go.campaign.dialogue.states.end", function() {
 
         editMode
           .$('.text')
-          .text('So Long, and Thanks for All the Fish')
+          .val('So Long, and Thanks for All the Fish')
           .change();
 
         assert.equal(

--- a/go/base/static/js/test/tests/campaign/dialogue/states/freetext.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/freetext.test.js
@@ -27,63 +27,21 @@ describe("go.campaign.dialogue.states.freetext", function() {
       state.edit();
     });
 
-    describe(".save", function() {
-      it("should update the freetext state's model", function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state2',
-          name: 'Message 2',
-          type: 'freetext',
-          text: 'What is your name?',
-          ordinal: 1,
-          entry_endpoint: {uuid: 'endpoint3'},
-          exit_endpoint: {uuid: 'endpoint4'}
-        });
+    describe("when '.text' has changed", function() {
+      it("should update the 'text' attribute of the state's model",
+      function() {
+        assert.equal(
+          state.model.get('text'),
+          'What is your name?');
 
-        editMode.$('.text').text('What is your parrot doing?');
-        editMode.save();
+        editMode
+          .$('.text')
+          .text('What is your parrot doing?')
+          .change();
 
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state2',
-          name: 'Message 2',
-          type: 'freetext',
-          ordinal: 1,
-          text: 'What is your parrot doing?',
-          entry_endpoint: {uuid: 'endpoint3'},
-          exit_endpoint: {uuid: 'endpoint4'}
-        });
-      });
-    });
-
-    describe("when the '.save' button is clicked", function() {
-      it("should update the freetext state's model", function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state2',
-          name: 'Message 2',
-          type: 'freetext',
-          text: 'What is your name?',
-          ordinal: 1,
-          entry_endpoint: {uuid: 'endpoint3'},
-          exit_endpoint: {uuid: 'endpoint4'}
-        });
-
-        editMode.$('.text').text('What is your parrot doing?');
-        editMode.$('.save').click();
-
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state2',
-          name: 'Message 2',
-          type: 'freetext',
-          ordinal: 1,
-          text: 'What is your parrot doing?',
-          entry_endpoint: {uuid: 'endpoint3'},
-          exit_endpoint: {uuid: 'endpoint4'}
-        });
-      });
-
-      it("should switch back to the preview view", function() {
-        assert.equal(state.modeName, 'edit');
-        editMode.$('.save').click();
-        assert.equal(state.modeName, 'preview');
+        assert.equal(
+          state.model.get('text'),
+          'What is your parrot doing?');
       });
     });
   });

--- a/go/base/static/js/test/tests/campaign/dialogue/states/freetext.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/freetext.test.js
@@ -36,7 +36,7 @@ describe("go.campaign.dialogue.states.freetext", function() {
 
         editMode
           .$('.text')
-          .text('What is your parrot doing?')
+          .val('What is your parrot doing?')
           .change();
 
         assert.equal(

--- a/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
@@ -197,29 +197,12 @@ describe("go.campaign.dialogue.states", function() {
       });
     });
 
-    describe("when the '.save' button is clicked", function() {
+    describe("when '.name' has changed", function() {
       it("should update the 'name' attribute of the state's model",
       function() {
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state4',
-          name: 'Dummy Message 1',
-          type: 'dummy',
-          entry_endpoint: {'uuid':'endpoint6'},
-          exit_endpoint: {'uuid':'endpoint7'},
-          ordinal: 3
-        });
-
-        state.$('.name').val('New Dummy');
-        editMode.$('.save').click();
-
-        assert.deepEqual(state.model.toJSON(), {
-          uuid: 'state4',
-          name: 'New Dummy',
-          type: 'dummy',
-          entry_endpoint: {'uuid':'endpoint6'},
-          exit_endpoint: {'uuid':'endpoint7'},
-          ordinal: 3
-        });
+        assert.equal(state.model.get('name'), 'Dummy Message 1');
+        state.$('.name').val('New Dummy').change();
+        assert.equal(state.model.get('name'), 'New Dummy');
       });
     });
 
@@ -250,6 +233,14 @@ describe("go.campaign.dialogue.states", function() {
       it("should switch back to the preview view", function() {
         assert.equal(state.modeName, 'edit');
         editMode.$('.cancel').click();
+        assert.equal(state.modeName, 'preview');
+      });
+    });
+
+    describe("when '.ok' button is clicked", function() {
+      it("should switch back to the preview view", function() {
+        assert.equal(state.modeName, 'edit');
+        editMode.$('.ok').click();
         assert.equal(state.modeName, 'preview');
       });
     });

--- a/go/base/static/templates/campaign/dialogue/states/modes/edit/tail.jst
+++ b/go/base/static/templates/campaign/dialogue/states/modes/edit/tail.jst
@@ -1,5 +1,5 @@
 <div class='actions pull-right'>
   <a class='btn cancel'>Cancel</a>
-  <a class='btn btn-primary save'>Save</a>
+  <a class='btn btn-primary ok'>Ok</a>
 </div>
 


### PR DESCRIPTION
Currently, we have a `.save()` for dialogue state views that looks up the values of each element that corresponds to a model attribute, and updates the model. This means that if the view is re-rendered before `.save()` is called, we lose the user's input, and the model can't be updated.

The plan is to get rid of `.save()`, and rather set each model attribute corresponding to an element on that element's change event.
