### PR TITLE
Reset the routing diagram's model without needing the api

### DIFF
--- a/go/routing/templates/routing.html
+++ b/go/routing/templates/routing.html
@@ -78,7 +78,7 @@ jsPlumb.ready(function() {
 
   $('#reset').click(function(e) {
       e.preventDefault();
-      diagram.model.fetch({reset: true});
+      diagram.model.set(modelData);
   });
 });
 {% endblock %}


### PR DESCRIPTION
When the user clicks the reset button, it makes more sense to just restore the model to a backup than to call `diagram.model.fetch()` and issue an unnecessary api request.
