### PR TITLE
Allow disabling of HTTP api concurrency limit.

### DIFF
--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -264,6 +264,8 @@ class ConversationResource(resource.Resource):
 
     @inlineCallbacks
     def is_allowed(self, config, user_id):
+        if config.concurrency_limit < 0:
+            returnValue(True)
         count = int((yield self.redis.get(self.key(user_id))) or 0)
         returnValue(count < config.concurrency_limit)
 

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -338,7 +338,7 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
                              concurrency_limit=-1)
         config = yield self.app.get_config(msg=None, ctxt=ctxt)
         self.assertTrue(
-            conv_resource.is_allowed(config, self.account.key))
+            (yield conv_resource.is_allowed(config, self.account.key)))
 
     @inlineCallbacks
     def test_backlog_on_connect(self):

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -11,12 +11,13 @@ from vumi.utils import http_request_full
 from vumi.message import TransportUserMessage, TransportEvent
 from vumi.tests.utils import MockHttpServer
 from vumi.transports.vumi_bridge.client import StreamingClient
+from vumi.config import ConfigContext
 
 from go.vumitools.tests.utils import AppWorkerTestCase
 from go.vumitools.api import VumiApiCommand
 
 from go.apps.http_api.vumi_app import StreamingHTTPWorker
-from go.apps.http_api.resource import StreamResource
+from go.apps.http_api.resource import StreamResource, ConversationResource
 
 
 class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
@@ -328,6 +329,16 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
             'Too many concurrent connections' in maxed_out_resp.delivered_body)
 
         [r.disconnect() for r in max_receivers]
+
+    @inlineCallbacks
+    def test_disabling_concurrency_limit(self):
+        conv_resource = ConversationResource(self.app, self.conversation.key)
+        # negative concurrency limit disables it
+        ctxt = ConfigContext(user_account=self.account.key,
+                             concurrency_limit=-1)
+        config = yield self.app.get_config(msg=None, ctxt=ctxt)
+        self.assertTrue(
+            conv_resource.is_allowed(config, self.account.key))
 
     @inlineCallbacks
     def test_backlog_on_connect(self):

--- a/go/apps/http_api/vumi_app.py
+++ b/go/apps/http_api/vumi_app.py
@@ -73,7 +73,8 @@ class StreamingHTTPWorkerConfig(GoApplicationWorker.CONFIG_CLASS):
         "The path the resource should receive health checks on.",
         default='/health/', static=True)
     concurrency_limit = ConfigInt(
-        "Maximum number of clients per account.",
+        "Maximum number of clients per account. A value less than "
+        "zero disables the limit",
         default=10)
 
 


### PR DESCRIPTION
Setting it to less than zero should stop concurrency cap.
