### PR TITLE
Fix highlighting of selected dashboard screen.

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -368,14 +368,13 @@ PIPELINE_JS = {
             'js/vendor/base64-2.12.js',
             'js/vendor/uuid-1.4.0.js',
             'js/vendor/jquery-1.9.1.js',
+            'js/vendor/jquery.ui-1.10.3.js',
             'js/vendor/lodash.underscore-1.2.1.js',
             'js/vendor/backbone-1.0.0.js',
             'js/vendor/backbone-relational-0.8.5.js',
-
-            'js/vendor/jquery.jsPlumb-1.4.1.js',
-            'js/vendor/jquery.ui-1.10.3.js',
             'bootstrap/js/bootstrap.min.js',
             'js/vendor/bootbox.js',
+            'js/vendor/jquery.jsPlumb-1.4.1.js',
         ),
         'output_filename': 'export/lib.js'
     },


### PR DESCRIPTION
Currently on QA `All campaigns`, `Activated`, `Deactivated`, `Archived`, `All channels` and `All routers` are not highlighted by a red background when they're selected but I think they should be.
