### PR TITLE
Disabled conversation actions

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -8,6 +8,9 @@ class BulkSendAction(ConversationAction):
 
     needs_confirmation = True
 
+    needs_group = True
+    needs_running = True
+
     def perform_action(self, action_data):
         return self.send_command(
             'bulk_send', batch_id=self._conv.get_latest_batch_key(),

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -266,7 +266,6 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             {'message': 'I am ham, not spam.', 'dedupe': True},
             follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
-        print [str(m) for m in response.context['messages']]
         [msg] = response.context['messages']
         self.assertEqual(
             str(msg), "Action disabled: This action needs a contact group.")

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -45,6 +45,23 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         conv = self.conv_store.get_conversation_by_key(self.conv_key)
         return self.user_api.wrap_conversation(conv)
 
+    def prepare_conversation(self, start=True, group=True):
+        if start:
+            resp = self.client.post(self.get_view_url('start'), follow=True)
+            [msg] = resp.context['messages']
+            self.assertEqual(str(msg), "Conversation started")
+            self.assertEqual(1, len(self.get_api_commands_sent()))
+
+        conv = self.get_wrapped_conv()
+
+        if not group:
+            conv.groups.remove_key(self.group.key)
+        if start:
+            conv.set_status_started()
+
+        conv.save()
+        return conv
+
     def run_new_conversation(self, selected_option, pool, tag):
         self.assertEqual(len(self.conv_store.list_conversations()), 1)
         response = self.post_new_conversation()
@@ -242,10 +259,34 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertContains(response, 'name="message"')
         self.assertContains(response, '<h1>Send Bulk Message</h1>')
 
+    def test_action_bulk_send_no_group(self):
+        self.prepare_conversation(group=False)
+        response = self.client.post(
+            self.get_action_view_url('bulk_send'),
+            {'message': 'I am ham, not spam.', 'dedupe': True},
+            follow=True)
+        self.assertRedirects(response, self.get_view_url('show'))
+        print [str(m) for m in response.context['messages']]
+        [msg] = response.context['messages']
+        self.assertEqual(
+            str(msg), "Action disabled: This action needs a contact group.")
+        self.assertEqual([], self.get_api_commands_sent())
+
+    def test_action_bulk_send_not_running(self):
+        self.prepare_conversation(start=False)
+        response = self.client.post(
+            self.get_action_view_url('bulk_send'),
+            {'message': 'I am ham, not spam.', 'dedupe': True},
+            follow=True)
+        self.assertRedirects(response, self.get_view_url('show'))
+        [msg] = response.context['messages']
+        self.assertEqual(
+            str(msg),
+            "Action disabled: This action needs a running conversation.")
+        self.assertEqual([], self.get_api_commands_sent())
+
     def test_action_bulk_send_dedupe(self):
-        # Start the conversation
-        self.client.post(self.get_view_url('start'))
-        self.assertEqual(1, len(self.get_api_commands_sent()))
+        self.prepare_conversation()
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': True})
@@ -262,9 +303,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             content='I am ham, not spam.', dedupe=True))
 
     def test_action_bulk_send_no_dedupe(self):
-        # Start the conversation
-        self.client.post(self.get_view_url('start'))
-        self.assertEqual(1, len(self.get_api_commands_sent()))
+        self.prepare_conversation()
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': False})
@@ -305,8 +344,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         account.save()
 
         # Start the conversation
-        self.client.post(self.get_view_url('start'))
-        self.assertEqual(1, len(self.get_api_commands_sent()))
+        self.prepare_conversation()
 
         # POST the action with a mock token manager
         with patch.object(TokenManager, 'generate_token') as mock_method:

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -6,6 +6,11 @@ class SendSurveyAction(ConversationAction):
     action_name = 'send_survey'
     action_display_name = 'Send Survey'
 
+    needs_confirmation = True
+
+    needs_group = True
+    needs_running = True
+
     def perform_action(self, action_data):
         return self.send_command(
             'send_survey', batch_id=self._conv.get_latest_batch_key(),

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -48,6 +48,23 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         conv = self.conv_store.get_conversation_by_key(self.conv_key)
         return self.user_api.wrap_conversation(conv)
 
+    def prepare_conversation(self, start=True, group=True):
+        if start:
+            resp = self.client.post(self.get_view_url('start'), follow=True)
+            [msg] = resp.context['messages']
+            self.assertEqual(str(msg), "Conversation started")
+            self.assertEqual(1, len(self.get_api_commands_sent()))
+
+        conv = self.get_wrapped_conv()
+
+        if not group:
+            conv.groups.remove_key(self.group.key)
+        if start:
+            conv.set_status_started()
+
+        conv.save()
+        return conv
+
     def create_poll(self, conversation, **kwargs):
         poll_id = 'poll-%s' % (conversation.key,)
         pm, config = get_poll_config(poll_id)
@@ -93,15 +110,13 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertEqual([], self.get_api_commands_sent())
 
     def test_action_send_survey_post(self):
-        # Start the conversation
-        self.client.post(self.get_view_url('start'))
-        self.assertEqual(1, len(self.get_api_commands_sent()))
+        self.prepare_conversation()
         response = self.client.post(
-            self.get_action_view_url('send_survey'), {})
+            self.get_action_view_url('send_survey'), {}, follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
-        [bulk_send_cmd] = self.get_api_commands_sent()
+        [send_survey_cmd] = self.get_api_commands_sent()
         conversation = self.user_api.get_wrapped_conversation(self.conv_key)
-        self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
+        self.assertEqual(send_survey_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
             'send_survey',
             user_account_key=conversation.user_account.key,
@@ -110,17 +125,27 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             delivery_class=conversation.delivery_class,
             is_client_initiated=False))
 
-    @skip("The new views don't handle this kind of thing very well yet.")
-    def test_action_send_survey_fails(self):
-        """
-        Test failure to send messages
-        """
-        self.acquire_all_longcode_tags()
-        response = self.client.post(self.get_view_url('start'), follow=True)
-        self.assertRedirects(response, self.get_view_url('start'))
-        [] = self.get_api_commands_sent()
+    def test_action_send_survey_no_group(self):
+        self.prepare_conversation(group=False)
+        response = self.client.post(
+            self.get_action_view_url('send_survey'), {}, follow=True)
+        self.assertRedirects(response, self.get_view_url('show'))
+        print [str(m) for m in response.context['messages']]
         [msg] = response.context['messages']
-        self.assertEqual(str(msg), "No spare messaging tags.")
+        self.assertEqual(
+            str(msg), "Action disabled: This action needs a contact group.")
+        self.assertEqual([], self.get_api_commands_sent())
+
+    def test_action_send_survey_not_running(self):
+        self.prepare_conversation(start=False)
+        response = self.client.post(
+            self.get_action_view_url('send_survey'), {}, follow=True)
+        self.assertRedirects(response, self.get_view_url('show'))
+        [msg] = response.context['messages']
+        self.assertEqual(
+            str(msg),
+            "Action disabled: This action needs a running conversation.")
+        self.assertEqual([], self.get_api_commands_sent())
 
     @skip("The new views don't have this yet.")
     def test_group_selection(self):

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -130,7 +130,6 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         response = self.client.post(
             self.get_action_view_url('send_survey'), {}, follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
-        print [str(m) for m in response.context['messages']]
         [msg] = response.context['messages']
         self.assertEqual(
             str(msg), "Action disabled: This action needs a contact group.")

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -332,7 +332,7 @@ class ConversationActionView(ConversationTemplateView):
     def perform_action(self, request, conversation, action_data):
         disabled = self.action.is_disabled()
         if disabled:
-            messages.warning(request, 'Action disabled: %s!' % (disabled,))
+            messages.warning(request, 'Action disabled: %s' % (disabled,))
             return self.redirect_to('show', conversation_key=conversation.key)
 
         self.action.perform_action(action_data)

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -330,6 +330,11 @@ class ConversationActionView(ConversationTemplateView):
         return self.perform_action(request, conversation, action_data)
 
     def perform_action(self, request, conversation, action_data):
+        disabled = self.action.is_disabled()
+        if disabled:
+            messages.warning(request, 'Action disabled: %s!' % (disabled,))
+            return self.redirect_to('show', conversation_key=conversation.key)
+
         self.action.perform_action(action_data)
         messages.info(request, 'Action successful: %s!' % (
             self.action.action_display_name,))

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -331,7 +331,7 @@ class ConversationActionView(ConversationTemplateView):
 
     def perform_action(self, request, conversation, action_data):
         disabled = self.action.is_disabled()
-        if disabled:
+        if disabled is not None:
             messages.warning(request, 'Action disabled: %s' % (disabled,))
             return self.redirect_to('show', conversation_key=conversation.key)
 

--- a/go/vumitools/conversation/definition.py
+++ b/go/vumitools/conversation/definition.py
@@ -34,6 +34,10 @@ class ConversationAction(object):
     action_display_name = None
     needs_confirmation = False
 
+    # Some actions are only possible under certain conditions.
+    needs_group = False
+    needs_running = False
+
     redirect_to = None
 
     def __init__(self, conv):
@@ -49,3 +53,18 @@ class ConversationAction(object):
             user_account_key=self._conv.user_account.key,
             conversation_key=self._conv.key,
             **params)
+
+    def is_disabled(self):
+        """Returns `None` if the action is enabled, otherwise a reason string.
+        """
+        if self.needs_group and not self._conv.groups.keys():
+            return "This action needs a contact group."
+
+        if self.needs_running and not self._conv.running():
+            return "This action needs a running conversation."
+
+        return self.check_disabled()
+
+    def check_disabled(self):
+        """Override in subclasses to provide custom disable logic."""
+        return None


### PR DESCRIPTION
Certain conversation actions only make sense when the conversation is in a particular state. For example, "send bulk message" needs the conversation to be running and to have contact groups attached to it.
