### PR TITLE
Check action is enabled before showing action form or processing GETs or POSTs.

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -126,6 +126,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         """
         Test showing the conversation
         """
+        self.prepare_conversation()
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -252,6 +252,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(mime_type, 'application/zip')
 
     def test_action_bulk_send_view(self):
+        self.prepare_conversation()
         response = self.client.get(self.get_action_view_url('bulk_send'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -179,6 +179,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         """
         Test showing the conversation
         """
+        self.prepare_conversation()
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, 'Test Conversation')

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -104,6 +104,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertTrue(conversation.stopping())
 
     def test_action_send_survey_get(self):
+        self.prepare_conversation()
         response = self.client.get(self.get_action_view_url('send_survey'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -78,7 +78,13 @@
             <p>
                 <ol>
                 {% for action in actions %}
-                    <li><a href="{% conversation_action conversation action.action_name %}">{{action.action_display_name}}</a></li>
+                    {% with is_disabled=action.is_disabled %}
+                    {% if is_disabled %}
+                    <li><a href="#" class="disabled" title="{{ is_disabled }}">{{action.action_display_name}}</a></li>
+                    {% else %}
+                    <li><a href="{% conversation_action conversation action.action_name %}">{{ action.action_display_name }}</a></li>
+                    {% endif %}
+                    {% endwith %}
                 {% empty %}
                     <li>This conversation has no actions.</li>
                 {% endfor %}

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -80,7 +80,7 @@
                 {% for action in actions %}
                     {% with is_disabled=action.is_disabled %}
                     {% if is_disabled %}
-                    <li><a href="#" class="disabled" title="{{ is_disabled }}">{{action.action_display_name}}</a></li>
+                    <li><a href="#" class="disabled" title="Action disabled" data-content="{{ is_disabled }}">{{ action.action_display_name }}</a></li>
                     {% else %}
                     <li><a href="{% conversation_action conversation action.action_name %}">{{ action.action_display_name }}</a></li>
                     {% endif %}
@@ -103,8 +103,8 @@
                 {{ conversation.description }}
             </p>
         </div>
-        
-        
+
+
         <div class="sub-contacts">
             <h4 class="control-label">
                 Contacts
@@ -128,7 +128,6 @@
 
 {% block ondomready %}
 
-    
     $('.content .actions .right .action').on('click', function() {
 
         // confirm if the user wants to perform the action,
@@ -143,5 +142,8 @@
 
         return false;
     });
+
+    $('.content .sub-actions .disabled').popover();
+    $('.content .sub-actions .disabled').on('click', function() { return false; });
 
 {% endblock %}

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import functools
 from StringIO import StringIO
 
 from django.views.generic import View, TemplateView
@@ -287,6 +288,26 @@ class EditConversationView(ConversationTemplateView):
         conversation.save()
 
 
+def check_action_is_enabled(f):
+    """Decorator to check that the action is not disabled.
+
+    Redirections to 'show' conversation with an appropriate message
+    if the action is disabled. Calls the original function otherwise.
+
+    Only wraps functions of the form
+    `f(request, conversation, *args, **kw)`.
+    """
+    @functools.wraps(f)
+    def wrapper(self, request, conversation, *args, **kw):
+        disabled = self.action.is_disabled()
+        if disabled is not None:
+            messages.warning(request, 'Action disabled: %s' % (disabled,))
+            return self.redirect_to(
+                'show', conversation_key=conversation.key)
+        return f(self, request, conversation, *args, **kw)
+    return wrapper
+
+
 class ConversationActionView(ConversationTemplateView):
     """View for performing an arbitrary conversation action.
 
@@ -304,6 +325,7 @@ class ConversationActionView(ConversationTemplateView):
             'action_display_name': self.action.action_display_name,
         })
 
+    @check_action_is_enabled
     def get(self, request, conversation):
         form_cls = self.view_def.get_action_form(self.action.action_name)
         if form_cls is None:
@@ -311,6 +333,7 @@ class ConversationActionView(ConversationTemplateView):
             return self._action_done(request, conversation)
         return self._render_form(request, conversation, form_cls)
 
+    @check_action_is_enabled
     def post(self, request, conversation):
         action_data = {}
         form_cls = self.view_def.get_action_form(self.action.action_name)
@@ -329,12 +352,8 @@ class ConversationActionView(ConversationTemplateView):
 
         return self.perform_action(request, conversation, action_data)
 
+    @check_action_is_enabled
     def perform_action(self, request, conversation, action_data):
-        disabled = self.action.is_disabled()
-        if disabled is not None:
-            messages.warning(request, 'Action disabled: %s' % (disabled,))
-            return self.redirect_to('show', conversation_key=conversation.key)
-
         self.action.perform_action(action_data)
         messages.info(request, 'Action successful: %s!' % (
             self.action.action_display_name,))


### PR DESCRIPTION
Currently actions are checked for being enabled just before being performed (which is  good) but users could do with feedback a little earlier (so they don't fill out forms or get asked for confirmations).
