### PR TITLE
Change bulk message action button to "Write and send bulk message"

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -4,7 +4,7 @@ from go.vumitools.conversation.definition import (
 
 class BulkSendAction(ConversationAction):
     action_name = 'bulk_send'
-    action_display_name = 'Send Bulk Message'
+    action_display_name = 'Write and send bulk message'
 
     needs_confirmation = True
 

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -98,7 +98,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
-        self.assertContains(response, 'Send Bulk Message')
+        self.assertContains(response, 'Write and send bulk message')
         self.assertNotContains(response, self.get_action_view_url('bulk_send'))
 
     def test_show_running(self):
@@ -110,7 +110,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
-        self.assertContains(response, 'Send Bulk Message')
+        self.assertContains(response, 'Write and send bulk message')
         self.assertContains(response, self.get_action_view_url('bulk_send'))
 
     @skip("The new views don't have this.")


### PR DESCRIPTION
The bulk message conversation's show page currently contains an action button named "Send bulk message". This needs to be changed to "Write and send bulk message".
