### PR TITLE
Fix positioning of arrow on dialogue state connections

### DIFF
--- a/go/base/static/js/src/campaign/dialogue/style.js
+++ b/go/base/static/js/src/campaign/dialogue/style.js
@@ -33,7 +33,7 @@
       'Arrow', {
       width: 14,
       height: 14,
-      location: 0.75
+      location: 0.85
     }]];
   };
 


### PR DESCRIPTION
Currently, the dialogue state connection arrows are positioned near the middle of the connection. This screws up the arrow a bit when connections are made from the last state on a row to the first state on the next row.
