### PR TITLE
Refactor app view test infrastructure

### DIFF
--- a/go/account/tests.py
+++ b/go/account/tests.py
@@ -191,7 +191,7 @@ class EmailTestCase(VumiGoDjangoTestCase):
         self.contact_store.new_contact(
             name=u'Contact', surname=u'Two', msisdn=u"+27761234567")
 
-        self.put_sample_messages_in_conversation(10, conv, reply=True)
+        self.add_messages_to_conv(5, conv, reply=True)
         # create a second conversation to test sorting
         self.create_conversation()
 
@@ -205,14 +205,14 @@ class EmailTestCase(VumiGoDjangoTestCase):
         self.assertTrue('number of contacts: 2' in email.body)
         self.assertTrue('number of unique contacts by contact number: 1'
                             in email.body)
-        self.assertTrue('number of messages sent: 10' in email.body)
-        self.assertTrue('number of messages received: 10' in email.body)
+        self.assertTrue('number of messages sent: 5' in email.body)
+        self.assertTrue('number of messages received: 5' in email.body)
         self.assertTrue('Group Message' in email.body)
         self.assertTrue('Test Conversation' in email.body)
-        self.assertTrue('Sent: 10 to 10 uniques.' in email.body)
-        self.assertTrue('Received: 10 from 10 uniques.' in email.body)
-        self.assertTrue('"Group Message" Sent: 10' in email.body)
-        self.assertTrue('"Group Message" Received: 10' in email.body)
+        self.assertTrue('Sent: 5 to 5 uniques.' in email.body)
+        self.assertTrue('Received: 5 from 5 uniques.' in email.body)
+        self.assertTrue('"Group Message" Sent: 5' in email.body)
+        self.assertTrue('"Group Message" Received: 5' in email.body)
 
     def test_send_scheduled_account_summary_task(self):
         user_account = self.user_api.get_user_account()

--- a/go/account/tests.py
+++ b/go/account/tests.py
@@ -1,6 +1,5 @@
 import urlparse
 
-from django.test.client import Client
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.core import mail
@@ -13,12 +12,7 @@ from go.account.tasks import send_scheduled_account_summary
 
 
 class AccountTestCase(DjangoGoApplicationTestCase):
-
-    def setUp(self):
-        super(AccountTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def confirm(self, token_url):
         url = urlparse.urlsplit(token_url)
@@ -35,7 +29,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
         token_url = response.context['token_url']
         self.confirm(token_url)
         # reload from db
-        user = User.objects.get(pk=self.user.pk)
+        user = User.objects.get(pk=self.django_user.pk)
         self.assertEqual(user.first_name, 'foo')
         self.assertEqual(user.last_name, 'bar')
         self.assertEqual(user.email, 'foo@bar.com')
@@ -54,7 +48,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
         token_url = response.context['token_url']
         self.confirm(token_url)
         # reload from db
-        user = User.objects.get(pk=self.user.pk)
+        user = User.objects.get(pk=self.django_user.pk)
         self.assertTrue(user.check_password('new_password'))
 
     def test_update_msisdn_valid(self):
@@ -70,8 +64,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
                 })
             token_url = response.context['token_url']
             self.confirm(token_url)
-            profile = User.objects.get(pk=self.user.pk).get_profile()
-            user_account = profile.get_user_account()
+            user_account = self.user_api.get_user_account()
             self.assertEqual(user_account.msisdn, '+27761234567')
 
     def test_update_msisdn_invalid(self):
@@ -88,8 +81,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
             self.assertFormError(response, 'account_form', 'msisdn',
                 'Please provide a valid phone number.')
             self.assertEqual([], mail.outbox)
-            profile = User.objects.get(pk=self.user.pk).get_profile()
-            user_account = profile.get_user_account()
+            user_account = self.user_api.get_user_account()
             self.assertEqual(user_account.msisdn, None)
 
     @staticmethod
@@ -114,8 +106,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
             'Please confirm this change by clicking on the link that was '
             'just sent to your mailbox.' in notifications)
 
-        profile = User.objects.get(pk=self.user.pk).get_profile()
-        user_account = profile.get_user_account()
+        user_account = self.user_api.get_user_account()
         self.assertFalse(user_account.confirm_start_conversation)
 
         [email] = mail.outbox
@@ -125,12 +116,11 @@ class AccountTestCase(DjangoGoApplicationTestCase):
         notifications = self.extract_notification_messages(response)
         self.assertTrue('Your details are being updated' in notifications)
 
-        profile = User.objects.get(pk=self.user.pk).get_profile()
-        user_account = profile.get_user_account()
+        user_account = self.user_api.get_user_account()
         self.assertTrue(user_account.confirm_start_conversation)
 
     def test_email_summary(self):
-        user_account = self.user.get_profile().get_user_account()
+        user_account = self.user_api.get_user_account()
         response = self.client.post(reverse('account:details'), {
             'name': 'foo',
             'surname': 'bar',
@@ -148,7 +138,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
         notifications = self.extract_notification_messages(response)
         self.assertTrue('Your details are being updated' in notifications)
 
-        user_account = self.user.get_profile().get_user_account()
+        user_account = self.user_api.get_user_account()
         self.assertEqual(user_account.email_summary, 'daily')
 
     def test_require_msisdn_if_confirm_start_conversation(self):
@@ -166,13 +156,7 @@ class AccountTestCase(DjangoGoApplicationTestCase):
 
 
 class EmailTestCase(DjangoGoApplicationTestCase):
-
-    def setUp(self):
-        super(EmailTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-        self.declare_longcode_tags()
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def test_email_sending(self):
         response = self.client.post(reverse('account:details'), {
@@ -183,10 +167,12 @@ class EmailTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, reverse('account:details'))
         [email] = mail.outbox
         self.assertEqual(email.subject, 'foo')
-        self.assertEqual(email.from_email, self.user.email)
+        self.assertEqual(email.from_email, self.django_user.email)
         self.assertTrue('bar' in email.body)
 
     def test_daily_account_summary(self):
+        self.setup_conversation(
+            started=True, with_group=True, with_contact=True)
         contact_store = self.user_api.contact_store
         contact_keys = contact_store.list_contacts()
         [contacts] = contact_store.contacts.load_all_bunches(contact_keys)
@@ -194,18 +180,17 @@ class EmailTestCase(DjangoGoApplicationTestCase):
             # create a duplicate
             contact_store.new_contact(msisdn=contact.msisdn)
 
-        self.put_sample_messages_in_conversation(self.user_api,
-                                                    self.conv_key, 10)
+        self.put_sample_messages_in_conversation(10)
         # create a second conversation to test sorting
-        self.mkconversation()
+        self.create_conversation()
 
         # schedule the task
-        send_user_account_summary(self.user)
+        send_user_account_summary(self.django_user)
 
         [email] = mail.outbox
         self.assertEqual(email.subject, 'Vumi Go Account Summary')
         self.assertEqual(email.from_email, settings.DEFAULT_FROM_EMAIL)
-        self.assertEqual(email.recipients(), [self.user.email])
+        self.assertEqual(email.recipients(), [self.django_user.email])
         self.assertTrue('number of contacts: 2' in email.body)
         self.assertTrue('number of unique contacts by contact number: 1'
                             in email.body)
@@ -219,8 +204,7 @@ class EmailTestCase(DjangoGoApplicationTestCase):
         self.assertTrue('"Group Message" Received: 10' in email.body)
 
     def test_send_scheduled_account_summary_task(self):
-        profile = self.user.get_profile()
-        user_account = profile.get_user_account()
+        user_account = self.user_api.get_user_account()
         user_account.email_summary = u'daily'
         user_account.save()
 

--- a/go/account/tests.py
+++ b/go/account/tests.py
@@ -191,7 +191,7 @@ class EmailTestCase(VumiGoDjangoTestCase):
         self.contact_store.new_contact(
             name=u'Contact', surname=u'Two', msisdn=u"+27761234567")
 
-        self.put_sample_messages_in_conversation(10, conv)
+        self.put_sample_messages_in_conversation(10, conv, reply=True)
         # create a second conversation to test sorting
         self.create_conversation()
 

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -1,6 +1,7 @@
 from datetime import date
+from StringIO import StringIO
+from zipfile import ZipFile
 
-from django.test.client import Client
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.utils.unittest import skip
@@ -9,7 +10,6 @@ from vumi.tests.utils import RegexMatcher
 
 from go.vumitools.tests.utils import VumiApiCommand
 from go.vumitools.token_manager import TokenManager
-from go.base.utils import get_conversation_view_definition
 from go.apps.tests.base import DjangoGoApplicationTestCase
 from go.base.tests.utils import FakeMessageStoreClient, FakeMatchResult
 
@@ -19,74 +19,15 @@ from mock import patch
 class BulkMessageTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'bulk_message'
 
-    def setUp(self):
-        super(BulkMessageTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-
-    def get_view_url(self, view, conv_key=None):
-        if conv_key is None:
-            conv_key = self.conv_key
-        view_def = get_conversation_view_definition(
-            self.TEST_CONVERSATION_TYPE)
-        return view_def.get_view_url(view, conversation_key=conv_key)
-
-    def get_new_view_url(self):
-        return reverse('conversations:new_conversation')
-
-    def get_action_view_url(self, action_name, conv_key=None):
-        if conv_key is None:
-            conv_key = self.conv_key
-        return reverse('conversations:conversation_action', kwargs={
-            'conversation_key': conv_key, 'action_name': action_name})
-
-    def get_wrapped_conv(self):
-        conv = self.conv_store.get_conversation_by_key(self.conv_key)
-        return self.user_api.wrap_conversation(conv)
-
-    def prepare_conversation(self, start=True, group=True):
-        if start:
-            resp = self.client.post(self.get_view_url('start'), follow=True)
-            [msg] = resp.context['messages']
-            self.assertEqual(str(msg), "Conversation started")
-            self.assertEqual(1, len(self.get_api_commands_sent()))
-
-        conv = self.get_wrapped_conv()
-
-        if not group:
-            conv.groups.remove_key(self.group.key)
-        if start:
-            conv.set_status_started()
-
-        conv.save()
-        return conv
-
-    def run_new_conversation(self, selected_option, pool, tag):
-        self.assertEqual(len(self.conv_store.list_conversations()), 1)
+    def test_new_conversation(self):
+        self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
-        self.assertEqual(len(self.conv_store.list_conversations()), 2)
+        self.assertEqual(len(self.conv_store.list_conversations()), 1)
         conv = self.get_latest_conversation()
         self.assertRedirects(response, self.get_view_url('show', conv.key))
 
-    def test_new_conversation(self):
-        """test the creation of a new conversation"""
-        self.run_new_conversation('longcode:', 'longcode', None)
-
-    def test_new_conversation_with_user_selected_tags(self):
-        tp_meta = self.api.tpm.get_metadata('longcode')
-        tp_meta['user_selects_tag'] = True
-        self.api.tpm.set_metadata(u'longcode', tp_meta)
-        self.run_new_conversation(u'longcode:default10001', u'longcode',
-                                  u'default10001')
-
     def test_stop(self):
-        """
-        Test ending the conversation
-        """
-        conversation = self.get_wrapped_conv()
-        conversation.set_status_started()
-        conversation.save()
+        self.setup_conversation(started=True)
         response = self.client.post(self.get_view_url('stop'), follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
         [msg] = response.context['messages']
@@ -106,7 +47,27 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         """
         Test the start conversation view
         """
+        self.setup_conversation(started=True)
+
+        response = self.client.post(self.get_view_url('start'))
+        self.assertRedirects(response, self.get_view_url('show'))
+
         conversation = self.get_wrapped_conv()
+        [batch] = conversation.get_batches()
+        self.assertEqual([], list(batch.tags))
+
+        [start_cmd] = self.get_api_commands_sent()
+        self.assertEqual(start_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,), 'start',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key))
+
+    def test_start_with_group(self):
+        """
+        Test the start conversation view
+        """
+        self.setup_conversation(
+            started=True, with_group=True, with_contact=True)
 
         response = self.client.post(self.get_view_url('start'))
         self.assertRedirects(response, self.get_view_url('show'))
@@ -122,10 +83,22 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key))
 
-    def test_show(self):
+    def test_show_stopped(self):
         """
         Test showing the conversation
         """
+        self.setup_conversation()
+        response = self.client.get(self.get_view_url('show'))
+        conversation = response.context[0].get('conversation')
+        self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
+        self.assertContains(response, 'Send Bulk Message')
+        self.assertContains(response, self.get_action_view_url('bulk_send'))
+
+    def test_show_running(self):
+        """
+        Test showing the conversation
+        """
+        self.setup_conversation(started=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
@@ -219,9 +192,9 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             len(response2.context['message_page'].object_list), 10)
 
     def test_aggregates(self):
+        self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
-            time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12)
         response = self.client.get(self.get_view_url('aggregates'),
                                    {'direction': 'inbound'})
         self.assertEqual(response.content, '\r\n'.join([
@@ -234,24 +207,27 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             ]))
 
     def test_export_messages(self):
+        self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
-            time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12)
         response = self.client.post(self.get_view_url('show'), {
             '_export_conversation_messages': True,
         })
         self.assertRedirects(response, self.get_view_url('show'))
         [email] = mail.outbox
-        self.assertEqual(email.recipients(), [self.user.email])
+        self.assertEqual(email.recipients(), [self.django_user.email])
         self.assertTrue(self.conversation.name in email.subject)
         self.assertTrue(self.conversation.name in email.body)
-        [(file_name, content, mime_type)] = email.attachments
+        [(file_name, zipcontent, mime_type)] = email.attachments
         self.assertEqual(file_name, 'messages-export.zip')
+        zipfile = ZipFile(StringIO(zipcontent), 'r')
+        content = zipfile.open('messages-export.csv', 'r').read()
         # 1 header, 10 sent, 10 received, 1 trailing newline == 22
         self.assertEqual(22, len(content.split('\n')))
         self.assertEqual(mime_type, 'application/zip')
 
     def test_action_bulk_send_view(self):
+        self.setup_conversation()
         response = self.client.get(self.get_action_view_url('bulk_send'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
@@ -260,7 +236,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertContains(response, '<h1>Send Bulk Message</h1>')
 
     def test_action_bulk_send_no_group(self):
-        self.prepare_conversation(group=False)
+        self.setup_conversation(started=True)
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': True},
@@ -272,7 +248,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual([], self.get_api_commands_sent())
 
     def test_action_bulk_send_not_running(self):
-        self.prepare_conversation(start=False)
+        self.setup_conversation(with_group=True)
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': True},
@@ -285,50 +261,38 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual([], self.get_api_commands_sent())
 
     def test_action_bulk_send_dedupe(self):
-        self.prepare_conversation()
+        self.setup_conversation(started=True, with_group=True)
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': True})
         self.assertRedirects(response, self.get_view_url('show'))
         [bulk_send_cmd] = self.get_api_commands_sent()
-        conversation = self.user_api.get_wrapped_conversation(self.conv_key)
+        conversation = self.get_wrapped_conv()
         self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
             'bulk_send',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.get_batches()[0].key, msg_options={},
+            batch_id=conversation.get_latest_batch_key(), msg_options={},
             delivery_class=conversation.delivery_class,
             content='I am ham, not spam.', dedupe=True))
 
     def test_action_bulk_send_no_dedupe(self):
-        self.prepare_conversation()
+        self.setup_conversation(started=True, with_group=True)
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': False})
         self.assertRedirects(response, self.get_view_url('show'))
         [bulk_send_cmd] = self.get_api_commands_sent()
-        conversation = self.user_api.get_wrapped_conversation(self.conv_key)
+        conversation = self.get_wrapped_conv()
         self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
             'bulk_send',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.get_batches()[0].key, msg_options={},
+            batch_id=conversation.get_latest_batch_key(), msg_options={},
             delivery_class=conversation.delivery_class,
             content='I am ham, not spam.', dedupe=False))
-
-    @skip("The new views don't handle this kind of thing very well yet.")
-    def test_action_bulk_send_fails(self):
-        """
-        Test failure to send messages
-        """
-        self.acquire_all_longcode_tags()
-        response = self.client.post(self.get_view_url('start'), follow=True)
-        self.assertRedirects(response, self.get_view_url('start'))
-        [] = self.get_api_commands_sent()
-        [msg] = response.context['messages']
-        self.assertEqual(str(msg), "No spare messaging tags.")
 
     def test_action_bulk_send_confirm(self):
         """
@@ -336,14 +300,13 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         """
         # TODO: Break this test into smaller bits and move them to a more
         #       appropriate module.
-        profile = self.user.get_profile()
-        account = profile.get_user_account()
-        account.msisdn = u'+27761234567'
-        account.confirm_start_conversation = True
-        account.save()
+        user_account = self.user_api.get_user_account()
+        user_account.msisdn = u'+27761234567'
+        user_account.confirm_start_conversation = True
+        user_account.save()
 
         # Start the conversation
-        self.prepare_conversation()
+        self.setup_conversation(started=True, with_group=True)
 
         # POST the action with a mock token manager
         with patch.object(TokenManager, 'generate_token') as mock_method:
@@ -355,7 +318,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
 
         # Check that we get a confirmation message
         [token_send_cmd] = self.get_api_commands_sent()
-        conversation = self.user_api.get_wrapped_conversation(self.conv_key)
+        conversation = self.get_wrapped_conv()
         self.assertEqual(
             VumiApiCommand.command(
                 '%s_application' % (conversation.conversation_type,),
@@ -363,7 +326,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 command_data=dict(
-                    batch_id=conversation.get_batches()[0].key,
+                    batch_id=conversation.get_latest_batch_key(),
                     to_addr=u'+27761234567', msg_options={
                         'helper_metadata': {'go': {'sensitive': True}},
                     },
@@ -391,29 +354,9 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'bulk_send',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.get_batches()[0].key, msg_options={},
+            batch_id=conversation.get_latest_batch_key(), msg_options={},
             delivery_class=conversation.delivery_class,
             content='I am ham, not spam.', dedupe=True))
-
-
-class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
-
-    def setUp(self):
-        super(SendOneOffReplyTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-
-    def get_view_url(self, view, conv_key=None):
-        if conv_key is None:
-            conv_key = self.conv_key
-        view_def = get_conversation_view_definition(
-            self.TEST_CONVERSATION_TYPE)
-        return view_def.get_view_url(view, conversation_key=conv_key)
-
-    def get_wrapped_conv(self):
-        conv = self.conv_store.get_conversation_by_key(self.conv_key)
-        return self.user_api.wrap_conversation(conv)
 
     @skip("The new views don't have this.")
     def test_actions_on_inbound_only(self):
@@ -432,8 +375,8 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
         self.assertNotContains(response, 'Reply')
 
     def test_send_one_off_reply(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-                                                 self.conv_key, 1)
+        self.setup_conversation(started=True, with_group=True)
+        self.put_sample_messages_in_conversation(1)
         conversation = self.get_wrapped_conv()
         [msg] = conversation.received_messages()
         response = self.client.post(self.get_view_url('show'), {
@@ -444,10 +387,7 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
         })
         self.assertRedirects(response, self.get_view_url('show'))
 
-        [start_cmd, hack_cmd, reply_to_cmd] = self.get_api_commands_sent()
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = msg['message_id']
+        [reply_to_cmd] = self.get_api_commands_sent()
         self.assertEqual(reply_to_cmd['worker_name'],
                             'bulk_message_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
@@ -459,5 +399,5 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],
-            'msg_options': msg_options,
-            })
+            'msg_options': {'in_reply_to': msg['message_id']},
+        })

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -209,7 +209,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
     def test_export_messages(self):
         self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
         response = self.client.post(self.get_view_url('show'), {
             '_export_conversation_messages': True,
         })

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -92,13 +92,13 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
         self.assertContains(response, 'Send Bulk Message')
-        self.assertContains(response, self.get_action_view_url('bulk_send'))
+        self.assertNotContains(response, self.get_action_view_url('bulk_send'))
 
     def test_show_running(self):
         """
         Test showing the conversation
         """
-        self.setup_conversation(started=True)
+        self.setup_conversation(started=True, with_group=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
@@ -225,7 +225,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(mime_type, 'application/zip')
 
     def test_action_bulk_send_view(self):
-        self.setup_conversation()
+        self.setup_conversation(started=True, with_group=True)
         response = self.client.get(self.get_action_view_url('bulk_send'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -193,14 +193,12 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
 
     def test_aggregates(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12)
+        self.add_messages_to_conv(
+            5, start_date=date(2012, 1, 1), time_multiplier=12)
         response = self.client.get(self.get_view_url('aggregates'),
                                    {'direction': 'inbound'})
         self.assertEqual(response.content, '\r\n'.join([
-            '2011-12-28,2',
-            '2011-12-29,2',
-            '2011-12-30,2',
+            '2011-12-30,1',
             '2011-12-31,2',
             '2012-01-01,2',
             '',  # csv ends with a blank line
@@ -208,8 +206,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
 
     def test_export_messages(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
+        self.add_messages_to_conv(
+            5, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
         response = self.client.post(self.get_view_url('show'), {
             '_export_conversation_messages': True,
         })
@@ -222,8 +220,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(file_name, 'messages-export.zip')
         zipfile = ZipFile(StringIO(zipcontent), 'r')
         content = zipfile.open('messages-export.csv', 'r').read()
-        # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(content.split('\n')))
+        # 1 header, 5 sent, 5 received, 1 trailing newline == 12
+        self.assertEqual(12, len(content.split('\n')))
         self.assertEqual(mime_type, 'application/zip')
 
     def test_action_bulk_send_view(self):
@@ -376,7 +374,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
 
     def test_send_one_off_reply(self):
         self.setup_conversation(started=True, with_group=True)
-        self.put_sample_messages_in_conversation(1)
+        self.add_messages_to_conv(1)
         conversation = self.get_wrapped_conv()
         [msg] = conversation.received_messages()
         response = self.client.post(self.get_view_url('show'), {

--- a/go/apps/http_api/tests/test_views.py
+++ b/go/apps/http_api/tests/test_views.py
@@ -1,34 +1,13 @@
-from django.test.client import Client
-from django.core.urlresolvers import reverse
-
 from go.apps.tests.base import DjangoGoApplicationTestCase
-from go.base.utils import get_conversation_view_definition
 
 
 class HttpApiTestCase(DjangoGoApplicationTestCase):
-
     TEST_CONVERSATION_TYPE = u'http_api'
 
-    def setUp(self):
-        super(HttpApiTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-
-    def get_view_url(self, view, conv_key=None):
-        if conv_key is None:
-            conv_key = self.conv_key
-        view_def = get_conversation_view_definition(
-            self.TEST_CONVERSATION_TYPE)
-        return view_def.get_view_url(view, conversation_key=conv_key)
-
-    def get_new_view_url(self):
-        return reverse('conversations:new_conversation')
-
     def test_new_conversation(self):
-        self.assertEqual(len(self.conv_store.list_conversations()), 1)
+        self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
-        self.assertEqual(len(self.conv_store.list_conversations()), 2)
+        self.assertEqual(len(self.conv_store.list_conversations()), 1)
         conversation = self.get_latest_conversation()
         self.assertEqual(conversation.name, 'conversation name')
         self.assertEqual(conversation.description, '')
@@ -36,8 +15,20 @@ class HttpApiTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(
             response, self.get_view_url('show', conversation.key))
 
-    def test_show_conversation(self):
-        # render the form
-        [conversation_key] = self.conv_store.list_conversations()
+    def test_show_stopped(self):
+        """
+        Test showing the conversation
+        """
+        self.setup_conversation()
         response = self.client.get(self.get_view_url('show'))
-        self.assertEqual(response.status_code, 200)
+        conversation = response.context[0].get('conversation')
+        self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
+
+    def test_show_running(self):
+        """
+        Test showing the conversation
+        """
+        self.setup_conversation(started=True)
+        response = self.client.get(self.get_view_url('show'))
+        conversation = response.context[0].get('conversation')
+        self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -1,14 +1,12 @@
 from datetime import date
 from zipfile import ZipFile
 from StringIO import StringIO
-import uuid
 
 from django.core.urlresolvers import reverse
 from django.core import mail
 
 from go.vumitools.tests.utils import VumiApiCommand
 from go.apps.tests.base import DjangoGoApplicationTestCase
-from go.base.tests.utils import declare_longcode_tags
 
 
 class MultiSurveyTestCase(DjangoGoApplicationTestCase):
@@ -20,7 +18,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             VXPOLLS_REDIS_CONFIG=self._persist_config['redis_manager'])
 
     def add_tagpool_to_conv(self):
-        declare_longcode_tags(self.api)
+        self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         conv = self.get_wrapped_conv()
         conv.c.delivery_class = u'sms'
@@ -232,7 +230,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         self.client.post(reverse('multi_survey:start', kwargs={
             'conversation_key': self.conv_key}))
 
-        self.put_sample_messages_in_conversation(1)
+        print self.put_sample_messages_in_conversation(1)
         conversation = self.get_wrapped_conv()
         [msg] = conversation.received_messages()
         response = self.client.post(reverse('multi_survey:show', kwargs={

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -185,15 +185,13 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_aggregates(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12)
+        self.add_messages_to_conv(
+            5, start_date=date(2012, 1, 1), time_multiplier=12)
         response = self.client.get(reverse('multi_survey:aggregates', kwargs={
             'conversation_key': self.conv_key
             }), {'direction': 'inbound'})
         self.assertEqual(response.content, '\r\n'.join([
-            '2011-12-28,2',
-            '2011-12-29,2',
-            '2011-12-30,2',
+            '2011-12-30,1',
             '2011-12-31,2',
             '2012-01-01,2',
             '',  # csv ends with a blank line
@@ -201,8 +199,8 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_export_messages(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
+        self.add_messages_to_conv(
+            5, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
         conv_url = reverse('multi_survey:show', kwargs={
             'conversation_key': self.conv_key,
             })
@@ -220,8 +218,8 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         zipfile = ZipFile(StringIO(contents), 'r')
         csv_contents = zipfile.open('messages-export.csv', 'r').read()
 
-        # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(csv_contents.split('\n')))
+        # 1 header, 5 sent, 5 received, 1 trailing newline == 12
+        self.assertEqual(12, len(csv_contents.split('\n')))
         self.assertEqual(mime_type, 'application/zip')
 
     def test_send_one_off_reply(self):
@@ -230,7 +228,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         self.client.post(reverse('multi_survey:start', kwargs={
             'conversation_key': self.conv_key}))
 
-        print self.put_sample_messages_in_conversation(1)
+        self.add_messages_to_conv(1)
         conversation = self.get_wrapped_conv()
         [msg] = conversation.received_messages()
         response = self.client.post(reverse('multi_survey:show', kwargs={

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -1,34 +1,39 @@
 from datetime import date
 from zipfile import ZipFile
 from StringIO import StringIO
+import uuid
 
-from django.test.client import Client
 from django.core.urlresolvers import reverse
 from django.core import mail
 
 from go.vumitools.tests.utils import VumiApiCommand
 from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import declare_longcode_tags
 
 
 class MultiSurveyTestCase(DjangoGoApplicationTestCase):
-
     TEST_CONVERSATION_TYPE = u'multi_survey'
 
     def setUp(self):
         super(MultiSurveyTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
         self.patch_settings(
             VXPOLLS_REDIS_CONFIG=self._persist_config['redis_manager'])
 
-    def get_wrapped_conv(self):
-        conv = self.conv_store.get_conversation_by_key(self.conv_key)
-        return self.user_api.wrap_conversation(conv)
+    def add_tagpool_to_conv(self):
+        declare_longcode_tags(self.api)
+        self.add_tagpool_permission(u'longcode')
+        conv = self.get_wrapped_conv()
+        conv.c.delivery_class = u'sms'
+        conv.c.delivery_tag_pool = u'longcode'
+        conv.save()
+
+    def acquire_all_longcode_tags(self):
+        for _i in range(4):
+            self.user_api.acquire_tag(u"longcode")
 
     def run_new_conversation(self, selected_option, pool, tag):
         # render the form
-        self.assertEqual(len(self.conv_store.list_conversations()), 1)
+        self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.client.get(reverse('multi_survey:new'))
         self.assertEqual(response.status_code, 200)
         # post the form
@@ -38,7 +43,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             'delivery_class': 'sms',
             'delivery_tag_pool': selected_option,
         })
-        self.assertEqual(len(self.conv_store.list_conversations()), 2)
+        self.assertEqual(len(self.conv_store.list_conversations()), 1)
         conversation = self.get_latest_conversation()
         self.assertEqual(conversation.delivery_class, 'sms')
         self.assertEqual(conversation.delivery_tag_pool, pool)
@@ -62,6 +67,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         """
         Test ending the conversation
         """
+        self.setup_conversation()
         conversation = self.get_wrapped_conv()
         self.assertFalse(conversation.ended())
         response = self.client.post(reverse('multi_survey:end', kwargs={
@@ -76,6 +82,8 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
     def test_client_or_server_init_distinction(self):
         """A survey should not ask for recipients if the transport
         used only supports client initiated sessions (i.e. USSD)"""
+
+        self.setup_conversation()
 
         self.api.tpm.set_metadata("pool1", {
             "delivery_class": "sms",
@@ -100,6 +108,8 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
     def test_group_selection(self):
         """Select an existing group and use that as the group for the
         conversation"""
+        self.setup_conversation(with_group=True, with_contact=True)
+        self.add_tagpool_to_conv()
         conversation = self.get_wrapped_conv()
         self.assertFalse(conversation.is_client_initiated())
         response = self.client.post(reverse('multi_survey:people',
@@ -112,8 +122,12 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         """
         Test the start conversation view
         """
+        self.setup_conversation(with_group=True, with_contact=True)
+        self.add_tagpool_to_conv()
+
         response = self.client.post(reverse('multi_survey:start', kwargs={
             'conversation_key': self.conv_key}))
+        print repr(response.content)
         self.assertRedirects(response, reverse('multi_survey:show', kwargs={
             'conversation_key': self.conv_key}))
 
@@ -149,7 +163,10 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         """
         Test failure to send messages
         """
+        self.setup_conversation(with_group=True, with_contact=True)
+        self.add_tagpool_to_conv()
         self.acquire_all_longcode_tags()
+
         response = self.client.post(reverse('multi_survey:start', kwargs={
             'conversation_key': self.conv_key}), follow=True)
         self.assertRedirects(response, reverse('multi_survey:start', kwargs={
@@ -162,15 +179,16 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         """
         Test showing the conversation
         """
+        self.setup_conversation()
         response = self.client.get(reverse('multi_survey:show', kwargs={
             'conversation_key': self.conv_key}))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, 'Test Conversation')
 
     def test_aggregates(self):
+        self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
-            time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12)
         response = self.client.get(reverse('multi_survey:aggregates', kwargs={
             'conversation_key': self.conv_key
             }), {'direction': 'inbound'})
@@ -184,9 +202,9 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             ]))
 
     def test_export_messages(self):
+        self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            self.user_api, self.conv_key, 10, start_date=date(2012, 1, 1),
-            time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12)
         conv_url = reverse('multi_survey:show', kwargs={
             'conversation_key': self.conv_key,
             })
@@ -195,7 +213,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             })
         self.assertRedirects(response, conv_url)
         [email] = mail.outbox
-        self.assertEqual(email.recipients(), [self.user.email])
+        self.assertEqual(email.recipients(), [self.django_user.email])
         self.assertTrue(self.conversation.name in email.subject)
         self.assertTrue(self.conversation.name in email.body)
         [(file_name, contents, mime_type)] = email.attachments
@@ -209,8 +227,12 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(mime_type, 'application/zip')
 
     def test_send_one_off_reply(self):
-        self.put_sample_messages_in_conversation(self.user_api,
-                                                    self.conv_key, 1)
+        self.setup_conversation(with_group=True, with_contact=True)
+        self.add_tagpool_to_conv()
+        self.client.post(reverse('multi_survey:start', kwargs={
+            'conversation_key': self.conv_key}))
+
+        self.put_sample_messages_in_conversation(1)
         conversation = self.get_wrapped_conv()
         [msg] = conversation.received_messages()
         response = self.client.post(reverse('multi_survey:show', kwargs={

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -125,7 +125,6 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
 
         response = self.client.post(reverse('multi_survey:start', kwargs={
             'conversation_key': self.conv_key}))
-        print repr(response.content)
         self.assertRedirects(response, reverse('multi_survey:show', kwargs={
             'conversation_key': self.conv_key}))
 

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -202,7 +202,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
     def test_export_messages(self):
         self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
         conv_url = reverse('multi_survey:show', kwargs={
             'conversation_key': self.conv_key,
             })

--- a/go/apps/sequential_send/tests/test_views.py
+++ b/go/apps/sequential_send/tests/test_views.py
@@ -1,52 +1,19 @@
-from django.test.client import Client
-from django.core.urlresolvers import reverse
-
 from go.vumitools.tests.utils import VumiApiCommand
 from go.apps.tests.base import DjangoGoApplicationTestCase
-from go.base.utils import get_conversation_view_definition
 
 
 class SequentialSendTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'sequential_send'
 
-    def setUp(self):
-        super(SequentialSendTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-
-    def get_view_url(self, view, conv_key=None):
-        if conv_key is None:
-            conv_key = self.conv_key
-        view_def = get_conversation_view_definition(
-            self.TEST_CONVERSATION_TYPE)
-        return view_def.get_view_url(view, conversation_key=conv_key)
-
-    def get_new_view_url(self):
-        return reverse('conversations:new_conversation')
-
-    def get_wrapped_conv(self):
-        conv = self.conv_store.get_conversation_by_key(self.conv_key)
-        return self.user_api.wrap_conversation(conv)
-
-    def run_new_conversation(self):
-        self.assertEqual(len(self.conv_store.list_conversations()), 1)
+    def test_new_conversation(self):
+        self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
-        self.assertEqual(len(self.conv_store.list_conversations()), 2)
+        self.assertEqual(len(self.conv_store.list_conversations()), 1)
         conv = self.get_latest_conversation()
         self.assertRedirects(response, self.get_view_url('edit', conv.key))
 
-    def test_new_conversation(self):
-        """test the creation of a new conversation"""
-        self.run_new_conversation()
-
     def test_stop(self):
-        """
-        Test ending the conversation
-        """
-        conversation = self.get_wrapped_conv()
-        conversation.set_status_started()
-        conversation.save()
+        self.setup_conversation(started=True)
         response = self.client.post(self.get_view_url('stop'), follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
         [msg] = response.context['messages']
@@ -58,7 +25,26 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
         """
         Test the start conversation view
         """
+        self.setup_conversation()
+
+        response = self.client.post(self.get_view_url('start'))
+        self.assertRedirects(response, self.get_view_url('show'))
+
         conversation = self.get_wrapped_conv()
+        [batch] = conversation.get_batches()
+        self.assertEqual([], list(batch.tags))
+
+        [start_cmd] = self.get_api_commands_sent()
+        self.assertEqual(start_cmd, VumiApiCommand.command(
+                '%s_application' % (conversation.conversation_type,), 'start',
+                user_account_key=conversation.user_account.key,
+                conversation_key=conversation.key))
+
+    def test_start_with_group(self):
+        """
+        Test the start conversation view
+        """
+        self.setup_conversation(with_group=True, with_contact=True)
 
         response = self.client.post(self.get_view_url('start'))
         self.assertRedirects(response, self.get_view_url('show'))
@@ -74,15 +60,26 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key))
 
-    def test_show(self):
+    def test_show_stopped(self):
         """
         Test showing the conversation
         """
+        self.setup_conversation()
+        response = self.client.get(self.get_view_url('show'))
+        conversation = response.context[0].get('conversation')
+        self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
+
+    def test_show_running(self):
+        """
+        Test showing the conversation
+        """
+        self.setup_conversation(started=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
 
     def test_edit_conversation_schedule_config(self):
+        self.setup_conversation()
         conversation = self.get_wrapped_conv()
         self.assertEqual(conversation.config, {})
         response = self.client.post(self.get_view_url('edit'), {

--- a/go/apps/subscription/tests/test_views.py
+++ b/go/apps/subscription/tests/test_views.py
@@ -1,59 +1,19 @@
-from django.test.client import Client
-from django.core.urlresolvers import reverse
-
 from go.vumitools.tests.utils import VumiApiCommand
 from go.apps.tests.base import DjangoGoApplicationTestCase
-from go.base.utils import get_conversation_view_definition
 
 
 class SubscriptionTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'subscription'
 
-    def setUp(self):
-        super(SubscriptionTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-
-    def get_view_url(self, view, conv_key=None):
-        if conv_key is None:
-            conv_key = self.conv_key
-        view_def = get_conversation_view_definition(
-            self.TEST_CONVERSATION_TYPE)
-        return view_def.get_view_url(view, conversation_key=conv_key)
-
-    def get_new_view_url(self):
-        return reverse('conversations:new_conversation')
-
-    def get_wrapped_conv(self):
-        conv = self.conv_store.get_conversation_by_key(self.conv_key)
-        return self.user_api.wrap_conversation(conv)
-
-    def run_new_conversation(self, selected_option, pool, tag):
-        self.assertEqual(len(self.conv_store.list_conversations()), 1)
+    def test_new_conversation(self):
+        self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
-        self.assertEqual(len(self.conv_store.list_conversations()), 2)
+        self.assertEqual(len(self.conv_store.list_conversations()), 1)
         conv = self.get_latest_conversation()
         self.assertRedirects(response, self.get_view_url('edit', conv.key))
 
-    def test_new_conversation(self):
-        """test the creation of a new conversation"""
-        self.run_new_conversation('longcode:', 'longcode', None)
-
-    def test_new_conversation_with_user_selected_tags(self):
-        tp_meta = self.api.tpm.get_metadata('longcode')
-        tp_meta['user_selects_tag'] = True
-        self.api.tpm.set_metadata('longcode', tp_meta)
-        self.run_new_conversation('longcode:default10001', 'longcode',
-                                  'default10001')
-
     def test_stop(self):
-        """
-        Test ending the conversation
-        """
-        conversation = self.get_wrapped_conv()
-        conversation.set_status_started()
-        conversation.save()
+        self.setup_conversation(started=True)
         response = self.client.post(self.get_view_url('stop'), follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
         [msg] = response.context['messages']
@@ -65,7 +25,7 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
         """
         Test the start conversation view
         """
-        conversation = self.get_wrapped_conv()
+        self.setup_conversation()
 
         response = self.client.post(self.get_view_url('start'))
         self.assertRedirects(response, self.get_view_url('show'))
@@ -73,7 +33,6 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
         conversation = self.get_wrapped_conv()
         [batch] = conversation.get_batches()
         self.assertEqual([], list(batch.tags))
-        [contact] = self.get_contacts_for_conversation(conversation)
 
         [start_cmd] = self.get_api_commands_sent()
         self.assertEqual(start_cmd, VumiApiCommand.command(
@@ -81,10 +40,20 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key))
 
-    def test_show(self):
+    def test_show_stopped(self):
         """
         Test showing the conversation
         """
+        self.setup_conversation()
+        response = self.client.get(self.get_view_url('show'))
+        conversation = response.context[0].get('conversation')
+        self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
+
+    def test_show_running(self):
+        """
+        Test showing the conversation
+        """
+        self.setup_conversation(started=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -226,14 +226,12 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_aggregates(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12)
+        self.add_messages_to_conv(
+            5, start_date=date(2012, 1, 1), time_multiplier=12)
         response = self.client.get(self.get_view_url('aggregates'),
                                    {'direction': 'inbound'})
         self.assertEqual(response.content, '\r\n'.join([
-            '2011-12-28,2',
-            '2011-12-29,2',
-            '2011-12-30,2',
+            '2011-12-30,1',
             '2011-12-31,2',
             '2012-01-01,2',
             '',  # csv ends with a blank line
@@ -241,8 +239,8 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_export_messages(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
+        self.add_messages_to_conv(
+            5, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
         response = self.client.post(self.get_view_url('show'), {
             '_export_conversation_messages': True,
         })
@@ -257,8 +255,8 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         zipfile = ZipFile(StringIO(contents), 'r')
         csv_contents = zipfile.open('messages-export.csv', 'r').read()
 
-        # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(csv_contents.split('\n')))
+        # 1 header, 5 sent, 5 received, 1 trailing newline == 12
+        self.assertEqual(12, len(csv_contents.split('\n')))
         self.assertEqual(mime_type, 'application/zip')
 
     @skip("The new views don't have this.")
@@ -317,7 +315,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_send_one_off_reply(self):
         self.setup_conversation(started=True)
-        self.put_sample_messages_in_conversation(1)
+        self.add_messages_to_conv(1)
         conversation = self.get_wrapped_conv()
         [msg] = conversation.received_messages()
         response = self.client.post(self.get_view_url('show'), {

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -242,7 +242,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
     def test_export_messages(self):
         self.setup_conversation(started=True)
         self.put_sample_messages_in_conversation(
-            10, start_date=date(2012, 1, 1), time_multiplier=12)
+            10, start_date=date(2012, 1, 1), time_multiplier=12, reply=True)
         response = self.client.post(self.get_view_url('show'), {
             '_export_conversation_messages': True,
         })

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -45,7 +45,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertTrue(conversation.stopping())
 
     def test_action_send_survey_get(self):
-        self.setup_conversation()
+        self.setup_conversation(started=True, with_group=True)
         response = self.client.get(self.get_action_view_url('send_survey'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
@@ -143,13 +143,14 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, 'Test Conversation')
-        self.assertContains(response, self.get_action_view_url('send_survey'))
+        self.assertNotContains(
+            response, self.get_action_view_url('send_survey'))
 
     def test_show_running(self):
         """
         Test showing the conversation
         """
-        self.setup_conversation(started=True)
+        self.setup_conversation(started=True, with_group=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, 'Test Conversation')

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -211,10 +211,8 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
             conv_key = self.conv_key
         return self.user_api.get_wrapped_conversation(conv_key)
 
-    def put_sample_messages_in_conversation(self, message_count,
-                                            conversation=None, **kwargs):
+    def add_messages_to_conv(self, message_count, conversation=None, **kwargs):
         if conversation is None:
             conversation = self.get_wrapped_conv()
-        return super(DjangoGoApplicationTestCase,
-                     self).put_sample_messages_in_conversation(
-                         message_count, conversation, **kwargs)
+        return super(DjangoGoApplicationTestCase, self).add_messages_to_conv(
+            message_count, conversation, **kwargs)

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -24,27 +24,11 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
     transport_name = 'sphex'
     transport_type = 'sms'
 
-    # Set these to None so we can see if we've created them.
-    group = None
-    contact = None
-
     def setUp(self):
         super(DjangoGoApplicationTestCase, self).setUp()
         self.setup_api()
         self.setup_user_api()
         self.setup_client()
-
-    def _create_group(self, with_contact=False):
-        self.group = self.contact_store.new_group(self.TEST_GROUP_NAME)
-        self.group_key = self.group.key
-        if with_contact and self.contact is None:
-            self._create_contact()
-
-    def _create_contact(self):
-        self.contact = self.contact_store.new_contact(
-            name=self.TEST_CONTACT_NAME, surname=self.TEST_CONTACT_SURNAME,
-            msisdn=u"+27761234567", groups=[self.group])
-        self.contact_key = self.contact.key
 
     def setup_conversation(self, started=False, with_group=False,
                            with_contact=False):
@@ -55,9 +39,13 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
             'config': {},
         }
         if with_group:
-            if self.group is None:
-                self._create_group(with_contact)
+            self.group = self.contact_store.new_group(self.TEST_GROUP_NAME)
             params['groups'] = [self.group]
+            if with_contact:
+                self.contact = self.contact_store.new_contact(
+                    msisdn=u"+27761234567", name=self.TEST_CONTACT_NAME,
+                    surname=self.TEST_CONTACT_SURNAME, groups=[self.group])
+
         if self.TEST_CONVERSATION_PARAMS:
             params.update(self.TEST_CONVERSATION_PARAMS)
         self.conversation = self.create_conversation(started=started, **params)

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -212,12 +212,9 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
         return self.user_api.get_wrapped_conversation(conv_key)
 
     def put_sample_messages_in_conversation(self, message_count,
-                                            conversation=None,
-                                            start_date=None,
-                                            time_multiplier=10):
+                                            conversation=None, **kwargs):
         if conversation is None:
             conversation = self.get_wrapped_conv()
         return super(DjangoGoApplicationTestCase,
                      self).put_sample_messages_in_conversation(
-                         message_count, conversation, start_date=start_date,
-                         time_multiplier=time_multiplier)
+                         message_count, conversation, **kwargs)

--- a/go/base/tests/test_base.py
+++ b/go/base/tests/test_base.py
@@ -12,6 +12,8 @@ from go.vumitools.api import VumiApi, VumiUserApi
 
 class AuthenticationTestCase(VumiGoDjangoTestCase):
 
+    use_riak = True
+
     def setUp(self):
         super(AuthenticationTestCase, self).setUp()
         self.setup_api()

--- a/go/base/tests/test_go_account_stats.py
+++ b/go/base/tests/test_go_account_stats.py
@@ -56,8 +56,7 @@ class GoAccountStatsCommandTestCase(VumiGoDjangoTestCase):
 
     def test_stats(self):
         conv = self.create_conversation(started=True, name=u'active')
-        self.put_sample_messages_in_conversation(
-            5, conv, reply=True, time_multiplier=0)
+        self.add_messages_to_conv(5, conv, reply=True, time_multiplier=0)
 
         self.command.handle(self.django_user.username, 'stats', conv.key)
         output = self.command.stdout.getvalue().strip().split('\n')

--- a/go/base/tests/test_go_create_user.py
+++ b/go/base/tests/test_go_create_user.py
@@ -5,7 +5,7 @@ from go.base.management.commands import go_create_user
 
 class GoCreateUserCommandTestCase(VumiGoDjangoTestCase):
 
-    USE_RIAK = True
+    use_riak = True
 
     def test_user_creation(self):
         self.setup_api()

--- a/go/base/tests/test_go_import_contacts.py
+++ b/go/base/tests/test_go_import_contacts.py
@@ -10,7 +10,7 @@ from go.base.utils import vumi_api_for_user
 
 class GoImportContactsCommandTestCase(VumiGoDjangoTestCase):
 
-    USE_RIAK = True
+    use_riak = True
 
     def setUp(self):
         super(GoImportContactsCommandTestCase, self).setUp()

--- a/go/base/tests/test_go_list_accounts.py
+++ b/go/base/tests/test_go_list_accounts.py
@@ -6,7 +6,7 @@ from StringIO import StringIO
 
 class GoListAccountsCommandTestCase(VumiGoDjangoTestCase):
 
-    USE_RIAK = True
+    use_riak = True
 
     def setUp(self):
         super(GoListAccountsCommandTestCase, self).setUp()

--- a/go/base/tests/test_go_manage_applications.py
+++ b/go/base/tests/test_go_manage_applications.py
@@ -6,7 +6,7 @@ from go.base.utils import vumi_api_for_user
 
 class GoManageApplicationCommandTestCase(VumiGoDjangoTestCase):
 
-    USE_RIAK = True
+    use_riak = True
 
     def setUp(self):
         super(GoManageApplicationCommandTestCase, self).setUp()

--- a/go/base/tests/test_go_manage_contact_group.py
+++ b/go/base/tests/test_go_manage_contact_group.py
@@ -7,7 +7,7 @@ from go.base.utils import vumi_api_for_user
 
 class GoManageContactGroupCommandTestCase(VumiGoDjangoTestCase):
 
-    USE_RIAK = True
+    use_riak = True
 
     def setUp(self):
         super(GoManageContactGroupCommandTestCase, self).setUp()

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -2,15 +2,17 @@ from StringIO import StringIO
 
 from django.core.management.base import CommandError
 
-from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.base.management.commands import go_manage_conversation
 
 
-class GoManageConversationTestCase(DjangoGoApplicationTestCase):
-    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+class GoManageConversationTestCase(VumiGoDjangoTestCase):
+    use_riak = True
 
     def setUp(self):
         super(GoManageConversationTestCase, self).setUp()
+        self.setup_api()
+        self.setup_user_api()
         self.command = go_manage_conversation.Command()
         self.command.stdout = StringIO()
         self.command.stderr = StringIO()
@@ -34,26 +36,18 @@ class GoManageConversationTestCase(DjangoGoApplicationTestCase):
                                    **kwargs)
 
     def test_list(self):
-        self.setup_conversation()
+        conv = self.create_conversation()
         self.do_command(list_conversations=True)
         self.assertEqual(
-            self.command.stdout.getvalue(), "\n".join([
-                "0. Test Conversation (type: bulk_message,"
-                " key: %s)" % self.conversation.key,
-            ]) + "\n")
+            self.command.stdout.getvalue(),
+            "0. %s (type: %s, key: %s)\n" % (
+                conv.name, conv.conversation_type, conv.key))
 
     def test_show_config(self):
-        self.setup_conversation()
-        conv = self.get_wrapped_conv()
-        conv.set_config({
-            'http_api': {
-                'api_tokens': ['token'],
-            }
+        conv = self.create_conversation(config={
+            'http_api': {'api_tokens': ['token']},
         })
-        conv.save()
-        self.do_command(show_config=True,
-                        conversation_key=self.conversation.key)
+        self.do_command(show_config=True, conversation_key=conv.key)
         self.assertEqual(
-            self.command.stdout.getvalue(), "\n".join([
-                "{u'http_api': {u'api_tokens': [u'token']}}",
-            ]) + "\n")
+            self.command.stdout.getvalue(),
+            "{u'http_api': {u'api_tokens': [u'token']}}\n")

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -4,22 +4,16 @@ from django.core.management.base import CommandError
 
 from go.apps.tests.base import DjangoGoApplicationTestCase
 from go.base.management.commands import go_manage_conversation
-from go.base.utils import vumi_api_for_user
 
 
 class GoManageConversationTestCase(DjangoGoApplicationTestCase):
-
-    USE_RIAK = True
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def setUp(self):
         super(GoManageConversationTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.user_api = vumi_api_for_user(self.user)
-        self.profile = self.user.get_profile()
         self.command = go_manage_conversation.Command()
         self.command.stdout = StringIO()
         self.command.stderr = StringIO()
-        self.conversation = self.user_api.wrap_conversation(self.conversation)
 
     def test_conv_sanity_checks(self):
         self.assertRaisesRegexp(
@@ -29,17 +23,18 @@ class GoManageConversationTestCase(DjangoGoApplicationTestCase):
         self.assertRaisesRegexp(
             CommandError,
             'Please specify a conversation key', self.command.handle,
-            email_address=self.user.email)
+            email_address=self.django_user.email)
         self.assertRaisesRegexp(
             CommandError, 'Conversation does not exist',
-            self.command.handle, email_address=self.user.email,
+            self.command.handle, email_address=self.django_user.email,
             conversation_key='foo')
 
     def do_command(self, **kwargs):
-        return self.command.handle(email_address=self.user.email,
+        return self.command.handle(email_address=self.django_user.email,
                                    **kwargs)
 
     def test_list(self):
+        self.setup_conversation()
         self.do_command(list_conversations=True)
         self.assertEqual(
             self.command.stdout.getvalue(), "\n".join([
@@ -48,12 +43,14 @@ class GoManageConversationTestCase(DjangoGoApplicationTestCase):
             ]) + "\n")
 
     def test_show_config(self):
-        self.conversation.set_config({
+        self.setup_conversation()
+        conv = self.get_wrapped_conv()
+        conv.set_config({
             'http_api': {
                 'api_tokens': ['token'],
             }
         })
-        self.conversation.save()
+        conv.save()
         self.do_command(show_config=True,
                         conversation_key=self.conversation.key)
         self.assertEqual(

--- a/go/base/tests/test_go_manage_http_api.py
+++ b/go/base/tests/test_go_manage_http_api.py
@@ -4,80 +4,80 @@ from django.core.management.base import CommandError
 
 from go.apps.tests.base import DjangoGoApplicationTestCase
 from go.base.management.commands import go_manage_http_api
-from go.base.utils import vumi_api_for_user
 
 
 class GoManageHttpAPICommandTestCase(DjangoGoApplicationTestCase):
-
-    USE_RIAK = True
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def setUp(self):
         super(GoManageHttpAPICommandTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.user_api = vumi_api_for_user(self.user)
-        self.profile = self.user.get_profile()
         self.command = go_manage_http_api.Command()
         self.command.stdout = StringIO()
         self.command.stderr = StringIO()
-        self.conversation = self.user_api.wrap_conversation(self.conversation)
 
     def test_conv_sanity_checks(self):
+        self.setup_conversation()
         self.assertRaisesRegexp(
             CommandError,
             'User matching query does not exist', self.command.handle,
             email_address='foo@bar')
         self.assertRaisesRegexp(
             CommandError, 'Conversation does not exist',
-            self.command.handle, email_address=self.user.email,
+            self.command.handle, email_address=self.django_user.email,
             conversation_key='foo')
         self.assertRaisesRegexp(
             CommandError,
             'Conversation is not allowed for an HTTP API', self.command.handle,
-            email_address=self.user.email,
+            email_address=self.django_user.email,
             conversation_key=self.conversation.key)
 
-        self.set_conv_type(self.conversation, u'http_api')
+        self.set_conv_type(u'http_api')
         self.assertEqual(None, self.command.handle(
-            email_address=self.user.email,
+            email_address=self.django_user.email,
             conversation_key=self.conversation.key))
 
-        self.set_conv_type(self.conversation, u'jsbox')
+        self.set_conv_type(u'jsbox')
         self.assertEqual(None, self.command.handle(
-            email_address=self.user.email,
+            email_address=self.django_user.email,
             conversation_key=self.conversation.key))
 
-    def set_conv_type(self, conversation, conv_type):
-        conv = self.user_api.get_wrapped_conversation(conversation.key)
+    def set_conv_type(self, conv_type):
+        conv = self.get_wrapped_conv(self.conversation.key)
         conv.c.conversation_type = conv_type
         conv.save()
 
     def do_command(self, **kwargs):
-        self.set_conv_type(self.conversation, u'http_api')
-        return self.command.handle(email_address=self.user.email,
+        self.set_conv_type(u'http_api')
+        return self.command.handle(email_address=self.django_user.email,
                                    conversation_key=self.conversation.key,
                                    **kwargs)
 
     def test_create_token(self):
+        self.setup_conversation()
         self.do_command(create_token=True)
         self.assertTrue(
             self.command.stdout.getvalue().startswith('Created token'))
 
     def test_remove_token(self):
-        self.conversation.set_config({
+        self.setup_conversation()
+        conv = self.get_wrapped_conv()
+        conv.set_config({
             'http_api': {
                 'api_tokens': ['token'],
             }
         })
-        self.conversation.save()
+        conv.save()
         self.do_command(remove_token='token')
         self.assertTrue(
             self.command.stdout.getvalue().startswith('Removed token'))
 
     def test_remove_invalid_token(self):
+        self.setup_conversation()
         self.assertRaisesRegexp(CommandError, 'Token does not exist',
                                 self.do_command, remove_token='foo')
 
     def test_set_and_remove_message_url(self):
+        self.setup_conversation()
         self.do_command(set_message_url='http://foo/')
         self.assertEqual(self.command.stdout.getvalue(),
                          'Saved push_message_url: http://foo/')
@@ -89,6 +89,7 @@ class GoManageHttpAPICommandTestCase(DjangoGoApplicationTestCase):
                                 self.do_command, remove_message_url=True)
 
     def test_set_and_remove_event_url(self):
+        self.setup_conversation()
         self.do_command(set_event_url='http://foo/')
         self.assertEqual(self.command.stdout.getvalue(),
                          'Saved push_event_url: http://foo/')

--- a/go/base/tests/test_go_manage_metrics.py
+++ b/go/base/tests/test_go_manage_metrics.py
@@ -5,8 +5,6 @@ from go.base.management.commands import go_manage_metrics
 
 class GoManageApplicationCommandTestCase(VumiGoDjangoTestCase):
 
-    USE_RIAK = False
-
     def setUp(self):
         super(GoManageApplicationCommandTestCase, self).setUp()
         self.setup_api()

--- a/go/base/tests/test_go_migrate_conversations.py
+++ b/go/base/tests/test_go_migrate_conversations.py
@@ -11,11 +11,10 @@ from go.vumitools.conversation.old_models import ConversationVNone
 
 
 class GoMigrateConversationsCommandTestCase(DjangoGoApplicationTestCase):
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def setUp(self):
         super(GoMigrateConversationsCommandTestCase, self).setUp()
-        self.user = self.mk_django_user()
-        self.setup_user_api(self.user)
 
         self.old_conv_model = self.user_api.conversation_store.manager.proxy(
             ConversationVNone)
@@ -51,7 +50,7 @@ class GoMigrateConversationsCommandTestCase(DjangoGoApplicationTestCase):
         self.command.handle(migrate=False)
         output = self.command.stdout.getvalue().strip().split('\n')
         self.assertEqual(len(output), 2)
-        self.assertTrue(self.user.username in output[0])
+        self.assertTrue(self.django_user.username in output[0])
         self.assertTrue('Conversations: 3' in output[1])
         for conv in self.convs:
             # If we can load the old model, the data hasn't been migrated.
@@ -62,7 +61,7 @@ class GoMigrateConversationsCommandTestCase(DjangoGoApplicationTestCase):
         self.command.handle(migrate=True)
         output = self.command.stdout.getvalue().strip().split('\n')
         self.assertEqual(len(output), 8)
-        self.assertTrue(self.user.username in output[0])
+        self.assertTrue(self.django_user.username in output[0])
         self.assertTrue('Conversations: 3' in output[1])
         extracted_keys = set(line.split(': ')[1]
                              for line in output[2:] if 'migrated' not in line)

--- a/go/base/tests/test_go_migrate_conversations.py
+++ b/go/base/tests/test_go_migrate_conversations.py
@@ -5,16 +5,18 @@ from datetime import datetime
 
 from vumi.persist.model import ModelMigrationError
 
-from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.base.management.commands import go_migrate_conversations
 from go.vumitools.conversation.old_models import ConversationVNone
 
 
-class GoMigrateConversationsCommandTestCase(DjangoGoApplicationTestCase):
-    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+class GoMigrateConversationsCommandTestCase(VumiGoDjangoTestCase):
+    use_riak = True
 
     def setUp(self):
         super(GoMigrateConversationsCommandTestCase, self).setUp()
+        self.setup_api()
+        self.setup_user_api()
 
         self.old_conv_model = self.user_api.conversation_store.manager.proxy(
             ConversationVNone)

--- a/go/base/tests/test_go_send_app_worker_command.py
+++ b/go/base/tests/test_go_send_app_worker_command.py
@@ -3,8 +3,8 @@ from StringIO import StringIO
 
 from django.core.management.base import CommandError
 
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.base.management.commands import go_send_app_worker_command
-from go.apps.tests.base import DjangoGoApplicationTestCase
 
 
 class DummyMessageSender(object):
@@ -15,11 +15,13 @@ class DummyMessageSender(object):
         self.outbox.append(command)
 
 
-class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
-    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+class GoSendAppWorkerCommandTestCase(VumiGoDjangoTestCase):
+    use_riak = True
 
     def setUp(self):
         super(GoSendAppWorkerCommandTestCase, self).setUp()
+        self.setup_api()
+        self.setup_user_api()
         self.account_key = self.user_api.user_account_key
 
         self.command = go_send_app_worker_command.Command()
@@ -44,10 +46,10 @@ class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
             'account_key=%s' % self.account_key, 'conversation_key=bar')
 
     def test_reconcile_cache(self):
-        self.setup_conversation()
+        conv = self.create_conversation()
         self.command.handle('worker-name', 'reconcile_cache',
             'account_key=%s' % (self.account_key,),
-            'conversation_key=%s' % (self.conv_key,))
+            'conversation_key=%s' % (conv.key,))
         self.assertEqual(self.command.stderr.getvalue(), '')
         self.assertEqual(self.command.stdout.getvalue(), '')
         [cmd] = self.command.sender.outbox
@@ -56,5 +58,5 @@ class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(cmd['args'], [])
         self.assertEqual(cmd['kwargs'], {
             'user_account_key': self.account_key,
-            'conversation_key': self.conv_key,
+            'conversation_key': conv.key,
         })

--- a/go/base/tests/test_go_send_app_worker_command.py
+++ b/go/base/tests/test_go_send_app_worker_command.py
@@ -16,11 +16,11 @@ class DummyMessageSender(object):
 
 
 class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def setUp(self):
         super(GoSendAppWorkerCommandTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.account_key = self.user.get_profile().user_account
+        self.account_key = self.user_api.user_account_key
 
         self.command = go_send_app_worker_command.Command()
         self.command.sender_class = DummyMessageSender
@@ -44,6 +44,7 @@ class GoSendAppWorkerCommandTestCase(DjangoGoApplicationTestCase):
             'account_key=%s' % self.account_key, 'conversation_key=bar')
 
     def test_reconcile_cache(self):
+        self.setup_conversation()
         self.command.handle('worker-name', 'reconcile_cache',
             'account_key=%s' % (self.account_key,),
             'conversation_key=%s' % (self.conv_key,))

--- a/go/base/tests/test_go_setup_env.py
+++ b/go/base/tests/test_go_setup_env.py
@@ -7,7 +7,7 @@ from ConfigParser import ConfigParser
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 
-from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.base.management.commands import go_setup_env
 from go.base.utils import vumi_api_for_user
 
@@ -28,11 +28,12 @@ class FakeFile(StringIO):
         pass
 
 
-class GoBootstrapEnvTestCase(DjangoGoApplicationTestCase):
-    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+class GoBootstrapEnvTestCase(VumiGoDjangoTestCase):
+    use_riak = True
 
     def setUp(self):
         super(GoBootstrapEnvTestCase, self).setUp()
+        self.setup_api()
         self.config = self.mk_config({})
 
         self.command = go_setup_env.Command()

--- a/go/base/tests/test_go_setup_env.py
+++ b/go/base/tests/test_go_setup_env.py
@@ -29,12 +29,10 @@ class FakeFile(StringIO):
 
 
 class GoBootstrapEnvTestCase(DjangoGoApplicationTestCase):
-
-    USE_RIAK = True
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
 
     def setUp(self):
         super(GoBootstrapEnvTestCase, self).setUp()
-        self.setup_riak_fixtures()
         self.config = self.mk_config({})
 
         self.command = go_setup_env.Command()

--- a/go/base/tests/test_go_start_conversation.py
+++ b/go/base/tests/test_go_start_conversation.py
@@ -4,7 +4,6 @@ from django.core.management.base import CommandError
 
 from go.apps.tests.base import DjangoGoApplicationTestCase
 from go.base.management.commands import go_start_conversation
-from go.base.tests.utils import declare_longcode_tags
 
 from mock import patch
 
@@ -28,7 +27,7 @@ class GoStartConversationTestCase(DjangoGoApplicationTestCase):
         self.command.stderr = StringIO()
 
     def add_tagpool_to_conv(self):
-        declare_longcode_tags(self.api)
+        self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         conv = self.get_wrapped_conv()
         conv.c.delivery_class = u'sms'

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import uuid
 
 from django.conf import settings, UserSettingsHolder
@@ -8,6 +9,7 @@ from django.core.paginator import Paginator
 from django.test.client import Client
 
 from vumi.tests.fake_amqp import FakeAMQPBroker
+from vumi.message import TransportUserMessage, TransportEvent
 
 from go.vumitools.tests.utils import GoPersistenceMixin, FakeAmqpConnection
 from go.vumitools.api import VumiApi
@@ -119,6 +121,16 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
         self.api = VumiApi.from_config_sync(settings.VUMI_API_CONFIG)
         self._persist_riak_managers.append(self.api.manager)
 
+    def setup_user_api(self, django_user=None):
+        if django_user is None:
+            django_user = self.mk_django_user()
+        self.django_user = django_user
+        self.user_api = base_utils.vumi_api_for_user(django_user)
+        self.contact_store = self.user_api.contact_store
+        self.contact_store.contacts.enable_search()
+        self.contact_store.groups.enable_search()
+        self.conv_store = self.user_api.conversation_store
+
     def mk_django_user(self):
         user = User.objects.create_user(
             'username', 'user@domain.com', 'password')
@@ -127,18 +139,76 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
         user.save()
         return User.objects.get(username='username')
 
+    def create_conversation(self, started=False, **kwargs):
+        params = {
+            'conversation_type': u'test_conversation_type',
+            'name': u'conversation name',
+            'description': u'hello world',
+            'config': {},
+        }
+        params.update(kwargs)
+        conv = self.user_api.wrap_conversation(
+            self.conv_store.new_conversation(**params))
 
-def declare_longcode_tags(api):
-    """Declare a set of long codes to the tag pool."""
-    api.tpm.declare_tags([(u"longcode", u"default%s" % i) for i
-                      in range(10001, 10001 + 4)])
-    api.tpm.set_metadata(u"longcode", {
-        "display_name": "Long code",
-        "delivery_class": "sms",
-        "transport_type": "sms",
-        "server_initiated": True,
-        "transport_name": "sphex",
-        })
+        if started:
+            conv.set_status_started()
+            batch_id = conv.start_batch()
+            conv.batches.add_key(batch_id)
+            conv.save()
+
+        return conv
+
+    def put_sample_messages_in_conversation(self, message_count, conversation,
+                                            start_date=None,
+                                            time_multiplier=10):
+        now = start_date or datetime.now().date()
+        batch_key = conversation.get_latest_batch_key()
+
+        messages = []
+        for i in range(message_count):
+            msg_in = TransportUserMessage(
+                to_addr='9292',
+                from_addr='from-%s' % (i,),
+                content='hello',
+                transport_type='sms',
+                transport_name='sphex')
+            ts = now - timedelta(hours=i * time_multiplier)
+            msg_in['timestamp'] = ts
+            msg_out = msg_in.reply('thank you')
+            msg_out['timestamp'] = ts
+            ack = TransportEvent(
+                event_type='ack',
+                user_message_id=msg_out['message_id'],
+                sent_message_id=msg_out['message_id'],
+                transport_type='sms',
+                transport_name='sphex')
+            self.api.mdb.add_inbound_message(msg_in, batch_id=batch_key)
+            self.api.mdb.add_outbound_message(msg_out, batch_id=batch_key)
+            self.api.mdb.add_event(ack)
+            messages.append((msg_in, msg_out, ack))
+        return messages
+
+    def declare_tags(self, pool, num_tags, metadata=None):
+        """Declare a set of long codes to the tag pool."""
+        if metadata is None:
+            metadata = {
+                "display_name": "Long code",
+                "delivery_class": "sms",
+                "transport_type": "sms",
+                "server_initiated": True,
+                "transport_name": "sphex",
+            }
+        self.api.tpm.declare_tags([(pool, u"default%s" % i) for i
+                                   in range(10001, 10001 + num_tags)])
+        self.api.tpm.set_metadata(pool, metadata)
+
+    def add_tagpool_permission(self, tagpool, max_keys=None):
+        permission = self.api.account_store.tag_permissions(
+            uuid.uuid4().hex, tagpool=tagpool, max_keys=max_keys)
+        permission.save()
+        account = self.user_api.get_user_account()
+        account.tagpools.add(permission)
+        account.save()
 
 
 class FakeMessageStoreClient(object):

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -158,10 +158,8 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
 
         return conv
 
-    def put_sample_messages_in_conversation(self, message_count, conversation,
-                                            reply=False, ack=False,
-                                            start_date=None,
-                                            time_multiplier=10):
+    def add_messages_to_conv(self, message_count, conversation, reply=False,
+                             ack=False, start_date=None, time_multiplier=10):
         now = start_date or datetime.now().date()
         batch_key = conversation.get_latest_batch_key()
 

--- a/go/channel/tests.py
+++ b/go/channel/tests.py
@@ -10,6 +10,7 @@ from go.channel.views import get_channel_view_definition
 
 
 class ChannelViewsTestCase(VumiGoDjangoTestCase):
+    use_riak = True
 
     def setUp(self):
         super(ChannelViewsTestCase, self).setUp()

--- a/go/channel/tests.py
+++ b/go/channel/tests.py
@@ -4,7 +4,7 @@ import urllib
 from django.test.client import Client
 from django.core.urlresolvers import reverse
 
-from go.base.tests.utils import VumiGoDjangoTestCase, declare_longcode_tags
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.base import utils as base_utils
 from go.channel.views import get_channel_view_definition
 
@@ -15,7 +15,7 @@ class ChannelViewsTestCase(VumiGoDjangoTestCase):
     def setUp(self):
         super(ChannelViewsTestCase, self).setUp()
         self.setup_api()
-        declare_longcode_tags(self.api)
+        self.declare_tags(u'longcode', 4)
         self.user = self.mk_django_user()
         self.user_api = base_utils.vumi_api_for_user(self.user)
         self.add_tagpool_permission(u"longcode")

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -5,7 +5,6 @@ from zipfile import ZipFile
 
 from django.conf import settings
 from django.test import TestCase
-from django.test.client import Client
 from django.core.urlresolvers import reverse
 from django.core import mail
 
@@ -17,6 +16,7 @@ from go.contacts.parsers.base import FieldNormalizer
 TEST_GROUP_NAME = u"Test Group"
 TEST_CONTACT_NAME = u"Name"
 TEST_CONTACT_SURNAME = u"Surname"
+TEST_CONTACT_MSISDN = u"+27761234567"
 
 
 def newest(models):
@@ -32,24 +32,14 @@ def group_url(group_key):
 
 
 class ContactsTestCase(DjangoGoApplicationTestCase):
-
-    fixtures = ['test_user']
-
-    def setUp(self):
-        super(ContactsTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
-        self.contact_store.contacts.enable_search()
-        self.contact_store.groups.enable_search()
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+    # TODO: Cleaner test group and contact creation.
 
     def test_redirect_index(self):
         response = self.client.get(reverse('contacts:index'))
         self.assertRedirects(response, reverse('contacts:groups'))
 
-    def clear_groups(self, contact_key=None):
-        contact = self.contact_store.get_contact_by_key(
-            contact_key or self.contact_key)
+    def clear_groups(self, contact):
         contact.groups.clear()
         contact.save()
 
@@ -65,18 +55,22 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         return max(self.get_all_contacts(), key=lambda c: c.created_at)
 
     def test_contact_creation(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
         response = self.client.post(reverse('contacts:new_person'), {
             'name': 'New',
             'surname': 'Person',
             'msisdn': '27761234567',
-            'groups': [self.group_key],
+            'groups': [group.key],
         })
         contact = self.get_latest_contact()
         self.assertRedirects(response, person_url(contact.key))
 
     def test_contact_deleting(self):
+        contact = self.contact_store.new_contact(
+            name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
+            msisdn=TEST_CONTACT_MSISDN)
         person_url = reverse('contacts:person', kwargs={
-            'person_key': self.contact.key,
+            'person_key': contact.key,
         })
         response = self.client.post(person_url, {
             '_delete_contact': True,
@@ -90,15 +84,18 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_contact_update(self):
-        response = self.client.post(person_url(self.contact_key), {
+        contact = self.contact_store.new_contact(
+            name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
+            msisdn=TEST_CONTACT_MSISDN)
+        response = self.client.post(person_url(contact.key), {
             'name': 'changed name',
             'surname': 'changed surname',
             'msisdn': '112',
             'groups': [g.key for g in self.contact_store.list_groups()],
         })
-        self.assertRedirects(response, person_url(self.contact_key))
+        self.assertRedirects(response, person_url(contact.key))
         # reload to check
-        contact = self.contact_store.get_contact_by_key(self.contact_key)
+        contact = self.contact_store.get_contact_by_key(contact.key)
         self.assertEqual(contact.name, 'changed name')
         self.assertEqual(contact.surname, 'changed surname')
         self.assertEqual(contact.msisdn, '112')
@@ -106,9 +103,9 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
             set(contact.groups.keys()),
             set([g.key for g in self.contact_store.list_groups()]))
 
-    def specify_columns(self, group_key=None, columns=None):
+    def specify_columns(self, group_key, columns=None):
         group_url = reverse('contacts:group', kwargs={
-            'group_key': group_key or self.group_key
+            'group_key': group_key,
         })
         defaults = {
             'column-0': 'name',
@@ -127,7 +124,7 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
                         'fixtures', 'sample-contacts.csv'))
 
-        self.clear_groups()
+        # self.clear_groups()
         response = self.client.post(reverse('contacts:people'), {
             'file': csv_file,
             'name': 'a new group',
@@ -138,57 +135,60 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, group_url(group.key))
         self.assertEqual(len(group.backlinks.contacts()), 0)
 
-        self.specify_columns(group_key=group.key)
+        self.specify_columns(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_contact_upload_into_existing_group(self):
-        self.clear_groups()
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        # self.clear_groups()
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
                         'fixtures', 'sample-contacts.csv'), 'r')
         response = self.client.post(reverse('contacts:people'), {
             'file': csv_file,
-            'contact_group': self.group_key
+            'contact_group': group.key
         })
 
-        self.assertRedirects(response, group_url(self.group_key))
-        group = self.contact_store.get_group(self.group_key)
+        self.assertRedirects(response, group_url(group.key))
+        group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 0)
-        self.specify_columns()
+        self.specify_columns(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_uploading_unicode_chars_in_csv(self):
-        self.clear_groups()
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        # self.clear_groups()
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
                                   'fixtures', 'sample-unicode-contacts.csv'))
 
         response = self.client.post(reverse('contacts:people'), {
-            'contact_group': self.group_key,
+            'contact_group': group.key,
             'file': csv_file,
         })
-        self.assertRedirects(response, group_url(self.group_key))
+        self.assertRedirects(response, group_url(group.key))
 
-        self.specify_columns()
-        group = self.contact_store.get_group(self.group_key)
+        self.specify_columns(group.key)
+        group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTrue('successfully' in mail.outbox[0].subject)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_uploading_windows_linebreaks_in_csv(self):
-        self.clear_groups()
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        # self.clear_groups()
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
                                   'fixtures',
                                   'sample-windows-linebreaks-contacts.csv'))
 
         response = self.client.post(reverse('contacts:people'), {
-            'contact_group': self.group_key,
+            'contact_group': group.key,
             'file': csv_file,
         })
-        self.assertRedirects(response, group_url(self.group_key))
+        self.assertRedirects(response, group_url(group.key))
 
-        self.specify_columns(columns={
+        self.specify_columns(group.key, columns={
             'column-0': 'msisdn',
             'column-1': 'area',
             'column-2': 'nairobi_1',
@@ -206,14 +206,14 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
             'normalize-6': '',
             'normalize-7': '',
         })
-        group = self.contact_store.get_group(self.group_key)
+        group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 2)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTrue('successfully' in mail.outbox[0].subject)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_uploading_unicode_chars_in_csv_into_new_group(self):
-        self.clear_groups()
+        # self.clear_groups()
         new_group_name = u'Testing a ünicode grøüp'
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
                                   'fixtures', 'sample-unicode-contacts.csv'))
@@ -233,12 +233,13 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_contact_upload_from_group_page(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
 
         group_url = reverse('contacts:group', kwargs={
-            'group_key': self.group_key
+            'group_key': group.key
         })
 
-        self.clear_groups()
+        # self.clear_groups()
         csv_file = open(
             path.join(settings.PROJECT_ROOT, 'base',
                       'fixtures', 'sample-contacts.csv'), 'r')
@@ -262,29 +263,30 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(file_name, 'sample-contacts.csv')
 
         # Nothing should have been written to the db by now.
-        self.assertEqual(len(list(self.group.backlinks.contacts())), 0)
+        self.assertEqual(len(list(group.backlinks.contacts())), 0)
 
         # Now submit the column names and check that things have been written
         # to the db
-        response = self.specify_columns()
+        response = self.specify_columns(group.key)
         # Check the redirect
         self.assertRedirects(response, group_url)
         # 3 records should have been written to the db.
-        self.assertEqual(len(list(self.group.backlinks.contacts())), 3)
+        self.assertEqual(len(list(group.backlinks.contacts())), 3)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTrue('successfully' in mail.outbox[0].subject)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_graceful_error_handling_on_upload_failure(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
         group_url = reverse('contacts:group', kwargs={
-            'group_key': self.group_key
+            'group_key': group.key
         })
 
         # Carefully crafted but bad CSV data
         wrong_file = StringIO(',,\na,b,c\n"')
         wrong_file.name = 'fubar.csv'
 
-        self.clear_groups()
+        # self.clear_groups()
 
         response = self.client.post(group_url, {
             'file': wrong_file
@@ -295,13 +297,13 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_contact_upload_failure(self):
-        self.assertEqual(len(self.contact_store.list_groups()), 1)
+        self.assertEqual(len(self.contact_store.list_groups()), 0)
         response = self.client.post(reverse('contacts:people'), {
             'name': 'a new group',
             'file': None,
         })
         self.assertContains(response, 'Something went wrong with the upload')
-        self.assertEqual(len(self.contact_store.list_groups()), 1)
+        self.assertEqual(len(self.contact_store.list_groups()), 0)
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
@@ -360,6 +362,9 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
                         contacts]))
 
     def test_contact_querying(self):
+        contact = self.contact_store.new_contact(
+            name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
+            msisdn=TEST_CONTACT_MSISDN)
         people_url = reverse('contacts:people')
 
         # test no-match
@@ -372,24 +377,21 @@ class ContactsTestCase(DjangoGoApplicationTestCase):
         response = self.client.get(people_url, {
             'q': TEST_CONTACT_NAME,
         })
-        self.assertContains(response, person_url(self.contact_key))
+        self.assertContains(response, person_url(contact.key))
 
     def test_contact_key_value_query(self):
+        contact = self.contact_store.new_contact(
+            name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
+            msisdn=TEST_CONTACT_MSISDN)
         people_url = reverse('contacts:people')
         self.client.get(people_url, {
-            'q': 'name:%s' % (self.contact.name,)
+            'q': 'name:%s' % (contact.name,)
         })
 
 
 class GroupsTestCase(DjangoGoApplicationTestCase):
-
-    fixtures = ['test_user']
-
-    def setUp(self):
-        super(GroupsTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+    # TODO: Cleaner test group and contact creation.
 
     def get_all_contacts(self, keys=None):
         if keys is None:
@@ -413,14 +415,13 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, group_url(group.key))
 
     def test_group_updating(self):
-        new_group_name = 'a new group name'
-        self.assertNotEqual(self.group.name, new_group_name)
+        group = self.contact_store.new_group(u'old name')
         response = self.client.post(
-            reverse('contacts:group', kwargs={'group_key': self.group.key}),
-            {'name': new_group_name, '_save_group': '1'})
-        updated_group = self.contact_store.get_group(self.group.key)
-        self.assertEqual(new_group_name, updated_group.name)
-        self.assertRedirects(response, group_url(self.group.key))
+            reverse('contacts:group', kwargs={'group_key': group.key}),
+            {'name': 'new name', '_save_group': '1'})
+        updated_group = self.contact_store.get_group(group.key)
+        self.assertEqual('new name', updated_group.name)
+        self.assertRedirects(response, group_url(group.key))
 
     def test_groups_creation_with_funny_chars(self):
         response = self.client.post(reverse('contacts:groups'), {
@@ -433,27 +434,32 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, group_url(group.key))
 
     def test_group_contact_querying(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        contact = self.contact_store.new_contact(
+            name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
+            msisdn=TEST_CONTACT_MSISDN, groups=[group])
         # test no-match
-        response = self.client.get(group_url(self.group_key), {
+        response = self.client.get(group_url(group.key), {
             'q': 'this should not match',
         })
         self.assertContains(response, 'No contacts match')
 
         # test match name
-        response = self.client.get(group_url(self.group_key), {
+        response = self.client.get(group_url(group.key), {
             'q': TEST_CONTACT_NAME,
         })
-        self.assertContains(response, person_url(self.contact_key))
+        self.assertContains(response, person_url(contact.key))
 
     def test_group_contact_query_limits(self):
-        default_limit = self.client.get(group_url(self.group_key), {
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        default_limit = self.client.get(group_url(group.key), {
             'q': TEST_CONTACT_NAME,
         })
-        custom_limit = self.client.get(group_url(self.group_key), {
+        custom_limit = self.client.get(group_url(group.key), {
             'q': TEST_CONTACT_NAME,
             'limit': 10,
         })
-        no_limit = self.client.get(group_url(self.group_key), {
+        no_limit = self.client.get(group_url(group.key), {
             'q': TEST_CONTACT_NAME,
             'limit': 0,
         })
@@ -468,12 +474,14 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         self.assertNotContains(no_limit, 'alert-success')
 
     def test_group_deletion(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+
         # Create a contact in the group
         response = self.client.post(reverse('contacts:new_person'), {
             'name': 'New',
             'surname': 'Person',
             'msisdn': '27761234567',
-            'groups': [self.group_key],
+            'groups': [group.key],
         })
 
         contact = self.get_latest_contact()
@@ -481,7 +489,7 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
 
         # Delete the group
         group_url = reverse('contacts:group', kwargs={
-            'group_key': self.group.key,
+            'group_key': group.key,
         })
         response = self.client.post(group_url, {
             '_delete_group': True,
@@ -495,12 +503,13 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(reloaded_contact.groups.keys(), [])
 
     def test_group_clearing(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
         # Create a contact in the group
         response = self.client.post(reverse('contacts:new_person'), {
             'name': 'New',
             'surname': 'Person',
             'msisdn': '27761234567',
-            'groups': [self.group_key],
+            'groups': [group.key],
         })
 
         contact = self.get_latest_contact()
@@ -508,7 +517,7 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
 
         # Clear the group
         group_url = reverse('contacts:group', kwargs={
-            'group_key': self.group.key,
+            'group_key': group.key,
         })
         response = self.client.post(group_url, {
             '_delete_group_contacts': True,
@@ -516,19 +525,23 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, group_url)
 
         self.assertEqual(
-            self.contact_store.get_contacts_for_group(self.group), [])
+            self.contact_store.get_contacts_for_group(group), [])
         self.assertFalse(contact in self.contact_store.list_contacts())
 
     def test_group_contact_export(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        contact = self.contact_store.new_contact(
+            name=TEST_CONTACT_NAME, surname=TEST_CONTACT_SURNAME,
+            msisdn=TEST_CONTACT_MSISDN, groups=[group])
         # Clear the group
         group_url = reverse('contacts:group', kwargs={
-            'group_key': self.group.key,
+            'group_key': group.key,
         })
 
         # add some extra info to ensure it gets exported properly
-        self.contact.extra['foo'] = u'bar'
-        self.contact.extra['bar'] = u'baz'
-        self.contact.save()
+        contact.extra['foo'] = u'bar'
+        contact.extra['bar'] = u'baz'
+        contact.save()
 
         response = self.client.post(group_url, {
             '_export_group_contacts': True,
@@ -539,11 +552,11 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
         [email] = mail.outbox
         [(file_name, contents, mime_type)] = email.attachments
 
-        self.assertEqual(email.recipients(), [self.user.email])
+        self.assertEqual(email.recipients(), [self.django_user.email])
         self.assertTrue(
-            '%s contacts export' % (self.group.name,) in email.subject)
+            '%s contacts export' % (group.name,) in email.subject)
         self.assertTrue(
-            '1 contact(s) from group "%s" attached' % (self.group.name,)
+            '1 contact(s) from group "%s" attached' % (group.name,)
             in email.body)
         self.assertEqual(file_name, 'contacts-export.zip')
 
@@ -564,14 +577,8 @@ class GroupsTestCase(DjangoGoApplicationTestCase):
 
 
 class SmartGroupsTestCase(DjangoGoApplicationTestCase):
-
-    fixtures = ['test_user']
-
-    def setUp(self):
-        super(SmartGroupsTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username='username', password='password')
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+    # TODO: Cleaner test group and contact creation.
 
     def mksmart_group(self, query, name='a smart group'):
         response = self.client.post(reverse('contacts:groups'), {
@@ -583,8 +590,15 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, group_url(group.key))
         return group
 
+    def mkcontact(self, name=None, surname=None, msisdn=u'+1234567890',
+                  **kwargs):
+        return self.contact_store.new_contact(
+            name=unicode(name or self.TEST_CONTACT_NAME),
+            surname=unicode(surname or self.TEST_CONTACT_SURNAME),
+            msisdn=unicode(msisdn), **kwargs)
+
     def add_to_group(self, contact, group):
-        contact.add_to_group(self.group)
+        contact.add_to_group(group)
         contact.save()
         return contact
 
@@ -633,7 +647,7 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
             '_new_smart_group': '1',
         })
         group = newest(self.contact_store.list_groups())
-        conversation = self.mkconversation()
+        conversation = self.create_conversation()
         conversation.groups.add(group)
         conversation.save()
 
@@ -653,7 +667,7 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
 
         contact = self.mkcontact()
         group = newest(self.contact_store.list_groups())
-        conversation = self.mkconversation()
+        conversation = self.create_conversation()
         conversation.groups.add(group)
         conversation.save()
 
@@ -681,7 +695,7 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
         match = self.mkcontact(name='foo', surname='bar')
 
         group = newest(self.contact_store.list_groups())
-        conversation = self.mkconversation()
+        conversation = self.create_conversation()
         conversation.groups.add(group)
         conversation.save()
 
@@ -701,7 +715,7 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
         contact3 = self.mkcontact(name='foo', surname='bar')
 
         group = newest(self.contact_store.list_groups())
-        conv = self.mkconversation()
+        conv = self.create_conversation()
         conv.groups.add(group)
         conv.save()
 
@@ -772,7 +786,7 @@ class SmartGroupsTestCase(DjangoGoApplicationTestCase):
         zipfile = ZipFile(StringIO(contents), 'r')
         csv_contents = zipfile.open('contacts-export.csv', 'r').read()
 
-        self.assertEqual(email.recipients(), [self.user.email])
+        self.assertEqual(email.recipients(), [self.django_user.email])
         self.assertTrue(
             '%s contacts export' % (group.name,) in email.subject)
         self.assertTrue(

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -180,9 +180,6 @@ class ShowConversationView(ConversationTemplateView):
         if inbound_message is None:
             logger.info('Replying to an unknown message: %s' % (in_reply_to,))
 
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = in_reply_to
         conversation.dispatch_command(
             'send_message', user_api.user_account_key, conversation.key,
             command_data={
@@ -190,7 +187,7 @@ class ShowConversationView(ConversationTemplateView):
                 "conversation_key": conversation.key,
                 "to_addr": inbound_message['from_addr'],
                 "content": content,
-                "msg_options": msg_options,
+                "msg_options": {'in_reply_to': in_reply_to},
            }
         )
 

--- a/go/routing/tests.py
+++ b/go/routing/tests.py
@@ -1,6 +1,5 @@
 import json
 
-from django.test.client import Client
 from django.core.urlresolvers import reverse
 
 from mock import patch
@@ -11,14 +10,10 @@ from go.api.go_api.api_types import (
 
 
 class RoutingScreenTestCase(DjangoGoApplicationTestCase):
+    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+
     # Most of the functionality of this view lives in JS, so we just test that
     # we're correctly injecting initial state into the template.
-
-    def setUp(self):
-        super(RoutingScreenTestCase, self).setUp()
-        self.setup_riak_fixtures()
-        self.client = Client()
-        self.client.login(username=self.user.username, password='password')
 
     def get_routing_table(self, user_account_key, session_id):
         self.assertEqual(user_account_key, self.user_api.user_account_key)
@@ -70,6 +65,7 @@ class RoutingScreenTestCase(DjangoGoApplicationTestCase):
 
     @patch('go.routing.views._get_routing_table')
     def test_non_empty_routing(self, mock_routing):
+        self.setup_conversation()
         mock_routing.side_effect = self.get_routing_table
         tag = (u'pool', u'tag')
         self.routing_table_api_response = self.make_routing_table(

--- a/go/routing/tests.py
+++ b/go/routing/tests.py
@@ -4,16 +4,22 @@ from django.core.urlresolvers import reverse
 
 from mock import patch
 
-from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.api.go_api.api_types import (
     ChannelType, ConversationType, RoutingEntryType)
 
 
-class RoutingScreenTestCase(DjangoGoApplicationTestCase):
-    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
-
+class RoutingScreenTestCase(VumiGoDjangoTestCase):
     # Most of the functionality of this view lives in JS, so we just test that
     # we're correctly injecting initial state into the template.
+
+    use_riak = True
+
+    def setUp(self):
+        super(RoutingScreenTestCase, self).setUp()
+        self.setup_api()
+        self.setup_user_api()
+        self.setup_client()
 
     def get_routing_table(self, user_account_key, session_id):
         self.assertEqual(user_account_key, self.user_api.user_account_key)
@@ -65,12 +71,12 @@ class RoutingScreenTestCase(DjangoGoApplicationTestCase):
 
     @patch('go.routing.views._get_routing_table')
     def test_non_empty_routing(self, mock_routing):
-        self.setup_conversation()
+        conv = self.create_conversation()
         mock_routing.side_effect = self.get_routing_table
         tag = (u'pool', u'tag')
         self.routing_table_api_response = self.make_routing_table(
-            tags=[tag], conversations=[self.conversation],
-            routing=[(self.conversation, tag), (tag, self.conversation)])
+            tags=[tag], conversations=[conv],
+            routing=[(conv, tag), (tag, conv)])
         response = self.client.get(reverse('routing'))
         model_data = response.context['model_data']
         self.assertEqual(self.routing_table_api_response, model_data)

--- a/go/token/tests/test_django_token_manager.py
+++ b/go/token/tests/test_django_token_manager.py
@@ -4,12 +4,12 @@ from django.test.client import Client
 from django.core.urlresolvers import reverse
 from django.contrib import messages
 
-from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 from go.vumitools.token_manager import TokenManager
 from go.token.django_token_manager import DjangoTokenManager
 
 
-class DjangoTokenManagerTestCase(DjangoGoApplicationTestCase):
+class DjangoTokenManagerTestCase(VumiGoDjangoTestCase):
 
     use_riak = False
 

--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -1,14 +1,19 @@
 from django.core.urlresolvers import reverse
 
-from go.base.tests.utils import declare_longcode_tags
-from go.apps.tests.base import DjangoGoApplicationTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 
 
-class WizardViewsTestCase(DjangoGoApplicationTestCase):
-    # TODO: Stop abusing DjangoGoApplicationTestCase for this.
+class WizardViewsTestCase(VumiGoDjangoTestCase):
+    use_riak = True
+
+    def setUp(self):
+        super(WizardViewsTestCase, self).setUp()
+        self.setup_api()
+        self.setup_user_api()
+        self.setup_client()
 
     def test_get_create_view(self):
-        declare_longcode_tags(self.api)
+        self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         response = self.client.get(reverse('wizard:create'))
         # Check that we have a few conversation types in the response
@@ -18,7 +23,7 @@ class WizardViewsTestCase(DjangoGoApplicationTestCase):
         self.assertContains(response, 'longcode:')
 
     def test_post_create_view_valid(self):
-        declare_longcode_tags(self.api)
+        self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         self.assertEqual(0, len(self.user_api.active_conversations()))
         self.assertEqual(0, len(self.user_api.list_endpoints()))
@@ -28,9 +33,8 @@ class WizardViewsTestCase(DjangoGoApplicationTestCase):
             'country': 'International',
             'channel': 'longcode:',
         })
-        self.assertEqual(1, len(self.user_api.active_conversations()))
+        [conv] = self.user_api.active_conversations()
         self.assertEqual(1, len(self.user_api.list_endpoints()))
-        conv = self.get_latest_conversation()
         self.assertRedirects(
             response, reverse('conversations:conversation', kwargs={
                 'conversation_key': conv.key, 'path_suffix': '',


### PR DESCRIPTION
There's a bunch of variance and duplication is both view and app worker tests. We need to clean up and standardise this to make tests more readable and more maintainable. In the interests of not updating the whole world, this issue only touches the view tests.
