### PR TITLE
Better logic for enabling the send message and survey actions.

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -12,10 +12,8 @@ class BulkSendAction(ConversationAction):
     needs_running = True
 
     def check_disabled(self):
-        channels = self._conv.get_channels()
-        for channel in channels:
-            if channel.supports_generic_sends():
-                return None
+        if self._conv.has_channel_supporting(generic_sends=True):
+            return None
         return ("This action needs channels capable of sending"
                 " messages attached to this conversation.")
 

--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -11,6 +11,14 @@ class BulkSendAction(ConversationAction):
     needs_group = True
     needs_running = True
 
+    def check_disabled(self):
+        channels = self._conv.get_channels()
+        for channel in channels:
+            if channel.supports_generic_sends():
+                return None
+        return ("This action needs channels capable of sending"
+                " messages attached to this conversation.")
+
     def perform_action(self, action_data):
         return self.send_command(
             'bulk_send', batch_id=self._conv.get_latest_batch_key(),

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -17,13 +17,13 @@ from mock import patch
 
 
 class BulkMessageTestCase(DjangoGoApplicationTestCase):
-    TEST_CONVERSATION_TYPE = u'bulk_message'
 
-    def attach_channel(self):
-        self.declare_tags("pool", 1, {
-            "supports": {"generic_sends": True}})
-        self.add_channel_to_conversation(
-            self.conversation, ["pool", "default1"])
+    TEST_CONVERSATION_TYPE = u'bulk_message'
+    TEST_CHANNEL_METADATA = {
+        "supports": {
+            "generic_sends": True,
+        },
+    }
 
     def test_new_conversation(self):
         self.add_app_permission(u'go.apps.bulk_message')
@@ -105,8 +105,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         """
         Test showing the conversation
         """
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
@@ -233,8 +233,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(mime_type, 'application/zip')
 
     def test_action_bulk_send_view(self):
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.get(self.get_action_view_url('bulk_send'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
@@ -282,8 +282,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual([], self.get_api_commands_sent())
 
     def test_action_bulk_send_dedupe(self):
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': True})
@@ -300,8 +300,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             content='I am ham, not spam.', dedupe=True))
 
     def test_action_bulk_send_no_dedupe(self):
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.post(
             self.get_action_view_url('bulk_send'),
             {'message': 'I am ham, not spam.', 'dedupe': False})
@@ -329,8 +329,8 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         user_account.save()
 
         # Start the conversation
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
 
         # POST the action with a mock token manager
         with patch.object(TokenManager, 'generate_token') as mock_method:

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -12,10 +12,8 @@ class SendSurveyAction(ConversationAction):
     needs_running = True
 
     def check_disabled(self):
-        channels = self._conv.get_channels()
-        for channel in channels:
-            if channel.supports_generic_sends():
-                return None
+        if self._conv.has_channel_supporting(generic_sends=True):
+            return None
         return ("This action needs channels capable of sending"
                 " messages attached to this conversation.")
 

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -11,6 +11,14 @@ class SendSurveyAction(ConversationAction):
     needs_group = True
     needs_running = True
 
+    def check_disabled(self):
+        channels = self._conv.get_channels()
+        for channel in channels:
+            if channel.supports_generic_sends():
+                return None
+        return ("This action needs channels capable of sending"
+                " messages attached to this conversation.")
+
     def perform_action(self, action_data):
         return self.send_command(
             'send_survey', batch_id=self._conv.get_latest_batch_key(),

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -61,6 +61,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_action_send_survey_post(self):
         self.setup_conversation(started=True, with_group=True)
+        self.attach_channel()
         response = self.client.post(
             self.get_action_view_url('send_survey'), {}, follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
@@ -171,6 +172,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         Test showing the conversation
         """
         self.setup_conversation(started=True, with_group=True)
+        self.attach_channel()
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, 'Test Conversation')

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -88,6 +88,18 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             "Action disabled: This action needs a running conversation.")
         self.assertEqual([], self.get_api_commands_sent())
 
+    def test_action_send_survey_no_channel(self):
+        self.setup_conversation(started=True, with_group=True)
+        response = self.client.post(
+            self.get_action_view_url('send_survey'), {}, follow=True)
+        self.assertRedirects(response, self.get_view_url('show'))
+        [msg] = response.context['messages']
+        self.assertEqual(
+            str(msg),
+            "Action disabled: This action needs channels capable"
+            " of sending messages attached to this conversation.")
+        self.assertEqual([], self.get_api_commands_sent())
+
     @skip("The new views don't have this yet.")
     def test_group_selection(self):
         """Select an existing group and use that as the group for the

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -16,6 +16,11 @@ from mock import patch
 class SurveyTestCase(DjangoGoApplicationTestCase):
 
     TEST_CONVERSATION_TYPE = u'survey'
+    TEST_CHANNEL_METADATA = {
+        "supports": {
+            "generic_sends": True,
+        },
+    }
 
     def setUp(self):
         super(SurveyTestCase, self).setUp()
@@ -27,12 +32,6 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         pm, config = get_poll_config(poll_id)
         config.update(kwargs)
         return pm, pm.register(poll_id, config)
-
-    def attach_channel(self):
-        self.declare_tags("pool", 1, {
-            "supports": {"generic_sends": True}})
-        self.add_channel_to_conversation(
-            self.conversation, ["pool", "default1"])
 
     def test_new_conversation(self):
         self.add_app_permission(u'go.apps.surveys')
@@ -52,16 +51,16 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         self.assertTrue(conversation.stopping())
 
     def test_action_send_survey_get(self):
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.get(self.get_action_view_url('send_survey'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
         self.assertEqual([], self.get_api_commands_sent())
 
     def test_action_send_survey_post(self):
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.post(
             self.get_action_view_url('send_survey'), {}, follow=True)
         self.assertRedirects(response, self.get_view_url('show'))
@@ -171,8 +170,8 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         """
         Test showing the conversation
         """
-        self.setup_conversation(started=True, with_group=True)
-        self.attach_channel()
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, 'Test Conversation')

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -28,6 +28,12 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
         config.update(kwargs)
         return pm, pm.register(poll_id, config)
 
+    def attach_channel(self):
+        self.declare_tags("pool", 1, {
+            "supports": {"generic_sends": True}})
+        self.add_channel_to_conversation(
+            self.conversation, ["pool", "default1"])
+
     def test_new_conversation(self):
         self.add_app_permission(u'go.apps.surveys')
         self.assertEqual(len(self.conv_store.list_conversations()), 0)
@@ -47,6 +53,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
 
     def test_action_send_survey_get(self):
         self.setup_conversation(started=True, with_group=True)
+        self.attach_channel()
         response = self.client.get(self.get_action_view_url('send_survey'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -19,6 +19,7 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
     TEST_CONVERSATION_NAME = u"Test Conversation"
     TEST_CONVERSATION_TYPE = u'bulk_message'
     TEST_CONVERSATION_PARAMS = None
+    TEST_CHANNEL_METADATA = None
 
     # These are used for the mkmsg_in and mkmsg_out helper methods
     transport_name = 'sphex'
@@ -31,7 +32,7 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
         self.setup_client()
 
     def setup_conversation(self, started=False, with_group=False,
-                           with_contact=False):
+                           with_contact=False, with_channel=False):
         params = {
             'conversation_type': self.TEST_CONVERSATION_TYPE,
             'name': self.TEST_CONVERSATION_NAME,
@@ -45,7 +46,10 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
                 self.contact = self.contact_store.new_contact(
                     msisdn=u"+27761234567", name=self.TEST_CONTACT_NAME,
                     surname=self.TEST_CONTACT_SURNAME, groups=[self.group])
-
+        if with_channel:
+            self.declare_tags("pool", 1, self.TEST_CHANNEL_METADATA or {})
+            self.add_channel_to_conversation(
+                self.conversation, ["pool", "default1"])
         if self.TEST_CONVERSATION_PARAMS:
             params.update(self.TEST_CONVERSATION_PARAMS)
         self.conversation = self.create_conversation(started=started, **params)

--- a/go/apps/tests/base.py
+++ b/go/apps/tests/base.py
@@ -46,14 +46,14 @@ class DjangoGoApplicationTestCase(VumiGoDjangoTestCase):
                 self.contact = self.contact_store.new_contact(
                     msisdn=u"+27761234567", name=self.TEST_CONTACT_NAME,
                     surname=self.TEST_CONTACT_SURNAME, groups=[self.group])
-        if with_channel:
-            self.declare_tags("pool", 1, self.TEST_CHANNEL_METADATA or {})
-            self.add_channel_to_conversation(
-                self.conversation, ["pool", "default1"])
         if self.TEST_CONVERSATION_PARAMS:
             params.update(self.TEST_CONVERSATION_PARAMS)
         self.conversation = self.create_conversation(started=started, **params)
         self.conv_key = self.conversation.key
+        if with_channel:
+            self.declare_tags("pool", 1, self.TEST_CHANNEL_METADATA or {})
+            self.add_channel_to_conversation(
+                self.conversation, ["pool", "default1"])
 
     def get_latest_conversation(self):
         # We won't have too many here, so doing it naively is fine.

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -12,6 +12,7 @@ from vumi.tests.fake_amqp import FakeAMQPBroker
 from vumi.message import TransportUserMessage, TransportEvent
 
 from go.vumitools.tests.utils import GoPersistenceMixin, FakeAmqpConnection
+from go.vumitools.account.models import RoutingTableHelper
 from go.vumitools.api import VumiApi
 from go.base import models as base_models
 from go.base import utils as base_utils
@@ -194,6 +195,12 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
             self.api.mdb.add_event(ack)
             messages.append((msg_in, msg_out, ack))
         return messages
+
+    def add_channel_to_conversation(self, conv, tag):
+        user_account = self.user_api.get_user_account()
+        rt = RoutingTableHelper(user_account.routing_table)
+        rt.add_oldstyle_conversation(conv, tag)
+        user_account.save()
 
     def declare_tags(self, pool, num_tags, metadata=None):
         """Declare a set of long codes to the tag pool."""

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -197,6 +197,9 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
         return messages
 
     def add_channel_to_conversation(self, conv, tag):
+        # TODO: This is a duplicate of the method in
+        #       go.vumitools.test.utils.GoAppWorkerTestMixin but
+        #       there is no suitable common base class.
         user_account = self.user_api.get_user_account()
         rt = RoutingTableHelper(user_account.routing_table)
         rt.add_oldstyle_conversation(conv, tag)

--- a/go/vumitools/channel/models.py
+++ b/go/vumitools/channel/models.py
@@ -19,12 +19,22 @@ class CheapPlasticChannel(object):
     def release(self, user_api):
         user_api.release_tag((self.tagpool, self.tag))
 
+    def _check_support(self, option):
+        supports = self.tagpool_metadata.get('supports', {})
+        return bool(supports.get(option))
+
+    def supports_generic_sends(self):
+        return self._check_support('generic_sends')
+
+    def supports_replies(self):
+        return self._check_support('replies')
+
 
 class ChannelStore(PerAccountStore):
     # TODO: This is a mostly a placeholder until we have a real
     #       channel model.
 
-    def get_channel_by_tag(self, tag, tagpool_metadata=None):
+    def get_channel_by_tag(self, tag, tagpool_metadata):
         """Return the active channel within this account for the given tag.
 
         Returns `None` if no such channel exists.

--- a/go/vumitools/channel/models.py
+++ b/go/vumitools/channel/models.py
@@ -23,6 +23,10 @@ class CheapPlasticChannel(object):
         supports = self.tagpool_metadata.get('supports', {})
         return bool(supports.get(option))
 
+    def supports(self, **kw):
+        return all(self._check_support(option) == value
+                   for option, value in kw.iteritems())
+
     def supports_generic_sends(self):
         return self._check_support('generic_sends')
 

--- a/go/vumitools/channel/tests/test_models.py
+++ b/go/vumitools/channel/tests/test_models.py
@@ -7,7 +7,24 @@ from twisted.trial.unittest import TestCase
 
 from go.vumitools.tests.utils import GoPersistenceMixin
 from go.vumitools.account import AccountStore
-from go.vumitools.channel.models import ChannelStore
+from go.vumitools.channel.models import ChannelStore, CheapPlasticChannel
+
+
+class TestChannel(TestCase):
+
+    def test_supports_generic_sends(self):
+        channel = CheapPlasticChannel("pool", "tag", {
+            "supports": {"generic_sends": True}})
+        self.assertTrue(channel.supports_generic_sends())
+        channel = CheapPlasticChannel("pool", "tag", {})
+        self.assertFalse(channel.supports_generic_sends())
+
+    def test_supports_replies(self):
+        channel = CheapPlasticChannel("pool", "tag", {
+            "supports": {"replies": True}})
+        self.assertTrue(channel.supports_replies())
+        channel = CheapPlasticChannel("pool", "tag", {})
+        self.assertFalse(channel.supports_replies())
 
 
 class TestChannelStore(GoPersistenceMixin, TestCase):
@@ -25,12 +42,12 @@ class TestChannelStore(GoPersistenceMixin, TestCase):
     @inlineCallbacks
     def test_get_channel_by_tag(self):
         tag = ["pool", "tag"]
-        channel = yield self.channel_store.get_channel_by_tag(tag)
+        channel = yield self.channel_store.get_channel_by_tag(tag, {})
         self.assertEqual(channel.tagpool, "pool")
         self.assertEqual(channel.tag, "tag")
         self.assertEqual(channel.key, "pool:tag")
         self.assertEqual(channel.name, "tag")
-        self.assertEqual(channel.tagpool_metadata, None)
+        self.assertEqual(channel.tagpool_metadata, {})
 
 
 class TestChannelStoreSync(TestChannelStore):

--- a/go/vumitools/channel/tests/test_models.py
+++ b/go/vumitools/channel/tests/test_models.py
@@ -12,6 +12,15 @@ from go.vumitools.channel.models import ChannelStore, CheapPlasticChannel
 
 class TestChannel(TestCase):
 
+    def test_supports(self):
+        channel = CheapPlasticChannel("pool", "tag", {
+            "supports": {"foo": True}})
+        self.assertTrue(channel.supports(foo=True))
+        self.assertTrue(channel.supports())
+        self.assertFalse(channel.supports(foo=False))
+        self.assertFalse(channel.supports(bar=True))
+        self.assertFalse(channel.supports(foo=True, bar=True))
+
     def test_supports_generic_sends(self):
         channel = CheapPlasticChannel("pool", "tag", {
             "supports": {"generic_sends": True}})

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -141,6 +141,11 @@ class ConversationWrapper(object):
         returnValue(channels)
 
     @Manager.calls_manager
+    def has_channel_supporting(self, **kw):
+        channels = yield self.get_channels()
+        returnValue(any(channel.supports(**kw) for channel in channels))
+
+    @Manager.calls_manager
     def get_progress_status(self):
         """
         Get an overview of the progress of this conversation

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -128,10 +128,15 @@ class ConversationWrapper(object):
         outbound = rt_helper.transitive_targets(str(conn))
         connectors = incoming | outbound
         go_connectors = [GoConnector.parse(s) for s in connectors]
-        channels = [
-            self.user_api.channel_store.get_channel_by_tag(
-                [c.tagpool, c.tagname])
-            for c in go_connectors if c.ctype == c.TRANSPORT_TAG]
+        channels = []
+        for conn in go_connectors:
+            if conn.ctype != conn.TRANSPORT_TAG:
+                continue
+            tag = [conn.tagpool, conn.tagname]
+            metadata = yield self.user_api.api.tpm.get_metadata(conn.tagpool)
+            channel = self.user_api.channel_store.get_channel_by_tag(
+                tag, metadata)
+            channels.append(channel)
         channels.sort(key=lambda c: c.name)
         returnValue(channels)
 

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -202,6 +202,9 @@ class GoAppWorkerTestMixin(GoPersistenceMixin):
 
     @inlineCallbacks
     def add_channel_to_conversation(self, conv, tag):
+        # TODO: This is a duplicate of the method in
+        #       go.base.test.utils.VumiGoDjangoTestCase but
+        #       there is no suitable common base class.
         user_account = yield self.user_api.get_user_account()
         rt = RoutingTableHelper(user_account.routing_table)
         rt.add_oldstyle_conversation(conv, tag)

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -13,7 +13,7 @@ from vumi.application.tests.test_base import ApplicationTestCase
 from vumi.tests.utils import PersistenceMixin
 
 from go.vumitools.api import VumiApiCommand
-from go.vumitools.account import UserAccount
+from go.vumitools.account import UserAccount, RoutingTableHelper
 from go.vumitools.contact import Contact, ContactGroup
 
 
@@ -139,15 +139,16 @@ class GoAppWorkerTestMixin(GoPersistenceMixin):
         return self.setup_tagpool(u"pool", [u"tag1", u"tag2"])
 
     @inlineCallbacks
-    def setup_tagpool(self, pool, tags, transport_name=None, permission=True):
+    def setup_tagpool(self, pool, tags, transport_name=None, metadata=None,
+                      permission=True):
         tags = [(pool, tag) for tag in tags]
         if transport_name is None:
             transport_name = self.transport_name
+        metadata = metadata.copy() if metadata is not None else {}
+        metadata.setdefault("transport_type", self.transport_type)
+        metadata.setdefault("transport_name", transport_name)
         yield self.vumi_api.tpm.declare_tags(tags)
-        yield self.vumi_api.tpm.set_metadata(pool, {
-            "transport_type": self.transport_type,
-            "transport_name": transport_name,
-        })
+        yield self.vumi_api.tpm.set_metadata(pool, metadata)
         if permission:
             yield self.add_tagpool_permission(pool)
         returnValue(tags)
@@ -198,6 +199,13 @@ class GoAppWorkerTestMixin(GoPersistenceMixin):
             yield self.dispatch_command(
                 cmd.payload['command'], *cmd.payload['args'],
                 **cmd.payload['kwargs'])
+
+    @inlineCallbacks
+    def add_channel_to_conversation(self, conv, tag):
+        user_account = yield self.user_api.get_user_account()
+        rt = RoutingTableHelper(user_account.routing_table)
+        rt.add_oldstyle_conversation(conv, tag)
+        yield user_account.save()
 
     @inlineCallbacks
     def start_conversation(self, conversation):


### PR DESCRIPTION
Currently the send message and send survey actions are enabled when a bulk message or survey conversation is activated. Ideally this logic should be extended so that the action is only enabled if the conversation is:
- activated
- linked to a channel that supports sending messages that aren't replies
- has one or more contact groups assigned
