### PR TITLE
Message export Zip doesn't apply any compression.

### DIFF
--- a/go/apps/bulk_message/tests/test_new_views.py
+++ b/go/apps/bulk_message/tests/test_new_views.py
@@ -1,4 +1,6 @@
 from datetime import date
+from zipfile import ZipFile
+from StringIO import StringIO
 
 from django.test.client import Client
 from django.core import mail
@@ -246,10 +248,14 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual(email.recipients(), [self.user.email])
         self.assertTrue(self.conversation.name in email.subject)
         self.assertTrue(self.conversation.name in email.body)
-        [(file_name, content, mime_type)] = email.attachments
+        [(file_name, contents, mime_type)] = email.attachments
         self.assertEqual(file_name, 'messages-export.zip')
+
+        zipfile = ZipFile(StringIO(contents), 'r')
+        csv_contents = zipfile.open('messages-export.csv', 'r').read()
+
         # 1 header, 10 sent, 10 received, 1 trailing newline == 22
-        self.assertEqual(22, len(content.split('\n')))
+        self.assertEqual(22, len(csv_contents.split('\n')))
         self.assertEqual(mime_type, 'application/zip')
 
     def test_action_bulk_send_view(self):

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -1,5 +1,5 @@
 from StringIO import StringIO
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 
 from celery.task import task
 
@@ -69,7 +69,7 @@ def export_conversation_messages(account_key, conversation_key):
                             for fn in field_names])
 
     zipio = StringIO()
-    zf = ZipFile(zipio, "a")
+    zf = ZipFile(zipio, "a", ZIP_DEFLATED)
     zf.writestr("messages-export.csv", io.getvalue())
     zf.close()
 


### PR DESCRIPTION
A 16MB CSV file still stays 16MB when zipped because we're not applying any compression value. It defaults to [`ZIP_STORED`](http://docs.python.org/2/library/zipfile#zipfile.ZipFile). 

Thanks to @highvoltage for pointing this out.
