### PR TITLE
"Messages" should dynamically display the conversation type

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -425,3 +425,10 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'to_addr': msg['from_addr'],
             'msg_options': {'in_reply_to': msg['message_id']},
         })
+
+    def test_no_content_block(self):
+        # FIXME: This kind of thing probably belongs in generic view tests.
+        self.setup_conversation()
+        response = self.client.get(self.get_view_url('show'))
+        self.assertNotContains(response, 'Content')
+        self.assertNotContains(response, self.get_view_url('show') + 'edit/')

--- a/go/apps/subscription/tests/test_views.py
+++ b/go/apps/subscription/tests/test_views.py
@@ -58,3 +58,10 @@ class SubscriptionTestCase(DjangoGoApplicationTestCase):
         response = self.client.get(self.get_view_url('show'))
         conversation = response.context[0].get('conversation')
         self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
+
+    def test_content_block(self):
+        # FIXME: This kind of thing probably belongs in generic view tests.
+        self.setup_conversation()
+        response = self.client.get(self.get_view_url('show'))
+        self.assertContains(response, 'Content')
+        self.assertContains(response, self.get_view_url('edit'))

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -76,18 +76,18 @@
             </p>
         </div>
 
+        {% if is_editable %}
         <div class="sub-messages">
             <h4>
-                Messages
-                {% if is_editable %}
+                Content
                 <a href="{% conversation_screen conversation 'edit' %}" class="btn btn-primary">Edit</a>
-                {% endif %}
             </h4>
 
             <p class="message">
                 {{ conversation.description }}
             </p>
         </div>
+      {% endif %}
 
 
         <div class="sub-contacts">

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -60,6 +60,10 @@
                 {{ conversation.name }}<br>
             </p>
             <p>
+                <h6>DESCRIPTION</h6>
+                {{ conversation.description }}<br>
+            </p>
+            <p>
                 <h6>TYPE</h6>
                 {{ conversation.conversation_type }}<br>
             </p>
@@ -82,10 +86,6 @@
                 Content
                 <a href="{% conversation_screen conversation 'edit' %}" class="btn btn-primary">Edit</a>
             </h4>
-
-            <p class="message">
-                {{ conversation.description }}
-            </p>
         </div>
       {% endif %}
 


### PR DESCRIPTION
Currently on the conversation 'show' page - we use a very generic "Messages" header for all conversation types.

For the following conversation types: Dialogue, JavaScript app, Sequential send, Old surveys, Old multi-surveys, and Subscription, replace the "Messages" header with "Content"

For the remaining conversation types - remove the "Messages" block entirely

![screen shot 2013-07-25 at 1 46 02 pm](https://f.cloud.github.com/assets/1521387/855311/cb03f808-f51f-11e2-9b99-1c635b6cf836.png)
