### PR TITLE
Replace fakeServer with sinon.fakeServer

### DIFF
--- a/go/base/static/js/test/tests/components/models.test.js
+++ b/go/base/static/js/test/tests/components/models.test.js
@@ -3,7 +3,7 @@ describe("go.components.models", function() {
 
   var testHelpers = go.testHelpers,
       assertModelAttrs = testHelpers.assertModelAttrs,
-      fakeServer = testHelpers.rpc.fakeServer;
+      response = testHelpers.rpc.response;
 
   describe(".Model", function() {
     var Model = models.Model;
@@ -24,7 +24,8 @@ describe("go.components.models", function() {
         model;
 
     beforeEach(function() {
-      server = fakeServer('/api/v1/go/api');
+      server = sinon.fakeServer.create();
+
       model = new ToyModel({
         uuid: 'jimmy',
         a: 'red',
@@ -45,13 +46,15 @@ describe("go.components.models", function() {
       describe("when `reset` is `true`", function() {
         it("should reset to the server's state if the fetch was successful",
         function() {
-          model.fetch({reset: true});
-          server.respondWith({
+          server.respondWith(response({
             uuid: 'jimmy',
             a: 'blue',
             b: 'green',
             submodels: [{uuid: 'two', spoon: 'ham'}]
-          });
+          }));
+
+          model.fetch({reset: true});
+          server.respond();
 
           assertModelAttrs(model, {
             uuid: 'jimmy',
@@ -62,8 +65,10 @@ describe("go.components.models", function() {
         });
 
         it("shouldn't change if the fetch was unsuccessful", function() {
+          server.respondWith([400, {}, 'Error!']);
+
           model.fetch({reset: true});
-          server.errorWith(0, 'error', 'Error!');
+          server.respond();
 
           assertModelAttrs(model, {
             uuid: 'jimmy',

--- a/go/base/static/js/test/tests/testHelpers/rpc.js
+++ b/go/base/static/js/test/tests/testHelpers/rpc.js
@@ -3,63 +3,24 @@
 
 (function(exports) {
   var assertRequest = function(req, url, method, params) {
+    var data = JSON.parse(req.requestBody);
+
     assert.equal(req.url, url);
-    assert.equal(req.data.method, method);
-    assert.deepEqual(req.data.params, params || []);
+    assert.equal(data.method, method);
+    assert.deepEqual(data.params, params || []);
   };
 
-  var response = function(id, data) {
-    return {id: id, jsonrpc: '2.0', result: data};
+  var response = function(data, id) {
+    return JSON.stringify({id: id, jsonrpc: '2.0', result: data});
   };
 
-  var fakeServer = function(url) {
-    var requests = [];
-
-    var stub = sinon.stub($, 'ajax', function(options) {
-      options.data = JSON.parse(options.data);
-      requests.push(options);
-    });
-
-    return {
-      requests: requests,
-
-      assertRequest: function(method, params) {
-        assertRequest(requests.shift(), url, method, params);
-      },
-
-      restore: function() {
-        stub.restore();
-      },
-
-      respondWith: function(data) {
-        var req = requests.shift();
-
-        // deep copy the data to ensure it can't be modified (which may cause
-        // obscure test passes/failures)
-        data = JSON.parse(JSON.stringify(data));
-        req.success(response(req.data.id, data));
-      },
-
-      rpcErrorWith: function(error) {
-        var req = requests.shift();
-
-        req.success(_({}).extend(
-          response(req.data.id, null),
-          {error: error}));
-      },
-
-      errorWith: function(status, statusText, errorThrown) {
-        var req = requests.shift(),
-            jqXHR = {status: status, statusText: statusText};
-
-        req.error(req, jqXHR, statusText, errorThrown);
-      }
-    };
+  var errorResponse = function(error, id) {
+    return JSON.stringify({id: id, jsonrpc: '2.0', result: null, error: error});
   };
 
   _.extend(exports, {
     assertRequest: assertRequest,
     response: response,
-    fakeServer: fakeServer
+    errorResponse: errorResponse
   });
 })(go.testHelpers.rpc = {});


### PR DESCRIPTION
Our client side tests currently use our own `fakeServer` instead of `sinon.fakeServer`. This decision was made after testing out `sinon.fakeServer` and finding out that it didn't work well with phantomjs.

I've just tried it out again, and seem to have it working. I'm guessing this change is because I am using newer phantomjs and mocha-phantomjs versions on my new dev machine, but it could well be a result of a mistake I made when I first tried out `sinon.fakeServer`.
