### PR TITLE
Center '+' sign

### DIFF
--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -62,6 +62,8 @@
 
     .add {
       height: 60px;
+      display: table-cell;
+      vertical-align: center;
 
       font-size: 68px;
       .user-select(none);

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -288,6 +288,8 @@ button {
 }
 .dialogue #diagram .add {
   height: 60px;
+  display: table-cell;
+  vertical-align: center;
   font-size: 68px;
   -webkit-user-select: none;
   -moz-user-select: none;


### PR DESCRIPTION
On the dialogue page the '+' sign is aligned to the bottom of the blue square - it should be centered.

![screen shot 2013-07-10 at 11 29 25 am](https://f.cloud.github.com/assets/1521387/773800/3264d866-e943-11e2-8592-54fa0361f1a6.png)
