### PR TITLE
Add 'stored value name' and 'searchable' option to Message screens

### DIFF
--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -1,3 +1,14 @@
+.popover {
+  z-index: 20 !important;
+  font-size: 11px;
+  width: 220px;
+
+  input {
+    font-size:11px;
+    width:90%;
+  }
+}
+
 
 .dialogue {
   .actions {
@@ -6,11 +17,9 @@
     }
   }
 
-  #diagram {
 
-    * {
-      z-index: 2;
-    }
+
+  #diagram {
 
     ._jsPlumb_connector {
       z-index: 1;
@@ -55,6 +64,7 @@
       .item {
         margin:40px 20px;
         float: left;
+        z-index: 2;
       }
     }
 
@@ -214,17 +224,6 @@
         .search_enabled {
           display: block;
         }
-
-        .arrow::after {
-          border-right-color: #eee;
-        }
-
-        .popover {
-          z-index: 100;
-          font-size: 11px;
-          background: #eee !important;
-        }
-
 
 
         .choices {

--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -191,8 +191,6 @@
     }
 
     .search_enabled {
-      display: none;
-
       input {
         margin: 0;
         margin-left: 3px;
@@ -219,12 +217,6 @@
 
     .choice.state {
       .edit.mode {
-
-
-        .search_enabled {
-          display: block;
-        }
-
 
         .choices {
 

--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -53,7 +53,7 @@
       }
 
       .item {
-        margin: 40px 40px;
+        margin:40px 20px;
         float: left;
       }
     }
@@ -65,8 +65,7 @@
     }
 
     .state {
-      width: 220px;
-      margin: 30px 40px;
+      width: 260px;
       float: left;
       text-align: left;
     }
@@ -135,7 +134,7 @@
       }
 
       textarea, select, input {
-        width: 154px;
+        width:80%;
         margin-left: 3px;
         font-size: 11px;
       }
@@ -143,6 +142,7 @@
       textarea {
         resize: none;
         max-width: 80%;
+
       }
 
       
@@ -240,7 +240,7 @@
           
           input {
             min-width: 130px;
-            width: 130px;
+            width: 170px;
             margin-bottom: 0;
           }
 

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -284,7 +284,7 @@ button {
   margin: 0;
 }
 .dialogue #diagram .grid .item {
-  margin: 40px 40px;
+  margin: 40px 20px;
   float: left;
 }
 .dialogue #diagram .add {
@@ -295,8 +295,7 @@ button {
   -ms-user-select: none;
 }
 .dialogue #diagram .state {
-  width: 220px;
-  margin: 30px 40px;
+  width: 260px;
   float: left;
   text-align: left;
 }
@@ -361,7 +360,7 @@ button {
 .dialogue #diagram .state textarea,
 .dialogue #diagram .state select,
 .dialogue #diagram .state input {
-  width: 154px;
+  width: 80%;
   margin-left: 3px;
   font-size: 11px;
 }
@@ -440,7 +439,7 @@ button {
 }
 .dialogue #diagram .choice.state .edit.mode .choices input {
   min-width: 130px;
-  width: 130px;
+  width: 170px;
   margin-bottom: 0;
 }
 .dialogue #diagram .choice.state .edit.mode .choices .close {

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -239,11 +239,17 @@ button {
 .modal label input {
   margin: 0;
 }
+.popover {
+  z-index: 20 !important;
+  font-size: 11px;
+  width: 220px;
+}
+.popover input {
+  font-size: 11px;
+  width: 90%;
+}
 .dialogue .actions .sidebar {
   background: #d9d8d3;
-}
-.dialogue #diagram * {
-  z-index: 2;
 }
 .dialogue #diagram ._jsPlumb_connector {
   z-index: 1;
@@ -286,6 +292,7 @@ button {
 .dialogue #diagram .grid .item {
   margin: 40px 20px;
   float: left;
+  z-index: 2;
 }
 .dialogue #diagram .add {
   height: 65px;
@@ -420,14 +427,6 @@ button {
 }
 .dialogue #diagram .choice.state .edit.mode .search_enabled {
   display: block;
-}
-.dialogue #diagram .choice.state .edit.mode .arrow::after {
-  border-right-color: #eee;
-}
-.dialogue #diagram .choice.state .edit.mode .popover {
-  z-index: 100;
-  font-size: 11px;
-  background: #eee !important;
 }
 .dialogue #diagram .choice.state .edit.mode .choices {
   font-size: 11px;

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -405,9 +405,6 @@ button {
 .dialogue #diagram .endpoint:hover {
   cursor: pointer;
 }
-.dialogue #diagram .search_enabled {
-  display: none;
-}
 .dialogue #diagram .search_enabled input {
   margin: 0;
   margin-left: 3px;
@@ -424,9 +421,6 @@ button {
   background: transparent;
   font-size: 10px;
   color: #666;
-}
-.dialogue #diagram .choice.state .edit.mode .search_enabled {
-  display: block;
 }
 .dialogue #diagram .choice.state .edit.mode .choices {
   font-size: 11px;

--- a/go/base/static/js/src/campaign/dialogue/models.js
+++ b/go/base/static/js/src/campaign/dialogue/models.js
@@ -13,7 +13,17 @@
     defaults: function() { return {uuid: uuid.v4()}; }
   });
 
-  var ChoiceEndpointModel = DialogueEndpointModel.extend();
+  var ChoiceEndpointModel = DialogueEndpointModel.extend({
+    defaults: {user_defined_value: false},
+
+    initialize: function() {
+      this.on('change:label', function(m, v) {
+        if (!this.get('user_defined_value')) { this.setValue(v); }
+      }, this);
+    },
+
+    setValue: function(v) { return this.set('value', go.utils.slugify(v)); }
+  });
 
   var DialogueStateModel = StateModel.extend({
     relations: [],
@@ -23,7 +33,22 @@
       choice: 'go.campaign.dialogue.models.ChoiceStateModel',
       freetext: 'go.campaign.dialogue.models.FreeTextStateModel',
       end: 'go.campaign.dialogue.models.EndStateModel'
-    }
+    },
+
+    defaults: function() {
+      return {
+        uuid: uuid.v4(),
+        user_defined_store_as: false
+      };
+    },
+
+    initialize: function() {
+      this.on('change:name', function(m, v) {
+        if (!this.get('user_defined_store_as')) { this.setStoreAs(v); }
+      }, this);
+    },
+
+    setStoreAs: function(v) { return this.set('store_as', go.utils.slugify(v)); }
   });
 
   var DialogueStateModelCollection = Backbone.Collection.extend({
@@ -43,11 +68,10 @@
     }],
 
     defaults: function() {
-      return {
-        uuid: uuid.v4(),
+      return _({
         entry_endpoint: {},
         exit_endpoint: {}
-      };
+      }).defaults(DummyStateModel.__super__.defaults.call(this));
     }
   });
 
@@ -63,10 +87,9 @@
     }],
 
     defaults: function() {
-      return {
-        uuid: uuid.v4(),
+      return _({
         entry_endpoint: {}
-      };
+      }).defaults(ChoiceStateModel.__super__.defaults.call(this));
     }
   });
 
@@ -82,11 +105,10 @@
     }],
 
     defaults: function() {
-      return {
-        uuid: uuid.v4(),
+      return _({
         entry_endpoint: {},
         exit_endpoint: {}
-      };
+      }).defaults(FreeTextStateModel.__super__.defaults.call(this));
     }
   });
 
@@ -98,10 +120,9 @@
     }],
 
     defaults: function() {
-      return {
-        uuid: uuid.v4(),
+      return _({
         entry_endpoint: {}
-      };
+      }).defaults(EndStateModel.__super__.defaults.call(this));
     }
   });
 

--- a/go/base/static/js/src/campaign/dialogue/models.js
+++ b/go/base/static/js/src/campaign/dialogue/models.js
@@ -26,6 +26,8 @@
   });
 
   var DialogueStateModel = StateModel.extend({
+    storableOnContact: true,
+
     relations: [],
 
     subModelTypes: {
@@ -38,7 +40,8 @@
     defaults: function() {
       return {
         uuid: uuid.v4(),
-        user_defined_store_as: false
+        user_defined_store_as: false,
+        store_on_contact: false,
       };
     },
 
@@ -113,6 +116,8 @@
   });
 
   var EndStateModel = DialogueStateModel.extend({
+    storableOnContact: false,
+
     relations: [{
       type: Backbone.HasOne,
       key: 'entry_endpoint',

--- a/go/base/static/js/src/campaign/dialogue/states/choice.js
+++ b/go/base/static/js/src/campaign/dialogue/states/choice.js
@@ -36,6 +36,8 @@
   });
 
   var ChoiceEditExtrasView = PopoverView.extend({
+    popoverOptions: {container: 'body'},
+
     target: function() { return this.choice.$('.extras'); },
 
     events: {
@@ -57,7 +59,6 @@
       this.valueBackup = null;
       this.on('show', function() {
         this.valueBackup = this.choice.model.get('value');
-        this.delegateEvents();
       }, this);
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/choice.js
+++ b/go/base/static/js/src/campaign/dialogue/states/choice.js
@@ -49,6 +49,7 @@
     initialize: function(options) {
       ChoiceEditExtrasView.__super__.initialize.call(this, options);
       this.choice = options.choice;
+      this.model = this.choice.model;
 
       this.template = new TemplateView({
         el: this.$el,
@@ -64,12 +65,13 @@
     },
 
     onValueChange: function(e) {
-      this.choice.model.set('value', go.utils.slugify(this.$('.value').val()));
+      this.model.setValue(this.$('.value').val());
+      this.model.set('user_defined_value', true);
     },
 
     onCancelClick: function(e) {
       e.preventDefault();
-      this.choice.model.set('value', this.valueBackup);
+      this.model.set('value', this.valueBackup);
       this.hide();
     },
 
@@ -111,8 +113,7 @@
     onLabelChange: function(e) {
       this.model.set(
         'label',
-        this.$('.choice-label').prop('value'),
-        {silent: true});
+        this.$('.choice-label').prop('value'));
     },
 
     onRemoveClick: function(e) {

--- a/go/base/static/js/src/campaign/dialogue/states/choice.js
+++ b/go/base/static/js/src/campaign/dialogue/states/choice.js
@@ -59,6 +59,7 @@
       this.valueBackup = null;
       this.on('show', function() {
         this.valueBackup = this.choice.model.get('value');
+        this.delegateEvents();
       }, this);
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -45,6 +45,7 @@
     initialize: function(options) {
       NameEditExtrasView.__super__.initialize.call(this, options);
       this.mode = options.mode;
+      this.model = this.mode.state.model;
 
       this.template = new TemplateView({
         el: this.$el,
@@ -60,14 +61,14 @@
     },
 
     onStoreAsChange: function(e) {
-      this.mode.state.model.set(
-        'store_as',
-        go.utils.slugify(this.$('.store-as').val()));
+      this.model.setStoreAs(this.$('.store-as').val());
+      this.model.set('user_defined_store_as', true);
+      return this;
     },
 
     onCancelClick: function(e) {
       e.preventDefault();
-      this.mode.state.model.set('store_as', this.storeAsBackup);
+      this.model.set('store_as', this.storeAsBackup);
       this.hide();
     },
 
@@ -173,7 +174,7 @@
     },
 
     onNameChange: function(e) {
-      this.state.model.set('name', $(e.target).val(), {silent: true});
+      this.state.model.set('name', $(e.target).val());
     },
 
     onNameExtras: function(e) {

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -55,6 +55,7 @@
       this.storeAsBackup = null;
       this.on('show', function() {
         this.storeAsBackup = this.mode.state.model.get('store_as');
+        this.delegateEvents();
       }, this);
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -32,6 +32,8 @@
   });
 
   var NameEditExtrasView = PopoverView.extend({
+    popoverOptions: {container: 'body'},
+
     target: function() { return this.mode.$('.name-extras'); },
 
     events: {
@@ -53,7 +55,6 @@
       this.storeAsBackup = null;
       this.on('show', function() {
         this.storeAsBackup = this.mode.state.model.get('store_as');
-        this.delegateEvents();
       }, this);
     },
 

--- a/go/base/static/js/src/campaign/dialogue/states/states.js
+++ b/go/base/static/js/src/campaign/dialogue/states/states.js
@@ -91,7 +91,7 @@
       return {
         mode: this,
         state: this.state,
-        model: this.state.model
+        model: this.model
       };
     },
 
@@ -100,6 +100,7 @@
     initialize: function(options) {
       DialogueStateModeView.__super__.initialize.call(this, options);
       this.state = options.state;
+      this.model = this.state.model;
 
       this.partials.body = new TemplateView(
         _({data: this.data.bind(this)}).extend(
@@ -129,7 +130,8 @@
       'click .actions .cancel': 'onCancel',
       'change .type': 'onTypeChange',
       'change .name': 'onNameChange',
-      'click .name-extras': 'onNameExtras'
+      'click .name-extras': 'onNameExtras',
+      'change .store-on-contact': 'onStoreOnContact'
     },
 
     resetModal: new ConfirmView({
@@ -174,21 +176,25 @@
     },
 
     onNameChange: function(e) {
-      this.state.model.set('name', $(e.target).val());
+      this.model.set('name', $(e.target).val());
     },
 
     onNameExtras: function(e) {
       this.nameExtras.toggle();
     },
 
+    onStoreOnContact: function(e) {
+      this.model.set('store_on_contact', this.$('.store-on-contact').prop(':checked'));
+    },
+
     // Keep a backup to restore the model for when the user cancels the edit
     backupModel: function() {
-      this.modelBackup = this.state.model.toJSON();
+      this.modelBackup = this.model.toJSON();
       return this;
     },
 
     cancel: function() {
-      var model = this.state.model;
+      var model = this.model;
       if (this.modelBackup) { model.set(this.modelBackup); }
       return this;
     },

--- a/go/base/static/js/test/tests/campaign/dialogue/models.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/models.test.js
@@ -1,0 +1,79 @@
+describe("go.campaign.dialogue.models", function() {
+  var dialogue = go.campaign.dialogue;
+
+  describe(".ChoiceEndpointModel", function() {
+    var ChoiceEndpointModel = dialogue.models.ChoiceEndpointModel;
+
+    var model;
+
+    beforeEach(function() {
+      model = new ChoiceEndpointModel();
+    });
+
+    afterEach(function() {
+      Backbone.Relational.store.unregister(model);
+    });
+
+    describe("when its 'label' attr is changed", function() {
+      it("should reset the default 'value' attr if it isn't user defined",
+      function() {
+        assert(!model.has('value'));
+        assert.isFalse(model.get('user_defined_value'));
+
+        model.set('label', 'Message 1');
+        assert.equal(model.get('value'), 'message-1');
+
+        model.set('value', 'user-defined-value');
+        model.set('user_defined_value', true);
+        model.set('label', 'User Defined Message');
+        assert.equal(model.get('value'), 'user-defined-value');
+      });
+    });
+
+    describe(".setValue", function() {
+      it("should set its 'value' attr to a slug of the input", function() {
+        assert(!model.has('value'));
+        model.setValue('Some Value');
+        assert.equal(model.get('value'), 'some-value');
+      });
+    });
+  });
+
+  describe(".DialogueStateModel", function() {
+    var DialogueStateModel = dialogue.models.DialogueStateModel;
+
+    var model;
+
+    beforeEach(function() {
+      model = new DialogueStateModel();
+    });
+
+    afterEach(function() {
+      Backbone.Relational.store.unregister(model);
+    });
+
+    describe("when its 'name' attr is changed", function() {
+      it("should reset the default 'store_as' attr if it isn't user defined",
+      function() {
+        assert(!model.has('store_as'));
+        assert.isFalse(model.get('user_defined_store_as'));
+
+        model.set('name', 'State 1');
+        assert.equal(model.get('store_as'), 'state-1');
+
+        model.set('store_as', 'user-defined-store-as');
+        model.set('user_defined_store_as', true);
+        model.set('name', 'User Defined Name');
+        assert.equal(model.get('store_as'), 'user-defined-store-as');
+      });
+    });
+
+    describe(".setStoreAs", function() {
+      it("should set its 'store_as' attr to a slug of the input", function() {
+        assert(!model.has('store_as'));
+        model.setStoreAs('Some Value');
+        assert.equal(model.get('store_as'), 'some-value');
+      });
+    });
+  });
+});

--- a/go/base/static/js/test/tests/campaign/dialogue/states/choice.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/choice.test.js
@@ -47,7 +47,7 @@ describe("go.campaign.dialogue.states.choice", function() {
       it("should update the choice model's 'value' attribute", function() {
         assert.equal(
           choice.model.get('value'),
-          'value1');
+          'red');
 
         extras.$('.value')
           .val('In Which Our Hero Finds A Faithful Sidekick')
@@ -76,7 +76,7 @@ describe("go.campaign.dialogue.states.choice", function() {
       function() {
         choice.model.set('value', 'A fish');
         extras.$('.cancel').click();
-        assert.equal(choice.model.get('value'), 'value1');
+        assert.equal(choice.model.get('value'), 'red');
       });
     });
   });

--- a/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
@@ -123,6 +123,7 @@ describe("go.campaign.dialogue.states", function() {
             entry_endpoint: {'uuid':'endpoint6'},
             exit_endpoint: {'uuid':'endpoint7'},
             user_defined_store_as: false,
+            store_on_contact: false,
             ordinal: 3
           });
 
@@ -137,6 +138,7 @@ describe("go.campaign.dialogue.states", function() {
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
           user_defined_store_as: false,
+          store_on_contact: false,
           ordinal: 3
         });
 
@@ -155,6 +157,7 @@ describe("go.campaign.dialogue.states", function() {
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
           user_defined_store_as: false,
+          store_on_contact: false,
           ordinal: 3
         });
 
@@ -169,6 +172,7 @@ describe("go.campaign.dialogue.states", function() {
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
           user_defined_store_as: false,
+          store_on_contact: false,
           ordinal: 3
         });
       });
@@ -270,6 +274,7 @@ describe("go.campaign.dialogue.states", function() {
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
           user_defined_store_as: false,
+          store_on_contact: false,
           ordinal: 3
         });
 
@@ -284,6 +289,7 @@ describe("go.campaign.dialogue.states", function() {
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
           user_defined_store_as: false,
+          store_on_contact: false,
           ordinal: 3
         });
       });
@@ -295,11 +301,24 @@ describe("go.campaign.dialogue.states", function() {
       });
     });
 
-    describe("when '.ok' button is clicked", function() {
+    describe("when the '.ok' button is clicked", function() {
       it("should switch back to the preview view", function() {
         assert.equal(state.modeName, 'edit');
         editMode.$('.ok').click();
         assert.equal(state.modeName, 'preview');
+      });
+    });
+
+    describe("when '.store-on-contact' changes", function() {
+      it("should set its model's 'store_on_contact' attr accordingly",
+      function() {
+        assert.equal(state.model.get('store_on_contact'), false);
+
+        editMode.$('.store-on-contact')
+          .prop(':checked', true)
+          .change();
+
+        assert.equal(state.model.get('store_on_contact'), true);
       });
     });
   });

--- a/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/campaign/dialogue/states/states.test.js
@@ -119,9 +119,10 @@ describe("go.campaign.dialogue.states", function() {
             uuid: 'state4',
             name: 'New Dummy',
             type: 'dummy',
-            store_as: 'dummy-message-1',
+            store_as: 'new-dummy',
             entry_endpoint: {'uuid':'endpoint6'},
             exit_endpoint: {'uuid':'endpoint7'},
+            user_defined_store_as: false,
             ordinal: 3
           });
 
@@ -135,6 +136,7 @@ describe("go.campaign.dialogue.states", function() {
           store_as: 'dummy-message-1',
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
+          user_defined_store_as: false,
           ordinal: 3
         });
 
@@ -152,6 +154,7 @@ describe("go.campaign.dialogue.states", function() {
           store_as: 'dummy-message-1',
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
+          user_defined_store_as: false,
           ordinal: 3
         });
 
@@ -165,6 +168,7 @@ describe("go.campaign.dialogue.states", function() {
           store_as: 'dummy-message-1',
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
+          user_defined_store_as: false,
           ordinal: 3
         });
       });
@@ -265,6 +269,7 @@ describe("go.campaign.dialogue.states", function() {
           store_as: 'dummy-message-1',
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
+          user_defined_store_as: false,
           ordinal: 3
         });
 
@@ -278,6 +283,7 @@ describe("go.campaign.dialogue.states", function() {
           store_as: 'dummy-message-1',
           entry_endpoint: {'uuid':'endpoint6'},
           exit_endpoint: {'uuid':'endpoint7'},
+          user_defined_store_as: false,
           ordinal: 3
         });
       });

--- a/go/base/static/templates/campaign/dialogue/states/choice/edit.jst
+++ b/go/base/static/templates/campaign/dialogue/states/choice/edit.jst
@@ -3,9 +3,9 @@
 
 <label>Define the answers</label>
 <ol class='choices'>
-<% partials.choices.forEach(function(choice) { %>
-  <%= choice %>
-<% }); %>
+  <% partials.choices.forEach(function(choice) { %>
+    <%= choice %>
+  <% }); %>
 </ol>
 
 <button class='btn btn-primary new-choice'>Add another answer</button>

--- a/go/base/static/templates/campaign/dialogue/states/modes/edit.jst
+++ b/go/base/static/templates/campaign/dialogue/states/modes/edit.jst
@@ -21,11 +21,12 @@
     <option value="end">Recipients are shown text and the session ends</option>
   </select>
 
-  <!-- only displayed if `choice` is selected, controlled via CSS. -->
-  <div class="search_enabled">
-    <input type="checkbox" name="search" id="search"> 
-    <label for="id_search">Display this question in search results</label>
-  </div>
+  <% if (model.storableOnContact) { %>
+    <div class="search_enabled">
+      <input class="store-on-contact" type="checkbox" name="search" id="search"> 
+      <label for="id_search">Display this question in search results</label>
+    </div>
+  <% } %>
 
   <%= partials.body %>
 


### PR DESCRIPTION
On the dialogue (survey) creator screen we need to add the option for users to select whether the question should appear in search results (i.e. saved as extras in contacts) and we need to add a field where the user defines what the actual answer to the question will be stored as in the DB. 

See screenshot and let me know what questions you may have.
![screen shot 2013-07-19 at 4 41 44 pm](https://f.cloud.github.com/assets/1521387/826387/5c736508-f084-11e2-9739-565501ff84d6.png)
