### PR TITLE
User should be directed to the conversation edit or show pages after clicking “save” at the end of the wizard.

### DIFF
--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -40,6 +40,24 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
                 'conversation_key': conv.key, 'path_suffix': '',
             }))
 
+    def test_post_create_view_editable_conversation(self):
+        self.declare_tags(u'longcode', 4)
+        self.add_tagpool_permission(u'longcode')
+        self.assertEqual(0, len(self.user_api.active_conversations()))
+        self.assertEqual(0, len(self.user_api.list_endpoints()))
+        response = self.client.post(reverse('wizard:create'), {
+            'conversation_type': 'jsbox',
+            'name': 'My Conversation',
+            'country': 'International',
+            'channel': 'longcode:',
+        })
+        [conv] = self.user_api.active_conversations()
+        self.assertEqual(1, len(self.user_api.list_endpoints()))
+        self.assertRedirects(
+            response, reverse('conversations:conversation', kwargs={
+                'conversation_key': conv.key, 'path_suffix': 'edit/',
+            }))
+
     def test_post_create_view_extra_endpoints(self):
         self.declare_tags(u'longcode', 4)
         self.add_tagpool_permission(u'longcode')

--- a/go/wizard/views.py
+++ b/go/wizard/views.py
@@ -68,10 +68,12 @@ def create(request, conversation_key=None):
             rt_helper.add_oldstyle_conversation(conversation, got_tag)
             user_account.save()
 
-            # TODO save and go to next step.
-            return redirect(
-                'conversations:conversation',
-                conversation_key=conversation.key, path_suffix='')
+            if view_def.is_editable:
+                return redirect(view_def.get_view_url(
+                    'edit', conversation_key=conversation.key))
+            else:
+                return redirect(view_def.get_view_url(
+                    'show', conversation_key=conversation.key))
         else:
             logger.info("Validation failed: %r %r" % (
                 posted_conv_form.errors, posted_chan_form.errors))


### PR DESCRIPTION
Currently they are always directed to the show page.

If the conversation type is editable, they should be directed to the edit page instead.
