### PR TITLE
ConfirmView doens't unbind its events correctly

### DIFF
--- a/go/base/static/js/src/components/views.js
+++ b/go/base/static/js/src/components/views.js
@@ -116,12 +116,18 @@
       return this;
     },
 
+    remove: function() {
+      this.off();
+      return ConfirmView.__super__.remove.call(this);
+    },
+
     render: function() {
       this.$el
         .appendTo($('body'))
         .html(maybeByName(this.template)({self: this}))
         .modal('show');
 
+      this.delegateEvents();
       return this;
     }
   });

--- a/go/base/static/js/test/tests/apps/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/apps/dialogue/states/states.test.js
@@ -196,10 +196,7 @@ describe("go.apps.dialogue.states", function() {
 
       afterEach(function() {
         uuid.v4.restore();
-
-        editMode.resetModal
-         .off()
-         .hide();
+        editMode.resetModal.remove();
       });
 
       it("should display a modal to confirm the user's decision", function() {


### PR DESCRIPTION
`Backbone.View.prototype.remove()` invokes `.stopListening()` and removes its element, but doesn't invoke it's `.off()` to unbind events bound using `.on()`. This is sensible behaviour, since listeners should be using `listenTo()`, and `.on()` should be used internally by the view instance itself.

Currently, we use `.on()` for `ConfirmView` events, since this allows us to unbind both `cancel` and `ok` events after one of them is triggered. We either need to find a way to use `listenTo()`, and still only have `cancel` and `ok` events behave as they currently do (the preferable approach), or have `ConfirmView.prototype.remove()` invoke its `.off()`.
