### PR TITLE
Gray action buttons on conversation show page are too large

### DIFF
--- a/go/account/templates/account/details.html
+++ b/go/account/templates/account/details.html
@@ -31,7 +31,7 @@
         </form>
     </div>
 
-    {# TODO
+    {% comment %} TODO
     <div class="span4 sidebar">
         <h4>Admin settings</h4>
         <ul class="nav nav-pills nav-stacked">
@@ -50,7 +50,7 @@
             </li>   
         </ul>
     </div>
-    #}
+    {% endcomment %}
 </div>
 {% endblock %}
 

--- a/go/base/static/css/campaigns.less
+++ b/go/base/static/css/campaigns.less
@@ -4,6 +4,9 @@
   .status {
     text-transform:capitalize;
   }
+  .sidebar p .btn {
+    margin-left:-4px;
+  }
 }
 
 .campaigns.details {

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -389,6 +389,9 @@ button {
 .campaigns.dashboard .status {
   text-transform: capitalize;
 }
+.campaigns.dashboard .sidebar p .btn {
+  margin-left: -4px;
+}
 .campaigns.details ul,
 .campaigns.details li {
   list-style-type: none;

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -11,7 +11,7 @@ class NewConversationForm(forms.Form):
 
     name = forms.CharField(label="Conversation name", max_length=100)
     description = forms.CharField(
-        label="Conversation Description", required=False)
+        label="Conversation description", required=False)
     conversation_type = forms.ChoiceField(
         label="Which kind of conversation would you like?",
         choices=TYPE_CHOICES)

--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -99,7 +99,7 @@
                                 <td>{{ conversation.created_at|naturaltime }}</td>
                                 <td>
                                     <a href="{% url 'conversations:incoming_list' conversation.key %}">Messages</a>
-                                    <a href="{% url 'todo' %}">Reports</a>
+                                    {# <a href="{% url 'todo' %}">Reports</a> #}
                                 </td>
                             </tr>
                             {% endfor %}

--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -31,11 +31,14 @@
     <div class="row-fluid">
         <div class="span3 sidebar">
 
-            <div class="nav nav-list extra-actions">
-                <a href="{% url 'routing' %}">Configure channels</a>
-            </div>
+            
+            <p>
+                <a href="{% url 'routing' %}" class="btn btn-primary">Configure channels (alpha)</a>
+            <p>
+            
 
             <ul class="nav nav-list">
+                
                 <li>
                     <a href="{% url 'conversations:index' %}">All campaigns</a>
                     <ul class="nav nav-list">

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -108,7 +108,7 @@
 
     <div class="span5">
         {% if actions %}
-        <div class="sub-actions">
+        <div class="sub-actions pull-right">
             <ul class="nav nav-pills nav-stacked">
                 {% for action in actions %}
                     {% with is_disabled=action.is_disabled %}


### PR DESCRIPTION
One the conversation show page the gray action buttons span half the page. They should span the width of the text only and be aligned with the right hand side of the page.

![screen shot 2013-07-10 at 11 30 38 am](https://f.cloud.github.com/assets/1521387/773809/903c24bc-e943-11e2-903e-a74cd920121f.png)
