### PR TITLE
Remove make_message_options since new routing no longer needs it.

### DIFF
--- a/go/apps/bulk_message/tests/test_new_views.py
+++ b/go/apps/bulk_message/tests/test_new_views.py
@@ -365,15 +365,8 @@ class ConfirmBulkMessageTestCase(DjangoGoApplicationTestCase):
         [tag] = list(batch.tags)
         [contact] = self.get_contacts_for_conversation(conversation)
         msg_options = {
-            "transport_type": "sms",
-            "transport_name": self.transport_name,
-            "from_addr": "default10001",
             "helper_metadata": {
-                "tag": {
-                    "tag": list(tag)
-                },
                 "go": {
-                    "user_account": conversation.user_account.key,
                     "sensitive": True,
                 },
             },
@@ -523,9 +516,6 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, self.get_view_url('show'))
 
         [start_cmd, hack_cmd, reply_to_cmd] = self.get_api_commands_sent()
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = msg['message_id']
         self.assertEqual(reply_to_cmd['worker_name'],
                             'bulk_message_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
@@ -537,5 +527,5 @@ class SendOneOffReplyTestCase(DjangoGoApplicationTestCase):
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],
-            'msg_options': msg_options,
+            'msg_options': {'in_reply_to': msg['message_id']},
             })

--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -186,12 +186,9 @@ class MessageStream(StreamResource):
     @inlineCallbacks
     def handle_PUT_send_to(self, request, payload):
         user_account = request.getUser()
-        user_api = yield self.get_user_api(user_account)
         conversation = yield self.get_conversation(user_account)
 
         msg_options = self.get_msg_options(payload, ['content', 'to_addr'])
-        tag = self.get_conversation_tag(conversation)
-        msg_options.update((yield user_api.msg_options(tag)))
         to_addr = msg_options.pop('to_addr')
         content = msg_options.pop('content')
         msg_options['helper_metadata'] = conversation.set_go_helper_metadata()

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -147,8 +147,8 @@ class GoOutboundResource(SandboxResource):
         if tag not in tags:
             returnValue(self._mkfail(
                 command, reason="Tag %r not held by account" % (tag,)))
-        msg_options = yield user_api.msg_options(tag)
         conv = self.app_worker.conversation_for_api(api)
+        msg_options = {}
         self.app_worker.add_conv_to_msg_options(conv, msg_options)
         endpoint = ':'.join(tag)
         yield self.app_worker.send_to(

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -28,7 +28,6 @@ class StubbedAppWorker(DummyAppWorker):
         self.user_api = Mock()
         self.user_api.list_endpoints = Mock(
             return_value=set([('pool1', '1234'), ('pool2', '1234')]))
-        self.user_api.msg_options = Mock(return_value={'opt1': 'bar'})
         self.conversation = Mock()
         self.send_to = Mock(return_value=succeed(None))
         self.reply_to = Mock(return_value=succeed(None))
@@ -186,8 +185,7 @@ class TestGoOutboundResource(ResourceTestCaseBase):
                 "Sending outbound message to u'6789' via tag "
                 "(u'pool1', u'1234'), content: u'bar'"])
         self.check_reply(reply)
-        self.assert_sent(
-            '6789', 'bar', {'endpoint': 'pool1:1234', 'opt1': 'bar'})
+        self.assert_sent('6789', 'bar', {'endpoint': 'pool1:1234'})
 
     def test_send_to_tag_unacquired(self):
         return self.assert_send_fails(

--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -123,15 +123,6 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
         [batch] = conversation.get_batches()
         [tag] = list(batch.tags)
         [contact] = self.get_contacts_for_conversation(conversation)
-        msg_options = {
-            "transport_type": "sms",
-            "transport_name": self.transport_name,
-            "from_addr": "default10001",
-            "helper_metadata": {
-                "tag": {"tag": list(tag)},
-                "go": {"user_account": conversation.user_account.key},
-                },
-            }
 
         self.assertEqual(start_cmd, VumiApiCommand.command(
                 '%s_application' % (conversation.conversation_type,), 'start',
@@ -144,7 +135,7 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
                 delivery_class=conversation.delivery_class,
-                batch_id=batch.key, msg_options=msg_options))
+                batch_id=batch.key, msg_options={}))
 
     def test_send_fails(self):
         """
@@ -227,9 +218,6 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             }))
 
         [start_cmd, hack_cmd, reply_to_cmd] = self.get_api_commands_sent()
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = msg['message_id']
         self.assertEqual(reply_to_cmd['worker_name'],
                             'multi_survey_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
@@ -238,5 +226,5 @@ class MultiSurveyTestCase(DjangoGoApplicationTestCase):
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],
-            'msg_options': msg_options,
+            'msg_options': {'in_reply_to': msg['message_id']},
             })

--- a/go/apps/multi_surveys/vumi_app.py
+++ b/go/apps/multi_surveys/vumi_app.py
@@ -124,7 +124,9 @@ class MultiSurveyApplication(MamaPollApplication, GoApplicationMixin):
 
         # We reverse the to_addr & from_addr since we're faking input
         # from the client to start the survey.
-        from_addr = msg_options.pop('from_addr')
+        from_addr = msg_options.pop('from_addr', None)
+        msg_options.setdefault('transport_type', None)
+        msg_options.setdefault('transport_name', None)
         conversation.set_go_helper_metadata(
             msg_options.setdefault('helper_metadata', {}))
         msg = TransportUserMessage(from_addr=to_addr, to_addr=from_addr,

--- a/go/apps/sequential_send/tests/test_views.py
+++ b/go/apps/sequential_send/tests/test_views.py
@@ -115,16 +115,6 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
         [start_cmd, hack_cmd] = self.get_api_commands_sent()
         [batch] = conversation.get_batches()
         [] = list(batch.tags)
-        [contact] = self.get_contacts_for_conversation(conversation)
-        msg_options = {
-            "transport_type": "sms",
-            "transport_name": self.transport_name,
-            "from_addr": "default10001",
-            "helper_metadata": {
-                "tag": {"tag": ["longcode", "default10001"]},
-                "go": {"user_account": conversation.user_account.key},
-                },
-            }
 
         self.assertEqual(start_cmd, VumiApiCommand.command(
                 '%s_application' % (conversation.conversation_type,), 'start',
@@ -137,7 +127,7 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
                 delivery_class=conversation.delivery_class,
-                batch_id=batch.key, msg_options=msg_options, dedupe=False))
+                batch_id=batch.key, msg_options={}, dedupe=False))
 
     def test_send_fails(self):
         response = self.client.post(reverse('sequential_send:start', kwargs={

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -138,8 +138,7 @@ class SequentialSendApplication(GoApplicationWorker):
         config = self.get_config_for_conversation(conv)
         messages = config.messages
         batch_id = conv.get_batch_keys()[0]
-        tag = (conv.c.delivery_tag_pool, conv.c.delivery_tag)
-        message_options = yield conv.make_message_options(tag)
+        message_options = {}
         conv.set_go_helper_metadata(
             message_options.setdefault('helper_metadata', {}))
 

--- a/go/apps/sna/handlers.py
+++ b/go/apps/sna/handlers.py
@@ -100,8 +100,6 @@ class USSDMenuCompletionHandler(SNAEventHandler):
         conversation = yield user_api.get_wrapped_conversation(
                                                 conversation_key)
         batch_id = yield conversation.get_latest_batch_key()
-        [tag] = yield conversation.get_tags()
-        msg_options = yield conversation.make_message_options(tag)
 
         yield conversation.dispatch_command(
             'send_message', account_key, conversation.key,
@@ -109,6 +107,6 @@ class USSDMenuCompletionHandler(SNAEventHandler):
                 'batch_id': batch_id,
                 'to_addr': from_addr,
                 'content': content,
-                'msg_options': msg_options,
+                'msg_options': {},
             }
         )

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -116,8 +116,6 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
                                                         msisdn=u'+27761234567')
         yield self.conversation.old_start()
         [self.tag] = yield self.conversation.get_tags()
-        self.msg_options = yield self.conversation.make_message_options(
-            self.tag)
         self.track_event(self.account.key, self.conversation.key,
             'survey_completed', 'sisi_ni_amani', handler_config={
                 'sms_copy': {
@@ -148,7 +146,7 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
                 'batch_id': (yield self.conversation.get_latest_batch_key()),
                 'content': 'english sms',
                 'to_addr': self.contact.msisdn,
-                'msg_options': self.msg_options,
+                'msg_options': {},
             }
         })
 

--- a/go/apps/subscription/tests/test_views.py
+++ b/go/apps/subscription/tests/test_views.py
@@ -80,15 +80,6 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
         [batch] = conversation.get_batches()
         [tag] = list(batch.tags)
         [contact] = self.get_contacts_for_conversation(conversation)
-        msg_options = {
-            "transport_type": "sms",
-            "transport_name": self.transport_name,
-            "from_addr": "default10001",
-            "helper_metadata": {
-                "tag": {"tag": list(tag)},
-                "go": {"user_account": conversation.user_account.key},
-                },
-            }
 
         [start_cmd, hack_cmd] = self.get_api_commands_sent()
         self.assertEqual(start_cmd, VumiApiCommand.command(
@@ -102,7 +93,7 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
                 delivery_class=conversation.delivery_class,
-                batch_id=batch.key, msg_options=msg_options))
+                batch_id=batch.key, msg_options={}))
 
     def test_send_fails(self):
         """

--- a/go/apps/surveys/tests/test_new_views.py
+++ b/go/apps/surveys/tests/test_new_views.py
@@ -361,9 +361,6 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertRedirects(response, self.get_view_url('show'))
 
         [start_cmd, hack_cmd, reply_to_cmd] = self.get_api_commands_sent()
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = msg['message_id']
         self.assertEqual(reply_to_cmd['worker_name'],
                          'survey_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
@@ -372,5 +369,5 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],
-            'msg_options': msg_options,
+            'msg_options': {'in_reply_to': msg['message_id']},
         })

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -133,15 +133,6 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         [batch] = conversation.get_batches()
         [tag] = list(batch.tags)
         [contact] = self.get_contacts_for_conversation(conversation)
-        msg_options = {
-            "transport_type": "sms",
-            "transport_name": self.transport_name,
-            "from_addr": "default10001",
-            "helper_metadata": {
-                "tag": {"tag": list(tag)},
-                "go": {"user_account": conversation.user_account.key},
-                },
-            }
 
         self.assertEqual(start_cmd, VumiApiCommand.command(
                 '%s_application' % (conversation.conversation_type,), 'start',
@@ -154,7 +145,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
                 conversation_key=conversation.key,
                 is_client_initiated=conversation.is_client_initiated(),
                 delivery_class=conversation.delivery_class,
-                batch_id=batch.key, msg_options=msg_options))
+                batch_id=batch.key, msg_options={}))
 
     def test_send_fails(self):
         """
@@ -373,9 +364,6 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             }))
 
         [start_cmd, hack_cmd, reply_to_cmd] = self.get_api_commands_sent()
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = msg['message_id']
         self.assertEqual(reply_to_cmd['worker_name'],
                             'survey_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
@@ -384,5 +372,5 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],
-            'msg_options': msg_options,
+            'msg_options': {'in_reply_to': msg['message_id']},
             })

--- a/go/conversation/base.py
+++ b/go/conversation/base.py
@@ -316,9 +316,7 @@ class ShowConversationView(ConversationView):
         if inbound_message is None:
             logger.info('Replying to an unknown message: %s' % (in_reply_to,))
 
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = in_reply_to
+        msg_options = {'in_reply_to': in_reply_to}
         conversation.dispatch_command(
             'send_message', user_api.user_account_key, conversation.key,
             command_data={

--- a/go/conversation/conversation_views.py
+++ b/go/conversation/conversation_views.py
@@ -301,9 +301,7 @@ class ShowConversationView(ConversationView):
         if inbound_message is None:
             logger.info('Replying to an unknown message: %s' % (in_reply_to,))
 
-        [tag] = conversation.get_tags()
-        msg_options = conversation.make_message_options(tag)
-        msg_options['in_reply_to'] = in_reply_to
+        msg_options = {'in_reply_to': in_reply_to}
         conversation.dispatch_command(
             'send_message', user_api.user_account_key, conversation.key,
             command_data={

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -17,7 +17,6 @@ from vumi.persist.riak_manager import RiakManager
 from vumi.persist.txriak_manager import TxRiakManager
 from vumi.persist.redis_manager import RedisManager
 from vumi.persist.txredis_manager import TxRedisManager
-from vumi.middleware.tagger import TaggingMiddleware
 from vumi import log
 
 from go.vumitools.account import AccountStore, RoutingTableHelper, GoConnector
@@ -25,7 +24,6 @@ from go.vumitools.contact import ContactStore
 from go.vumitools.conversation import ConversationStore
 from go.vumitools.conversation.utils import ConversationWrapper
 from go.vumitools.credit import CreditManager
-from go.vumitools.middleware import DebitAccountMiddleware
 from go.vumitools.token_manager import TokenManager
 
 from django.conf import settings
@@ -367,27 +365,6 @@ class VumiUserApi(object):
             raise VumiError(
                 "Routing table contains illegal connector names: %s" % (
                     routing_connectors,))
-
-    @Manager.calls_manager
-    def msg_options(self, tag, tagpool_metadata=None):
-        """Return a dictionary of message options needed to send a message
-        from this user to the given tag.
-        """
-        if tagpool_metadata is None:
-            tagpool_metadata = yield self.api.tpm.get_metadata(tag[0])
-        msg_options = {}
-        # TODO: transport_type is probably irrelevant
-        msg_options['transport_type'] = tagpool_metadata.get('transport_type')
-        # TODO: not sure whether to declare that tag names must always be
-        #       valid from_addr values or whether to put in a mapping somewhere
-        msg_options['from_addr'] = tag[1]
-        if 'transport_name' in tagpool_metadata:
-            msg_options['transport_name'] = tagpool_metadata['transport_name']
-        msg_options.update(tagpool_metadata.get('msg_options', {}))
-        TaggingMiddleware.add_tag_to_payload(msg_options, tag)
-        DebitAccountMiddleware.add_user_to_payload(msg_options,
-                                                   self.user_account_key)
-        returnValue(msg_options)
 
     @Manager.calls_manager
     def _update_tag_data_for_acquire(self, user_account, tag):

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -162,13 +162,6 @@ class ConversationWrapper(object):
             groups.extend((yield bunch))
         returnValue(groups)
 
-    @Manager.calls_manager
-    def make_message_options(self, tag):
-        yield self.get_tagpool_metadata('msg_options')  # force cache update
-        msg_options = yield self.user_api.msg_options(
-            tag, self._tagpool_metadata)
-        returnValue(msg_options)
-
     def set_go_helper_metadata(self, helper_metadata=None):
         if helper_metadata is None:
             helper_metadata = {}
@@ -246,15 +239,13 @@ class ConversationWrapper(object):
                                     conversation_key=self.c.key)
 
         if send_initial_action_hack:
-            msg_options = yield self.make_message_options(tag)
-
             is_client_initiated = yield self.is_client_initiated()
             yield self.dispatch_command(
                 'initial_action_hack',
                 user_account_key=self.c.user_account.key,
                 conversation_key=self.c.key,
                 batch_id=batch_id,
-                msg_options=msg_options,
+                msg_options={},
                 is_client_initiated=is_client_initiated,
                 delivery_class=self.c.delivery_class,
                 **extra_params)
@@ -323,11 +314,8 @@ class ConversationWrapper(object):
         """
         tag = yield self.acquire_tag()
         batch_id = yield self.start_batch(tag)
-        msg_options = yield self.make_message_options(tag)
         # specify this message as being sensitive
-        helper_metadata = msg_options.setdefault('helper_metadata', {})
-        go_metadata = helper_metadata.setdefault('go', {})
-        go_metadata['sensitive'] = True
+        msg_options = {'helper_metadata': {'go': {'sensitive': True}}}
 
         # We need to have routing set up so that we can send the message with
         # the token in it.

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -226,43 +226,6 @@ class TestTxVumiUserApi(AppWorkerTestCase):
         self.assertEqual(endpoints, set([tag1]))
 
     @inlineCallbacks
-    def test_msg_options(self):
-        tag1, tag2, tag3 = yield self.setup_tagpool(
-            u"pool1", [u"1234", u"5678", u"9012"])
-        yield self.vumi_api.tpm.set_metadata(u"pool1", {
-            'transport_type': 'dummy_transport',
-            'msg_options': {'opt1': 'bar'},
-        })
-        msg_options = yield self.user_api.msg_options(tag1)
-        self.assertEqual(msg_options, {
-            'from_addr': '1234',
-            'helper_metadata': {
-                'go': {'user_account': 'test-0-user'},
-                'tag': {'tag': ['pool1', '1234']},
-            },
-            'transport_type': 'dummy_transport',
-            'opt1': 'bar',
-        })
-
-    @inlineCallbacks
-    def test_msg_options_with_tagpool_metadata(self):
-        tag = ('pool1', '1234')
-        tagpool_metadata = {
-            'transport_type': 'dummy_transport',
-            'msg_options': {'opt1': 'bar'},
-        }
-        msg_options = yield self.user_api.msg_options(tag, tagpool_metadata)
-        self.assertEqual(msg_options, {
-            'from_addr': '1234',
-            'helper_metadata': {
-                'go': {'user_account': 'test-0-user'},
-                'tag': {'tag': ['pool1', '1234']},
-            },
-            'transport_type': 'dummy_transport',
-            'opt1': 'bar',
-        })
-
-    @inlineCallbacks
     def assert_account_tags(self, expected):
         user_account = yield self.user_api.get_user_account()
         self.assertEqual(expected, user_account.tags)


### PR DESCRIPTION
The introduction of new routing means that outbound messages from conversations no longer need tags and other metadata in order to be routed correctly (in fact these are ignored except by the message storing middleware).
