### PR TITLE
Add All channels link to dashboard template

### DIFF
--- a/go/base/static/css/channels.less
+++ b/go/base/static/css/channels.less
@@ -1,3 +1,12 @@
+.channels.dashboard {
+
+    // this table doesn't have a lot of content
+    // so we set the width of the first child to 30px
+    td:first-child {
+        width:30px;
+    }
+}
+
 .channels.new {
 
     // channel selection is based on country selection,

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -389,6 +389,9 @@ button {
 .dialogue #diagram .choice.state .preview.mode .choices {
   text-align: left;
 }
+.channels.dashboard td:first-child {
+  width: 30px;
+}
 .channels.new .channel select {
   display: none;
 }

--- a/go/channel/templates/channel/dashboard.html
+++ b/go/channel/templates/channel/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "app.html" %}
+{% extends "conversation/dashboard_base.html" %}
 {% load url from future %}
 {% load humanize %}
 {% load channel_tags %}
@@ -6,14 +6,8 @@
 
 {% block content_extraclass %}dashboard channels{% endblock %}
 
-{% block content_title %}Channel Dashboard{% endblock %}
+{% block content_title %}All channels{% endblock %}
 
-
-
-{% block content_actions_left %}
-    {# TODO: Something other than the wizard, I think. #}
-    <a href="{% url 'wizard:create' %}" class="btn btn-primary">Conversation wizard</a>
-{% endblock %}
 
 {% block content_actions_right %}
     <div class="table-form-view-buttons pull-left">
@@ -21,67 +15,37 @@
     </div>
 {% endblock %}
 
-{% block content_main %}
-    <div class="row-fluid">
-        <div class="span3 sidebar">
-
-            <ul class="nav nav-list">
-                <li>
-                    <a href="{% url 'channels:index' %}">All channels</a>
-                    <ul class="nav nav-list">
-                    </ul>
-                </li>
-            </ul>
-
-        </div>
-        <div class="span9">
-
-            {% include "base/includes/messages.html" %}
-
-            <form class="table-form-view" method="post" action="">
-                {% csrf_token %}
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th><input type="checkbox"></th>
-                            <th>Channels</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% if channels %}
-                            {% for channel in page.object_list %}
-                            <tr data-url="{% channel_screen channel %}">
-                                <td><input type="checkbox" name="channel_key" value="{{ channel.key }}"></td>
-                                <td>
-                                    <a href="{% channel_screen channel %}">
-                                        {{ channel.name }}
-                                    </a>
-                                </td>
-                                <td>
-                                    <a href="{% url 'todo' %}">Messages</a>
-                                    <a href="{% url 'todo' %}">Reports</a>
-                                </td>
-                            </tr>
-                            {% endfor %}
-                        {% else %}
-                        <tr>
-                            <td colspan="9">
-                                No channels.
-                            </td>
-                        </tr>
-                        {% endif %}
-                    </tbody>
-                </table>
-                {% include "base/includes/pagination.html" %}
-            </form>
-        </div>
-    </div>
-{% endblock %}
-
-{% block ondomready %}
-    var tableFormView = new go.components.tables.TableFormView({
-        el: '.table-form-view',
-        actions: '.table-form-view-buttons button'
-    });
+{% block content_dashboard %}
+<form class="table-form-view" method="post" action="">
+    {% csrf_token %}
+    <table class="table">
+        <thead>
+            <tr>
+                <th><input type="checkbox"></th>
+                <th>Channels</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% if channels %}
+                {% for channel in page.object_list %}
+                <tr data-url="{% channel_screen channel %}">
+                    <td><input type="checkbox" name="channel_key" value="{{ channel.key }}"></td>
+                    <td>
+                        <a href="{% channel_screen channel %}">
+                            {{ channel.name }}
+                        </a>
+                    </td>
+                </tr>
+                {% endfor %}
+            {% else %}
+            <tr>
+                <td colspan="9">
+                    No channels.
+                </td>
+            </tr>
+            {% endif %}
+        </tbody>
+    </table>
+    {% include "base/includes/pagination.html" %}
+</form>
 {% endblock %}

--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -1,131 +1,63 @@
-{% extends "app.html" %}
+{% extends "conversation/dashboard_base.html" %}
 {% load url from future %}
-{% load humanize %}
 {% load conversation_tags %}
+{% load humanize %}
 
 
-{% block content_extraclass %}dashboard campaigns{% endblock %}
-
-{% block content_title %}Dashboard{% endblock %}
-
-
-
-{% block content_actions_left %}
-    <a href="{% url 'wizard:create' %}" class="btn btn-primary">New conversation</a>
-{% endblock %}
-
-{% block content_actions_right %}
-    <div class="table-form-view-buttons pull-left">
-        <button class="btn" data-action="copy" disabled="disabled">Copy</button>
-        <button class="btn" data-action="archive" disabled="disabled">Archive</button>
-        <button class="btn" data-action="edit" disabled="disabled">Edit</button>
-    </div>
-
-    <form id="search-filter" name="search-filter" action="" method="get" class="navbar-search pull-right">
-        <input type="text" class="search-query" placeholder="Search" name="{{ search_form.query.name }}" value="{{ search_form.query.value|default:"" }}">
-        <button type="submit" class="btn" id="search-filter-btn">Search</button>
-    </form>
-{% endblock %}
-
-{% block content_main %}
-    <div class="row-fluid">
-        <div class="span3 sidebar">
-
-            
-            <p>
-                <a href="{% url 'routing' %}" class="btn btn-primary">Configure channels (alpha)</a>
-            <p>
-            
-
-            <ul class="nav nav-list">
+{% block content_dashboard %}
+<form class="table-form-view" method="post" action="">
+    {% csrf_token %}
+    <table class="table">
+        <thead>
+            <tr>
+                <th><input type="checkbox"></th>
+                <th>Campaigns</th>
+                <th>Status</th>
+                <!-- TODO: We don't have a backend that provides a friendly name for this yet. -->
+                <th>Channel</th>
+                <th>Interactions</th>
+                <!-- TODO: We don't have a backend service yet for this value -->
+                <!-- <th>In Last</th> -->
+                <!-- TODO: We're only storing the created_at value :\ -->
+                <th>Last Edited</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% if conversations %}
+                {% for conversation in page.object_list %}
+                <tr data-url="{% conversation_screen conversation %}">
+                    <td><input type="checkbox" name="conversation_key" value="{{ conversation.key }}"></td>
+                    <td>
+                        <a href="{% conversation_screen conversation %}">
+                            {{ conversation.name }}
+                        </a>
+                    </td>
+                    <td class="status {{ conversation.get_status }}">{{ conversation.get_status }}</td>
+                    <td></td>
+                    <td>{{ conversation.count_replies|add:conversation.count_sent_messages }} </td>
+                    <!-- <td></td> -->
+                    <td>{{ conversation.created_at|naturaltime }}</td>
+                    <td>
+                        <a href="{% url 'conversations:incoming_list' conversation.key %}">Messages</a>
+                        {# <a href="{% url 'todo' %}">Reports</a> #}
+                    </td>
+                </tr>
+                {% endfor %}
                 
-                <li>
-                    <a href="{% url 'conversations:index' %}">All campaigns</a>
-                    <ul class="nav nav-list">
-                        <li><a href="{% url 'conversations:index' %}?conversation_status=running">Activated</a></li>
-                        <!-- TODO: we don't have a backend service for this yet -->
-                        <!--
-                        <li><a href="#">Some problems</a></li>
-                        <li><a href="#">Paused</a></li>
-                        -->
-                        <li><a href="{% url 'conversations:index' %}?conversation_status=draft">Deactivated</a></li>
-                        <li><a href="{% url 'conversations:index' %}?conversation_status=finished">Archived</a></li>
-                    </ul>
-                </li>
-
-                <!-- TODO: we don't have a clear backend definition yet of what archived means -->
-                <!-- <li><a href="#">Archived Campaigns</a></li> -->
-                <!-- TODO: we won't have a backend service that exposes available transports -->
-                <!-- <li><a href="#">All Channels</a></li> -->
-
-            </ul>
-        </div>
-        <div class="span9">
-
-            {% include "base/includes/messages.html" %}
-
-            <form class="table-form-view" method="post" action="">
-                {% csrf_token %}
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th><input type="checkbox"></th>
-                            <th>Campaigns</th>
-                            <th>Status</th>
-                            <!-- TODO: We don't have a backend that provides a friendly name for this yet. -->
-                            <th>Channel</th>
-                            <th>Interactions</th>
-                            <!-- TODO: We don't have a backend service yet for this value -->
-                            <!-- <th>In Last</th> -->
-                            <!-- TODO: We're only storing the created_at value :\ -->
-                            <th>Last Edited</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% if conversations %}
-                            {% for conversation in page.object_list %}
-                            <tr data-url="{% conversation_screen conversation %}">
-                                <td><input type="checkbox" name="conversation_key" value="{{ conversation.key }}"></td>
-                                <td>
-                                    <a href="{% conversation_screen conversation %}">
-                                        {{ conversation.name }}
-                                    </a>
-                                </td>
-                                <td class="status {{ conversation.get_status }}">{{ conversation.get_status }}</td>
-                                <td></td>
-                                <td>{{ conversation.count_replies|add:conversation.count_sent_messages }} </td>
-                                <!-- <td></td> -->
-                                <td>{{ conversation.created_at|naturaltime }}</td>
-                                <td>
-                                    <a href="{% url 'conversations:incoming_list' conversation.key %}">Messages</a>
-                                    {# <a href="{% url 'todo' %}">Reports</a> #}
-                                </td>
-                            </tr>
-                            {% endfor %}
-                            
-                        {% else %}
-                        <tr>
-                            <td colspan="9">
-                            {% if query %}
-                                No contacts match <strong>{{ query }}</strong>
-                            {% else %}
-                                No conversations.
-                            {% endif %}
-                            </td>
-                        </tr>
-                        {% endif %}
-                    </tbody>
-                </table>
-                {% include "base/includes/pagination.html" %}
-            </form>
-        </div>
-    </div>
-{% endblock %}
-
-{% block ondomready %}
-    var tableFormView = new go.components.tables.TableFormView({
-        el: '.table-form-view',
-        actions: '.table-form-view-buttons button'
-    });
+            {% else %}
+            <tr>
+                <td colspan="9">
+                {% if query %}
+                    No contacts match <strong>{{ query }}</strong>
+                {% else %}
+                    No conversations.
+                {% endif %}
+                </td>
+            </tr>
+            {% endif %}
+        </tbody>
+    </table>
+    {% include "base/includes/pagination.html" %}
+</form>
 {% endblock %}

--- a/go/conversation/templates/conversation/dashboard_base.html
+++ b/go/conversation/templates/conversation/dashboard_base.html
@@ -1,0 +1,73 @@
+{% extends "app.html" %}
+{% load url from future %}
+
+
+{% block content_extraclass %}dashboard campaigns{% endblock %}
+
+{% block content_title %}Dashboard{% endblock %}
+
+{% block content_actions_left %}
+    <a href="{% url 'wizard:create' %}" class="btn btn-primary">New conversation</a>
+{% endblock %}
+
+{% block content_actions_right %}
+    <div class="table-form-view-buttons pull-left">
+        <button class="btn" data-action="copy" disabled="disabled">Copy</button>
+        <button class="btn" data-action="archive" disabled="disabled">Archive</button>
+        <button class="btn" data-action="edit" disabled="disabled">Edit</button>
+    </div>
+
+    <form id="search-filter" name="search-filter" action="" method="get" class="navbar-search pull-right">
+        <input type="text" class="search-query" placeholder="Search" name="{{ search_form.query.name }}" value="{{ search_form.query.value|default:"" }}">
+        <button type="submit" class="btn" id="search-filter-btn">Search</button>
+    </form>
+{% endblock %}
+
+{% block content_main %}
+    <div class="row-fluid">
+        <div class="span3 sidebar">
+
+            
+            <p>
+                <a href="{% url 'routing' %}" class="btn btn-primary">Configure channels (alpha)</a>
+            <p>
+            
+
+            <ul class="nav nav-list">
+                
+                <li>
+                    <a href="{% url 'conversations:index' %}">All campaigns</a>
+                    <ul class="nav nav-list">
+                        <li><a href="{% url 'conversations:index' %}?conversation_status=running">Activated</a></li>
+                        <!-- TODO: we don't have a backend service for this yet -->
+                        <!--
+                        <li><a href="#">Some problems</a></li>
+                        <li><a href="#">Paused</a></li>
+                        -->
+                        <li><a href="{% url 'conversations:index' %}?conversation_status=draft">Deactivated</a></li>
+                        <li><a href="{% url 'conversations:index' %}?conversation_status=finished">Archived</a></li>
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="{% url 'channels:index' %}">All channels</a>
+                </li>
+           </ul>
+        </div>
+        <div class="span9">
+
+            {% include "base/includes/messages.html" %}
+
+            {% block content_dashboard %}
+            {% endblock %}
+        </div>
+    </div>
+{% endblock %}
+
+{% block ondomready %}
+    var tableFormView = new go.components.tables.TableFormView({
+        el: '.table-form-view',
+        actions: '.table-form-view-buttons button'
+    });
+{% endblock %}


### PR DESCRIPTION
Please add a channels link in the left nav. This should be styled the same as the "All campaigns" link See screenshot:
![screen shot 2013-07-17 at 4 36 57 pm](https://f.cloud.github.com/assets/1521387/812712/8acb1608-eef4-11e2-97ef-f926f2a8efcb.png)

Please add the 'body' of the current channels page: http://qa-vumi.za.prk-host.net/channels/  to the 'body' of the dashboard page. This view is displayed when a user clicks "All channels" in the left nav. In other words, instead of having a separate channels page, we display the channels in the dashboard template when a user clicks "All channels" See screenshot: 
![screen shot 2013-07-17 at 5 21 12 pm](https://f.cloud.github.com/assets/1521387/812730/b6cfc924-eef4-11e2-8f63-71e7dc4d8087.png)
