### PR TITLE
Delete the 'cancel' link on the conversation show page

### DIFF
--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -8,7 +8,6 @@
 
 
 {% block content_actions_right %}
-    <a href="{% url 'conversations:index' %}">Cancel</a>
     {% if is_editable %}
         <a href="{% conversation_screen conversation 'edit' %}" class="btn btn-primary">Edit</a>
     {% endif %}


### PR DESCRIPTION
On the conversation show page, the 'cancel'
![screen shot 2013-07-10 at 11 30 38 am](https://f.cloud.github.com/assets/1521387/773827/13d3e440-e944-11e2-9108-efc932554bd5.png)
 link should not appear
