### PR TITLE
Restrict new conversations to allowed types

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -20,6 +20,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'bulk_message'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.bulk_message')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/http_api/tests/test_views.py
+++ b/go/apps/http_api/tests/test_views.py
@@ -5,6 +5,7 @@ class HttpApiTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'http_api'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.http_api')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/jsbox/tests/test_views.py
+++ b/go/apps/jsbox/tests/test_views.py
@@ -10,6 +10,7 @@ class JsBoxTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'jsbox'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.jsbox')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/opt_out/tests/test_views.py
+++ b/go/apps/opt_out/tests/test_views.py
@@ -5,6 +5,7 @@ class OptOutTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'opt_out'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.opt_out')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/sequential_send/tests/test_views.py
+++ b/go/apps/sequential_send/tests/test_views.py
@@ -6,6 +6,7 @@ class SequentialSendTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'sequential_send'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.sequential_send')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/subscription/tests/test_views.py
+++ b/go/apps/subscription/tests/test_views.py
@@ -6,6 +6,7 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'subscription'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.subscription')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -29,6 +29,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         return pm, pm.register(poll_id, config)
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.survey')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -29,7 +29,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         return pm, pm.register(poll_id, config)
 
     def test_new_conversation(self):
-        self.add_app_permission(u'go.apps.survey')
+        self.add_app_permission(u'go.apps.surveys')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/apps/wikipedia/tests/test_views.py
+++ b/go/apps/wikipedia/tests/test_views.py
@@ -5,6 +5,7 @@ class WikipediaTestCase(DjangoGoApplicationTestCase):
     TEST_CONVERSATION_TYPE = u'wikipedia'
 
     def test_new_conversation(self):
+        self.add_app_permission(u'go.apps.wikipedia')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
         response = self.post_new_conversation()
         self.assertEqual(len(self.conv_store.list_conversations()), 1)

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -217,6 +217,15 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
         account.tagpools.add(permission)
         account.save()
 
+    def add_app_permission(self, application):
+        permission = self.api.account_store.application_permissions(
+            uuid.uuid4().hex, application=application)
+        permission.save()
+
+        account = self.user_api.get_user_account()
+        account.applications.add(permission)
+        account.save()
+
 
 class FakeMessageStoreClient(object):
 

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -2,19 +2,20 @@ from django import forms
 
 from bootstrap.forms import BootstrapForm
 
-from go.base.utils import configured_conversation_types
-
 
 class NewConversationForm(forms.Form):
-
-    TYPE_CHOICES = configured_conversation_types().items()
 
     name = forms.CharField(label="Conversation name", max_length=100)
     description = forms.CharField(
         label="Conversation Description", required=False)
-    conversation_type = forms.ChoiceField(
-        label="Which kind of conversation would you like?",
-        choices=TYPE_CHOICES)
+
+    def __init__(self, user_api, *args, **kwargs):
+        super(NewConversationForm, self).__init__(*args, **kwargs)
+        type_choices = [(app['namespace'], app['display_name'])
+                        for key, app in user_api.applications()]
+        self.fields['conversation_type'] = forms.ChoiceField(
+            label="Which kind of conversation would you like?",
+            choices=type_choices)
 
 
 class ConfirmConversationForm(BootstrapForm):

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -12,7 +12,7 @@ class NewConversationForm(forms.Form):
     def __init__(self, user_api, *args, **kwargs):
         super(NewConversationForm, self).__init__(*args, **kwargs)
         type_choices = [(app['namespace'], app['display_name'])
-                        for key, app in user_api.applications()]
+                        for app in user_api.applications().itervalues()]
         self.fields['conversation_type'] = forms.ChoiceField(
             label="Which kind of conversation would you like?",
             choices=type_choices)

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -30,11 +30,15 @@ class ConversationTestCase(VumiGoDjangoTestCase):
         account.save()
 
     def test_get_new_conversation(self):
+        self.add_app_permission(u'go.apps.bulk_message')
         response = self.client.get(reverse('conversations:new_conversation'))
         self.assertContains(response, 'Conversation name')
         self.assertContains(response, 'kind of conversation')
+        self.assertContains(response, 'bulk_message')
+        self.assertNotContains(response, 'survey')
 
     def test_post_new_conversation(self):
+        self.add_app_permission(u'go.apps.bulk_message')
         conv_data = {
             'name': 'new conv',
             'conversation_type': 'bulk_message',
@@ -49,6 +53,7 @@ class ConversationTestCase(VumiGoDjangoTestCase):
         self.assertEqual(conv.conversation_type, 'bulk_message')
 
     def test_post_new_conversation_extra_endpoints(self):
+        self.add_app_permission(u'go.apps.wikipedia')
         conv_data = {
             'name': 'new conv',
             'conversation_type': 'wikipedia',

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.core.urlresolvers import reverse
 from django.utils.unittest import skip
 
@@ -19,15 +17,6 @@ class ConversationTestCase(VumiGoDjangoTestCase):
         self.setup_api()
         self.setup_user_api()
         self.setup_client()
-
-    def add_app_permission(self, application):
-        permission = self.api.account_store.application_permissions(
-            uuid.uuid4().hex, application=application)
-        permission.save()
-
-        account = self.user_api.get_user_account()
-        account.applications.add(permission)
-        account.save()
 
     def test_get_new_conversation(self):
         self.add_app_permission(u'go.apps.bulk_message')

--- a/go/conversation/views.py
+++ b/go/conversation/views.py
@@ -98,7 +98,7 @@ def conversation_action(request, conversation_key, action_name):
 @login_required
 def new_conversation(request):
     if request.method == 'POST':
-        form = NewConversationForm(request.POST)
+        form = NewConversationForm(request.user_api, request.POST)
         if not form.is_valid():
             # TODO: Something more sensible here?
             return HttpResponse(
@@ -124,7 +124,7 @@ def new_conversation(request):
         return redirect(view_def.get_view_url(
             next_view, conversation_key=conv.key))
 
-    conversation_form = NewConversationForm()
+    conversation_form = NewConversationForm(request.user_api)
     return render(request, 'conversation/new.html', {
         'conversation_form': conversation_form,
     })

--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -45,6 +45,7 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
             }))
 
     def test_post_create_view_editable_conversation(self):
+        self.add_app_permission(u'go.apps.jsbox')
         self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         self.assertEqual(0, len(self.user_api.active_conversations()))

--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -13,16 +13,20 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
         self.setup_client()
 
     def test_get_create_view(self):
+        self.add_app_permission(u'go.apps.bulk_message')
+        self.add_app_permission(u'go.apps.subscription')
         self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         response = self.client.get(reverse('wizard:create'))
         # Check that we have a few conversation types in the response
         self.assertContains(response, 'bulk_message')
         self.assertContains(response, 'subscription')
+        self.assertNotContains(response, 'survey')
         # Check that we have a tagpool/tag in the response
         self.assertContains(response, 'longcode:')
 
     def test_post_create_view_valid(self):
+        self.add_app_permission(u'go.apps.bulk_message')
         self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         self.assertEqual(0, len(self.user_api.active_conversations()))
@@ -41,6 +45,7 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
             }))
 
     def test_post_create_view_extra_endpoints(self):
+        self.add_app_permission(u'go.apps.wikipedia')
         self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')
         self.assertEqual(0, len(self.user_api.active_conversations()))
@@ -71,6 +76,7 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_post_create_view_invalid_country(self):
+        self.add_app_permission(u'go.apps.bulk_message')
         response = self.client.post(reverse('wizard:create'), {
             'conversation_type': 'bulk_message',
             'name': 'My Conversation',
@@ -82,6 +88,7 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_post_create_view_invalid_channel(self):
+        self.add_app_permission(u'go.apps.bulk_message')
         response = self.client.post(reverse('wizard:create'), {
             'conversation_type': 'bulk_message',
             'name': 'My Conversation',

--- a/go/wizard/views.py
+++ b/go/wizard/views.py
@@ -26,18 +26,18 @@ def create(request, conversation_key=None):
 
     """
     wizard_form = Wizard1CreateForm()
-    conversation_form = NewConversationForm()
+    conversation_form = NewConversationForm(request.user_api)
     channel_form = NewChannelForm(request.user_api)
 
     conversation = None
     if conversation_key:
         conversation = conversation_or_404(request.user_api, conversation_key)
         conversation_form = NewConversationForm(
-            data={'name': conversation.name})
+            request.user_api, data={'name': conversation.name})
 
     if request.method == 'POST':
         # TODO: Reuse new conversation/channel view logic here.
-        posted_conv_form = NewConversationForm(request.POST)
+        posted_conv_form = NewConversationForm(request.user_api, request.POST)
         posted_chan_form = NewChannelForm(request.user_api, request.POST)
         if posted_conv_form.is_valid() and posted_chan_form.is_valid():
 


### PR DESCRIPTION
We're not checking app permissions anywhere in the conversation creation flow. We really need to do this.
