### PR TITLE
Group contacts exporting is not working

### DIFF
--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -1,7 +1,7 @@
 import sys
 import traceback
 from StringIO import StringIO
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 
 from celery.task import task
 
@@ -53,7 +53,7 @@ def delete_group_contacts(account_key, group_key):
 
 def zipped_file(filename, data):
     zipio = StringIO()
-    zf = ZipFile(zipio, "a")
+    zf = ZipFile(zipio, "a", ZIP_DEFLATED)
     zf.writestr(filename, data)
     zf.close()
     return zipio.getvalue()

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -51,14 +51,80 @@ def delete_group_contacts(account_key, group_key):
         contact_store.get_contact_by_key(contact_key).delete()
 
 
+def zipped_file(filename, data):
+    zipio = StringIO()
+    zf = ZipFile(zipio, "a")
+    zf.writestr(filename, data)
+    zf.close()
+    return zipio.getvalue()
+
+
+_contact_fields = [
+    'name',
+    'surname',
+    'email_address',
+    'msisdn',
+    'dob',
+    'twitter_handle',
+    'facebook_id',
+    'bbm_pin',
+    'gtalk_id',
+    'created_at',
+]
+
+
+def contacts_to_csv(contacts, include_extra=True):
+    contacts = sorted(contacts, key=lambda c: c.created_at)
+
+    io = StringIO()
+    writer = UnicodeCSVWriter(io)
+
+    # Collect the possible field names for this set of contacts, depending
+    # the number of contacts found this could be potentially expensive.
+    extra_fields = set()
+    if include_extra:
+        for contact in contacts:
+            extra_fields.update(contact.extra.keys())
+    extra_fields = sorted(extra_fields)
+
+    # write the CSV header
+    writer.writerow(_contact_fields + ['extras-%s' % f for f in extra_fields])
+
+    # loop over the contacts and create the row populated with
+    # the values of the selected fields.
+    for contact in contacts:
+        row = [unicode(getattr(contact, field, None) or '')
+               for field in _contact_fields]
+
+        if include_extra:
+            row.extend([unicode(contact.extra[extra_field] or '')
+                        for extra_field in extra_fields])
+
+        writer.writerow(row)
+
+    return io.getvalue()
+
+
+def get_group_contacts(contact_store, *groups):
+    contact_keys = []
+    for group in groups:
+        contact_keys.extend(contact_store.get_contacts_for_group(group))
+
+    contacts = []
+    for bunch in contact_store.contacts.load_all_bunches(contact_keys):
+        contacts.extend(bunch)
+
+    return contacts
+
+
 @task(ignore_result=True)
-def export_group_contacts(account_key, group_key, include_extra):
+def export_group_contacts(account_key, group_key, include_extra=True):
     """
-    Export the a groups' contacts as a CSV file and email to the account
+    Export a group's contacts as a CSV file and email to the account
     holders' email address.
 
     :param str account_key:
-        The account holder's account key
+        The account holders account key
     :param str group_key:
         The group to export contacts for (can be either static or smart groups)
     :param bool include_extra:
@@ -67,62 +133,65 @@ def export_group_contacts(account_key, group_key, include_extra):
 
     api = VumiUserApi.from_config_sync(account_key, settings.VUMI_API_CONFIG)
     contact_store = api.contact_store
+
     group = contact_store.get_group(group_key)
-    contact_keys = contact_store.get_contacts_for_group(group)
+    contacts = get_group_contacts(contact_store, group)
+    data = contacts_to_csv(contacts, include_extra)
+    file = zipped_file('contacts-export.csv', data)
 
     # Get the profile for this user so we can email them when the import
     # has been completed.
     user_profile = UserProfile.objects.get(user_account=account_key)
 
-    io = StringIO()
-    writer = UnicodeCSVWriter(io)
-
-    contacts = []
-    for bunch in contact_store.contacts.load_all_bunches(contact_keys):
-        contacts.extend(bunch)
-
-    contacts = sorted(contacts, key=lambda c: c.created_at)
-
-    # collect all names that we can export
-    fields = ['name', 'surname', 'email_address', 'msisdn', 'dob',
-              'twitter_handle', 'facebook_id', 'bbm_pin', 'gtalk_id',
-              'created_at']
-
-    # Collect the possible field names for this set of contacts, depending
-    # the number of contacts found this could be potentially expensive.
-    extra_fields = set()
-    if include_extra:
-        for contact in contacts:
-            extra_fields.update(contact.extra.keys())
-
-    # write the CSV header
-    extra_fields = sorted(extra_fields)
-    writer.writerow(fields + ['extras-%s' % (key,) for key in extra_fields])
-
-    # loop over the contacts and create the row populated with
-    # the values of the selected fields.
-    for contact in contacts:
-        row = [unicode(getattr(contact, field, None) or '')
-               for field in fields]
-
-        if include_extra:
-            row.extend([unicode(contact.extra[extra_field] or '')
-                        for extra_field in extra_fields])
-
-        writer.writerow(row)
-
-    zipio = StringIO()
-    zf = ZipFile(zipio, "a")
-    zf.writestr("contacts-export.csv", io.getvalue())
-    zf.close()
-
     email = EmailMessage(
         '%s contacts export' % (group.name,),
+
         'Please find the CSV data for %s contact(s) from '
-        'group "%s" attached.\n\n' % (len(contact_keys), group.name),
+        'group "%s" attached.\n\n' % (len(contacts), group.name),
+
         settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
 
-    email.attach('contacts-export.zip', zipio.getvalue(), 'application/zip')
+    email.attach('contacts-export.zip', file, 'application/zip')
+    email.send()
+
+
+@task(ignore_result=True)
+def export_many_group_contacts(account_key, group_keys, include_extra=True):
+    """
+    Export multiple group contacts as a single CSV file and email to the
+    account holders' email address.
+
+    :param str account_key:
+        The account holders account key
+    :param list group_keys:
+        The groups to export contacts for
+        (can be either static or smart groups)
+    :param bool include_extra:
+        Whether or not to include the extra data stored in the dynamic field.
+    """
+
+    api = VumiUserApi.from_config_sync(account_key, settings.VUMI_API_CONFIG)
+    contact_store = api.contact_store
+
+    groups = [contact_store.get_group(k) for k in group_keys]
+    contacts = get_group_contacts(contact_store, *groups)
+    data = contacts_to_csv(contacts, include_extra)
+    file = zipped_file('contacts-export.csv', data)
+
+    # Get the profile for this user so we can email them when the import
+    # has been completed.
+    user_profile = UserProfile.objects.get(user_account=account_key)
+
+    email = EmailMessage(
+        'Contacts export',
+
+        'Please find the attached CSV data for %s contact(s) from the '
+        'following groups:\n%s\n' %
+        (len(contacts), '\n'.join('  - %s' % g.name for g in groups)),
+
+        settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
+
+    email.attach('contacts-export.zip', file, 'application/zip')
     email.send()
 
 

--- a/go/contacts/templates/contacts/group_detail.html
+++ b/go/contacts/templates/contacts/group_detail.html
@@ -8,7 +8,6 @@
 {% block content_actions_right %}
     <div class="table-form-view-buttons pull-left">
         <button class="btn" data-action="delete" disabled="disabled">Delete</button>
-        
     </div>
     <div class="pull-left ">
         With group: 

--- a/go/contacts/templates/contacts/group_detail.html
+++ b/go/contacts/templates/contacts/group_detail.html
@@ -8,12 +8,13 @@
 {% block content_actions_right %}
     <div class="table-form-view-buttons pull-left">
         <button class="btn" data-action="delete" disabled="disabled">Delete</button>
-        <button class="btn" data-toggle="modal" data-target="#expContactFrm" disabled="disabled">Export</button>
+        
     </div>
     <div class="pull-left ">
         With group: 
         <button class="btn" data-toggle="modal" data-target="#delGroup">Delete</button>
         <button class="btn" data-toggle="modal" data-target="#editGroup">Rename</button>
+        <button class="btn" data-toggle="modal" data-target="#expContactFrm">Export</button>
         <button class="btn" data-toggle="modal" data-target="#startCampaign">Start campaign</button>
     </div>
 

--- a/go/contacts/templates/contacts/group_list.html
+++ b/go/contacts/templates/contacts/group_list.html
@@ -8,7 +8,6 @@
 {% block content_actions_right %}
     <div class="table-form-view-buttons pull-left">
         <button class="btn" data-action="delete" disabled="disabled">Delete</button>
-        <button class="btn" data-toggle="modal" data-target="#expContactFrm" disabled="disabled">Export</button>
     </div>
 {% endblock %}
 

--- a/go/contacts/templates/contacts/group_list_table.html
+++ b/go/contacts/templates/contacts/group_list_table.html
@@ -6,6 +6,7 @@
             <th>Name</th>
             <th>No. of contacts</th>
             <th>Date created</th>
+            <th></th>
         </tr>
     </thead>
     <tbody>
@@ -26,10 +27,13 @@
             <td>
                 {# TODO: group date created #}
             </td>
+            <td>
+                <button class="btn btn-mini">Export</button>
+            </td>
         </tr>
     {% empty %}
         <tr>
-            <td colspan="4">
+            <td colspan="5">
             {% if query %}
                 No group names match <strong>{{ query }}</strong>
             {% else %}

--- a/go/contacts/templates/contacts/group_list_table.html
+++ b/go/contacts/templates/contacts/group_list_table.html
@@ -6,7 +6,6 @@
             <th>Name</th>
             <th>No. of contacts</th>
             <th>Date created</th>
-            <th></th>
         </tr>
     </thead>
     <tbody>
@@ -27,13 +26,10 @@
             <td>
                 {# TODO: group date created #}
             </td>
-            <td>
-                <button class="btn btn-mini">Export</button>
-            </td>
         </tr>
     {% empty %}
         <tr>
-            <td colspan="5">
+            <td colspan="4">
             {% if query %}
                 No group names match <strong>{{ query }}</strong>
             {% else %}

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -476,7 +476,7 @@ class GroupsTestCase(VumiGoDjangoTestCase):
 
         # Delete the groups
         groups_url = reverse('contacts:groups')
-        response = self.client.post(groups_url, {
+        self.client.post(groups_url, {
             'group': [group_1.key, group_2.key],
             '_delete': True,
         })
@@ -582,15 +582,13 @@ class GroupsTestCase(VumiGoDjangoTestCase):
         self.assertTrue(contents)
         self.assertEqual(mime_type, 'application/zip')
 
-
-
     def test_multiple_group_exportation(self):
         group_1 = self.contact_store.new_group(TEST_GROUP_NAME)
         contact_1 = mkcontact(self, groups=[group_1])
         contact_1.extra['foo'] = u'bar'
         contact_1.extra['bar'] = u'baz'
         contact_1.save()
-        
+
         group_2 = self.contact_store.new_group(TEST_GROUP_NAME)
         contact_2 = mkcontact(self, groups=[group_2])
         contact_2.extra['foo'] = u'bar'
@@ -598,7 +596,7 @@ class GroupsTestCase(VumiGoDjangoTestCase):
         contact_2.save()
 
         groups_url = reverse('contacts:groups')
-        response = self.client.post(groups_url, {
+        self.client.post(groups_url, {
             'group': [group_1.key, group_2.key],
             '_export_group_contacts': True,
         })

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -583,16 +583,16 @@ class GroupsTestCase(VumiGoDjangoTestCase):
         self.assertEqual(mime_type, 'application/zip')
 
     def test_multiple_group_exportation(self):
-        group_1 = self.contact_store.new_group(TEST_GROUP_NAME)
+        group_1 = self.contact_store.new_group(u'Test Group 1')
         contact_1 = mkcontact(self, groups=[group_1])
         contact_1.extra['foo'] = u'bar'
         contact_1.extra['bar'] = u'baz'
         contact_1.save()
 
-        group_2 = self.contact_store.new_group(TEST_GROUP_NAME)
+        group_2 = self.contact_store.new_group(u'Test Group 2')
         contact_2 = mkcontact(self, groups=[group_2])
-        contact_2.extra['foo'] = u'bar'
-        contact_2.extra['bar'] = u'baz'
+        contact_2.extra['foo'] = u'lorem'
+        contact_2.extra['bar'] = u'ipsum'
         contact_2.save()
 
         groups_url = reverse('contacts:groups')
@@ -601,23 +601,23 @@ class GroupsTestCase(VumiGoDjangoTestCase):
             '_export_group_contacts': True,
         })
 
-        # test first email
-        self.assertEqual(len(mail.outbox), 2)
-        [email_1, email_2] = mail.outbox
-        [(file_name, contents, mime_type)] = email_1.attachments
+        self.assertEqual(len(mail.outbox), 1)
+        [email] = mail.outbox
+        [(file_name, contents, mime_type)] = email.attachments
 
-        self.assertEqual(email_1.recipients(), [self.django_user.email])
+        self.assertEqual(email.recipients(), [self.django_user.email])
+        self.assertTrue('Contacts export' in email.subject)
         self.assertTrue(
-            '%s contacts export' % (group_1.name,) in email_1.subject)
-        self.assertTrue(
-            '1 contact(s) from group "%s" attached' % (group_1.name,)
-            in email_1.body)
+            '2 contact(s) from the following groups:',
+            '\n  - Test Group 1'
+            '\n  - Test Group 2'
+            in email.body)
         self.assertEqual(file_name, 'contacts-export.zip')
 
         zipfile = ZipFile(StringIO(contents), 'r')
         csv_contents = zipfile.open('contacts-export.csv', 'r').read()
 
-        [header, contact, _] = csv_contents.split('\r\n')
+        [header, c1_data, c2_data, _] = csv_contents.split('\r\n')
 
         self.assertEqual(
             header,
@@ -625,33 +625,8 @@ class GroupsTestCase(VumiGoDjangoTestCase):
                       'twitter_handle', 'facebook_id', 'bbm_pin', 'gtalk_id',
                       'created_at', 'extras-bar', 'extras-foo']))
 
-        self.assertTrue(contact.endswith('baz,bar'))
-        self.assertTrue(contents)
-        self.assertEqual(mime_type, 'application/zip')
-
-        # test the 2nd email.
-        [(file_name, contents, mime_type)] = email_2.attachments
-
-        self.assertEqual(email_2.recipients(), [self.django_user.email])
-        self.assertTrue(
-            '%s contacts export' % (group_1.name,) in email_2.subject)
-        self.assertTrue(
-            '1 contact(s) from group "%s" attached' % (group_1.name,)
-            in email_2.body)
-        self.assertEqual(file_name, 'contacts-export.zip')
-
-        zipfile = ZipFile(StringIO(contents), 'r')
-        csv_contents = zipfile.open('contacts-export.csv', 'r').read()
-
-        [header, contact, _] = csv_contents.split('\r\n')
-
-        self.assertEqual(
-            header,
-            ','.join(['name', 'surname', 'email_address', 'msisdn', 'dob',
-                      'twitter_handle', 'facebook_id', 'bbm_pin', 'gtalk_id',
-                      'created_at', 'extras-bar', 'extras-foo']))
-
-        self.assertTrue(contact.endswith('baz,bar'))
+        self.assertTrue(c1_data.endswith('baz,bar'))
+        self.assertTrue(c2_data.endswith('ipsum,lorem'))
         self.assertTrue(contents)
         self.assertEqual(mime_type, 'application/zip')
 

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -67,10 +67,10 @@ def groups(request, type=None):
             messages.info(request, '%d groups will be deleted '
                                    'shortly.' % len(groups))
         elif '_export_group_contacts' in request.POST:
-            groups = request.POST.getlist('group')
-            for group_key in groups:
-                tasks.export_group_contacts.delay(
-                    request.user_api.user_account_key, group_key, True)
+            tasks.export_many_group_contacts.delay(
+                request.user_api.user_account_key,
+                request.POST.getlist('group'))
+
             messages.info(request, 'The export is scheduled and should '
                                    'complete within a few minutes.')
     else:
@@ -149,7 +149,9 @@ def _static_group(request, contact_store, group):
             return redirect(_group_url(group.key))
         elif '_export_group_contacts' in request.POST:
             tasks.export_group_contacts.delay(
-                request.user_api.user_account_key, group.key, True)
+                request.user_api.user_account_key,
+                group.key)
+
             messages.info(request,
                           'The export is scheduled and should '
                           'complete within a few minutes.')


### PR DESCRIPTION
The original code was written to export a single group at a time.

The new implementation allows you to export multiple groups at a time.
