### PR TITLE
Fix router directionality

### DIFF
--- a/go/routers/keyword/definition.py
+++ b/go/routers/keyword/definition.py
@@ -4,5 +4,5 @@ from go.vumitools.router.definition import RouterDefinitionBase
 class RouterDefinition(RouterDefinitionBase):
     router_type = 'keyword'
 
-    def configured_inbound_endpoints(self, config):
+    def configured_outbound_endpoints(self, config):
         return list(set(config.get('keyword_endpoint_mapping', {}).values()))

--- a/go/routers/keyword/tests/test_views.py
+++ b/go/routers/keyword/tests/test_views.py
@@ -55,3 +55,6 @@ class KeywordViewTests(DjangoGoRouterTestCase):
             'foo': 'bar',
             'baz': 'quux',
         }})
+        self.assertEqual(set(router.extra_inbound_endpoints), set())
+        self.assertEqual(
+            set(router.extra_outbound_endpoints), set(['bar', 'quux']))

--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -161,7 +161,8 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
         [router] = self.user_api.active_routers()
         self.assertEqual('keyword', router.router_type)
         self.assertEqual('My Conversation router', router.name)
-        self.assertEqual(['keyword_foo'], list(router.extra_inbound_endpoints))
+        self.assertEqual(
+            ['keyword_foo'], list(router.extra_outbound_endpoints))
         self.assertEqual({
             'keyword_endpoint_mapping': {'foo': 'keyword_foo'},
         }, router.config)
@@ -179,10 +180,10 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
             GoConnector.for_router(
                 router.router_type, router.key, GoConnector.OUTBOUND))
         self.assertEqual(self.user_api.get_routing_table(), {
-            conv_conn: {u'default': [rin_conn, u'keyword_foo']},
-            tag_conn: {u'default': [rout_conn, u'default']},
-            rin_conn: {u'keyword_foo': [conv_conn, u'default']},
-            rout_conn: {u'default': [tag_conn, u'default']},
+            conv_conn: {u'default': [rout_conn, u'keyword_foo']},
+            tag_conn: {u'default': [rin_conn, u'default']},
+            rout_conn: {u'keyword_foo': [conv_conn, u'default']},
+            rin_conn: {u'default': [tag_conn, u'default']},
         })
 
     def test_post_create_view_with_keyword_default(self):
@@ -212,7 +213,7 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
         self.assertEqual('keyword', router.router_type)
         self.assertEqual('My Conversation router', router.name)
         self.assertEqual(
-            ['keyword_default'], list(router.extra_inbound_endpoints))
+            ['keyword_default'], list(router.extra_outbound_endpoints))
         self.assertEqual({
             'keyword_endpoint_mapping': {'default': 'keyword_default'},
         }, router.config)
@@ -230,8 +231,8 @@ class WizardViewsTestCase(VumiGoDjangoTestCase):
             GoConnector.for_router(
                 router.router_type, router.key, GoConnector.OUTBOUND))
         self.assertEqual(self.user_api.get_routing_table(), {
-            conv_conn: {u'default': [rin_conn, u'keyword_default']},
-            tag_conn: {u'default': [rout_conn, u'default']},
-            rin_conn: {u'keyword_default': [conv_conn, u'default']},
-            rout_conn: {u'default': [tag_conn, u'default']},
+            conv_conn: {u'default': [rout_conn, u'keyword_default']},
+            tag_conn: {u'default': [rin_conn, u'default']},
+            rout_conn: {u'keyword_default': [conv_conn, u'default']},
+            rin_conn: {u'default': [tag_conn, u'default']},
         })

--- a/go/wizard/views.py
+++ b/go/wizard/views.py
@@ -108,7 +108,7 @@ class WizardCreateView(BaseWizardView):
         router = request.user_api.new_router(
             router_type=u'keyword', name=u'%s router' % (conv_name,),
             description=u'Keyword router for %s' % (conv_name,), config=config,
-            extra_inbound_endpoints=view_def.get_inbound_endpoints(config),
+            extra_outbound_endpoints=view_def.get_outbound_endpoints(config),
         )
         return endpoint, router
 
@@ -138,10 +138,10 @@ class WizardCreateView(BaseWizardView):
         rout_conn = str(
             GoConnector.for_router(
                 router.router_type, router.key, GoConnector.OUTBOUND))
-        rt_helper.add_entry(conv_conn, "default", rin_conn, endpoint)
-        rt_helper.add_entry(rin_conn, endpoint, conv_conn, "default")
-        rt_helper.add_entry(rout_conn, "default", tag_conn, "default")
-        rt_helper.add_entry(tag_conn, "default", rout_conn, "default")
+        rt_helper.add_entry(conv_conn, "default", rout_conn, endpoint)
+        rt_helper.add_entry(rout_conn, endpoint, conv_conn, "default")
+        rt_helper.add_entry(rin_conn, "default", tag_conn, "default")
+        rt_helper.add_entry(tag_conn, "default", rin_conn, "default")
 
         user_account.save()
 


### PR DESCRIPTION
We have "INBOUND" meaning one side of a router in some places and the other side in other places. We need to standardise on "INBOUND" mapping to a `ReceiveInboundConnector` on the router.
