### PR TITLE
Allow conversations in transitional states to be stopped

### DIFF
--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -38,7 +38,12 @@
         </a>
     {% else %}
         {# TODO: Figure out what to put here. #}
-        <a href="{% conversation_screen conversation %}" class="btn btn-primary">???</a>
+        <a href="{% conversation_screen conversation 'stop' %}" 
+            class="btn btn-warning action" 
+            data-name="stop"
+            data-value="Stop">
+            In transition: attempt to stop
+        </a>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
If a conversation somehow gets stuck in a transitional state, there's currently no way to get it out. We should be able to stop such a conversation.
