### PR TITLE
Remove 'channel' column from dashboard

### DIFF
--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -13,8 +13,6 @@
                 <th><input type="checkbox"></th>
                 <th>Campaigns</th>
                 <th>Status</th>
-                <!-- TODO: We don't have a backend that provides a friendly name for this yet. -->
-                <th>Channel</th>
                 <th>Interactions</th>
                 <!-- TODO: We don't have a backend service yet for this value -->
                 <!-- <th>In Last</th> -->
@@ -34,7 +32,6 @@
                         </a>
                     </td>
                     <td class="status {{ conversation.get_status }}">{{ conversation.get_status }}</td>
-                    <td></td>
                     <td>{{ conversation.count_replies|add:conversation.count_sent_messages }} </td>
                     <!-- <td></td> -->
                     <td>{{ conversation.created_at|naturaltime }}</td>


### PR DESCRIPTION
We'll add it back in the next release. But for 0.5b1 please remove the channel column from the dashboard.

![screen shot 2013-07-22 at 1 43 36 pm](https://f.cloud.github.com/assets/1521387/834569/053bd936-f2c4-11e2-86fe-463ada2d7267.png)
