### PR TITLE
Duplicate id when recreating deleted routing connection

### DIFF
--- a/go/base/static/js/src/components/plumbing/connections.js
+++ b/go/base/static/js/src/components/plumbing/connections.js
@@ -184,8 +184,7 @@
       // -------
       // The connection was removed in the UI, so the model and view still
       // exist. We need to remove them.
-      var collection = this.ownerOf(connectionId);
-      collection.remove(connectionId, {removeModel: true});
+      this.remove(connectionId);
     }
   });
 

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -431,6 +431,12 @@
         if (options.removeModel) {
           if (!options.silent) { this.removeLock = true; }
           this.models.remove(model, {silent: options.silent});
+
+          // Ensure the model is removed from the store so it won't cause
+          // duplication errors if a new model with the same id is added to the
+          // store (backbone-relational does not appear to do this
+          // automatically)
+          Backbone.Relational.store.unregister(model);
         }
       }
 

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -755,18 +755,19 @@ describe("go.components.structures", function() {
           }]
         });
 
-        var thing = new ThingModel({subthings: {id: 'thing'}}),
+        var thing = new ThingModel({subthings: {id: 'subthing'}}),
             subthings = thing.get('subthings'),
-            subthing = subthings.get('thing');
+            subthing = subthings.get('subthing'),
+            storeSubthings = Backbone.Relational.store.getCollection(subthing);
 
         var views = new ViewCollection({
           type: ToyView,
           models: subthings
         });
 
-        assert(Backbone.Relational.store.getCollection(thing).size(), 1);
-        views.remove('thing', {removeModel: true});
-        assert(Backbone.Relational.store.getCollection(thing).size(), 0);
+        assert.isDefined(storeSubthings.get('subthing'));
+        views.remove('subthing', {removeModel: true});
+        assert.isUndefined(storeSubthings.get('subthing'));
       });
 
       it("should remove the view from the 'by model' lookup", function() {

--- a/go/base/static/js/test/tests/components/structures.test.js
+++ b/go/base/static/js/test/tests/components/structures.test.js
@@ -299,7 +299,7 @@ describe("go.components.structures", function() {
         comparator: function(v) { return v.ordinal; },
 
         arrangeable: true,
-        arranger: function(v, ordinal) { return v.ordinal = ordinal; }
+        arranger: function(v, ordinal) { v.ordinal = ordinal; }
       });
 
       beforeEach(function() {
@@ -742,6 +742,31 @@ describe("go.components.structures", function() {
       it("should remove the view's model if 'removeModel' is true", function() {
         views.remove('c', {removeModel: true});
         assert.isUndefined(views.models.get('c'));
+      });
+
+      it("should unregister the model from the relational model store", function() {
+        var SubthingModel = Backbone.RelationalModel.extend();
+
+        var ThingModel = Backbone.RelationalModel.extend({
+          relations: [{
+            type: Backbone.HasMany,
+            key: 'subthings',
+            relatedModel: SubthingModel
+          }]
+        });
+
+        var thing = new ThingModel({subthings: {id: 'thing'}}),
+            subthings = thing.get('subthings'),
+            subthing = subthings.get('thing');
+
+        var views = new ViewCollection({
+          type: ToyView,
+          models: subthings
+        });
+
+        assert(Backbone.Relational.store.getCollection(thing).size(), 1);
+        views.remove('thing', {removeModel: true});
+        assert(Backbone.Relational.store.getCollection(thing).size(), 0);
       });
 
       it("should remove the view from the 'by model' lookup", function() {


### PR DESCRIPTION
On the routing screen, it's possible to remove a connection between two endpoints and then create a new connection with the same source and destination. This causes a "Duplicate id" warning to be displayed on the JS console, but the new connection is displayed on the page. When the routing table is saved, however, the new connection is not included.
