### PR TITLE
Change the conversation show page's 'Messages' edit button to redirect to the right place

### DIFF
--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -82,7 +82,7 @@
         <div class="sub-messages">
             <h4>
                 Messages
-                <a href="{% url 'wizard:edit' conversation.key %}" class="btn btn-primary btn-mini">Edit</a>
+                <a href="{% conversation_screen conversation 'edit' %}" class="btn btn-primary">Edit</a>
             </h4>
 
             <p class="message">

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -82,7 +82,9 @@
         <div class="sub-messages">
             <h4>
                 Messages
+                {% is_editable %}
                 <a href="{% conversation_screen conversation 'edit' %}" class="btn btn-primary">Edit</a>
+                {% endif %}
             </h4>
 
             <p class="message">


### PR DESCRIPTION
The 'Messages' edit button should redirect to the appropriate app edit page instead of a wizard edit screen.
