### PR TITLE
Hook up edit contacts on the edit show screen

### DIFF
--- a/go/contacts/templates/contacts/group_detail.html
+++ b/go/contacts/templates/contacts/group_detail.html
@@ -10,14 +10,14 @@
         <button class="btn" data-action="delete" disabled="disabled">Delete</button>
     </div>
     <div class="pull-left ">
-        With group: 
+        With group:
         <button class="btn" data-toggle="modal" data-target="#delGroup">Delete</button>
         <button class="btn" data-toggle="modal" data-target="#editGroup">Rename</button>
         <button class="btn" data-toggle="modal" data-target="#expContactFrm">Export</button>
         <button class="btn" data-toggle="modal" data-target="#startCampaign">Start campaign</button>
     </div>
 
-    
+
 {% endblock %}
 
 
@@ -33,6 +33,7 @@
         el: '.table-form-view',
         actions: '.table-form-view-buttons button'
     });
+    $('#recMatchFrm').modal('show');
 {% endblock %}
 
 {% block modals %}

--- a/go/conversation/templates/conversation/edit_groups.html
+++ b/go/conversation/templates/conversation/edit_groups.html
@@ -12,7 +12,7 @@
 <div class="row-fluid">
     <div class="span12">
         <div class="indent">
-            <h3>Select contacts</h3>
+            <h3>Select contact groups</h3>
             <form id="form-conversation" method="post" action="">
                 {% csrf_token %}
                 {% include "contacts/group_list_table.html" %}
@@ -31,9 +31,6 @@
 
 {% block ondomready %}
     {{ block.super }}
-    // highlight the breadcrumbs.
-    $('.breadcrumbs a').eq(2).addClass('active');
-
     var tableFormView = new go.components.tables.TableFormView({
         el: '#form-conversation'
     });

--- a/go/conversation/templates/conversation/edit_groups.html
+++ b/go/conversation/templates/conversation/edit_groups.html
@@ -1,0 +1,39 @@
+{% extends "wizard_views/wizard_base.html" %}
+
+{% block content_title %}
+    Contacts for {{conversation.name}}
+{% endblock %}
+
+{% block content_main %}
+<div class="row-fluid">
+    <div class="span12">
+        <div class="indent">
+            <h3>Select contacts</h3>
+            <form id="form-conversation" method="post" action="">
+                {% csrf_token %}
+                {% include "contacts/group_list_table.html" %}
+                {% include "base/includes/pagination.html" %}
+            </form>
+            <button class="btn btn-primary" data-toggle="modal" data-target="#uplContacts">
+                <i class="icon-plus icon-white"></i> Upload contacts...
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block modals %}
+    {{ block.super }}
+    {% include "contacts/includes/tools.html" %}
+{% endblock %}
+
+
+{% block ondomready %}
+    {{ block.super }}
+    // highlight the breadcrumbs.
+    $('.breadcrumbs a').eq(2).addClass('active');
+
+    var tableFormView = new go.components.tables.TableFormView({
+        el: '#form-conversation'
+    });
+{% endblock %}

--- a/go/conversation/templates/conversation/edit_groups.html
+++ b/go/conversation/templates/conversation/edit_groups.html
@@ -18,9 +18,6 @@
                 {% include "contacts/group_list_table.html" %}
                 {% include "base/includes/pagination.html" %}
             </form>
-            <button class="btn btn-primary" data-toggle="modal" data-target="#uplContacts">
-                <i class="icon-plus icon-white"></i> Upload contacts...
-            </button>
         </div>
     </div>
 </div>

--- a/go/conversation/templates/conversation/edit_groups.html
+++ b/go/conversation/templates/conversation/edit_groups.html
@@ -1,7 +1,11 @@
-{% extends "wizard_views/wizard_base.html" %}
+{% extends "app.html" %}
 
-{% block content_title %}
-    Contacts for {{conversation.name}}
+{% block content_title %}Contact Groups for {{conversation.name}}{% endblock %}
+
+{% block content_actions_right %}
+    <div class="pull-right">
+        <button class="btn btn-primary" type="submit" value="Save">Save</button>
+    </div>
 {% endblock %}
 
 {% block content_main %}
@@ -35,5 +39,9 @@
 
     var tableFormView = new go.components.tables.TableFormView({
         el: '#form-conversation'
+    });
+
+    $('.content .actions .right button').click(function() {
+        $('#form-conversation').submit();
     });
 {% endblock %}

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -60,7 +60,7 @@
         <div class="sub-contacts">
             <h4 class="control-label">
                 Contacts
-                <a href="{% url 'wizard:contacts' conversation.key %}" class="btn btn-primary btn-mini">Edit</a>
+                <a href="{% conversation_screen conversation 'edit_groups' %}" class="btn btn-primary btn-mini">Edit</a>
             </h4>
             <p class="contacts">
                 {# TODO: List of groups contacts #}

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -59,14 +59,13 @@
 
         <div class="sub-contacts">
             <h4 class="control-label">
-                Contacts
+                Contact Groups
                 <a href="{% conversation_screen conversation 'edit_groups' %}" class="btn btn-primary btn-mini">Edit</a>
             </h4>
             <p class="contacts">
-                {# TODO: List of groups contacts #}
                 <ol>
-                {% for group, member_count in groups.items %}
-                    <li>{{group}} ({{member_count}} member{{member_count|pluralize}})</li>
+                {% for group in conversation.get_groups %}
+                    <li><a href="{% url 'contacts:group' group_key=group.key %}">{{group.name}}</a></li>
                 {% empty %}
                     <li>You have not specified any contacts.</li>
                 {% endfor %}

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -87,7 +87,7 @@ class ConversationTestCase(VumiGoDjangoTestCase):
             return self.client.get(reverse('conversations:index'), {
                 'query': conv.name,
                 'conversation_type': conversation_type,
-                })
+            })
 
         self.assertContains(search('bulk_message'), conv.key)
         self.assertNotContains(search('survey'), conv.key)
@@ -99,7 +99,7 @@ class ConversationTestCase(VumiGoDjangoTestCase):
             return self.client.get(reverse('conversations:index'), {
                 'query': conv.name,
                 'conversation_status': conversation_status,
-                })
+            })
 
         # it should be draft
         self.assertContains(search('draft'), conv.key)
@@ -196,14 +196,14 @@ class ConversationTestCase(VumiGoDjangoTestCase):
             'p': 2,
             'conversation_type': 'bulk_message',
             'conversation_status': 'draft',
-            })
+        })
 
         self.assertNotContains(response, '?p=2')
 
     def test_scrub_tokens(self):
         content = 'Please visit http://example.com/t/6be226/ ' \
-                    'to start your conversation.'
+                  'to start your conversation.'
         expected = 'Please visit http://example.com/t/******/ ' \
-                    'to start your conversation.'
+                   'to start your conversation.'
         self.assertEqual(scrub_tokens(content), expected)
         self.assertEqual(scrub_tokens(content * 2), expected * 2)

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -59,7 +59,7 @@ class ConversationTestCase(VumiGoDjangoTestCase):
         self.assertEqual(reloaded_conv.name, 'foo')
         self.assertEqual(reloaded_conv.description, 'bar')
 
-    def test_conversation_contact_management(self):
+    def test_conversation_contact_group_listing(self):
         conv = self.create_conversation(conversation_type=u'bulk_message',
                                         name=u'test', description=u'test')
         group1 = self.user_api.contact_store.new_group(u'Contact Group 1')
@@ -70,22 +70,29 @@ class ConversationTestCase(VumiGoDjangoTestCase):
 
         show_url = reverse('conversations:conversation', kwargs={
             'conversation_key': conv.key, 'path_suffix': ''})
-        groups_url = reverse('conversations:conversation', kwargs={
-            'conversation_key': conv.key, 'path_suffix': 'edit_groups/'})
 
         resp = self.client.get(show_url)
         self.assertContains(resp, 'Contact Group 1')
         self.assertNotContains(resp, 'Contact Group 2')
 
+    def test_conversation_contact_group_assignment(self):
+        conv = self.create_conversation(conversation_type=u'bulk_message',
+                                        name=u'test', description=u'test')
+        group1 = self.user_api.contact_store.new_group(u'Contact Group 1')
+        group2 = self.user_api.contact_store.new_group(u'Contact Group 2')
+
+        groups_url = reverse('conversations:conversation', kwargs={
+            'conversation_key': conv.key, 'path_suffix': 'edit_groups/'})
+
         resp = self.client.post(groups_url, {
             'group': [group2.key]
         })
 
-        self.assertRedirects(resp, show_url)
+        self.assertEqual(resp.status_code, 302)
 
-        resp = self.client.get(show_url)
-        self.assertNotContains(resp, 'Contact Group 1')
-        self.assertContains(resp, 'Contact Group 2')
+        reloaded_conv = self.user_api.get_wrapped_conversation(conv.key)
+        self.assertFalse(group1.key in reloaded_conv.groups.keys())
+        self.assertTrue(group2.key in reloaded_conv.groups.keys())
 
     def test_post_new_conversation_extra_endpoints(self):
         self.add_app_permission(u'go.apps.wikipedia')

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import functools
 from StringIO import StringIO
+from urllib import urlencode
 
 from django.views.generic import View, TemplateView
 from django import forms
@@ -10,6 +11,7 @@ from django.core.urlresolvers import reverse
 from django.contrib import messages
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from go.vumitools.exceptions import ConversationSendError
 from go.token.django_token_manager import DjangoTokenManager
@@ -397,11 +399,52 @@ class EditConversationGroupsView(ConversationTemplateView):
     view_name = 'edit_groups'
     path_suffix = 'edit_groups/'
 
+    def _render_groups(self, request, conversation):
+        groups = sorted(request.user_api.list_groups(),
+                        key=lambda group: group.created_at,
+                        reverse=True)
+
+        selected_groups = list(group.key for group
+                               in conversation.get_groups())
+
+        for group in groups:
+            if group.key in selected_groups:
+                group.selected = True
+
+        query = request.GET.get('query', '')
+        p = request.GET.get('p', 1)
+
+        paginator = Paginator(groups, 15)
+        try:
+            page = paginator.page(p)
+        except PageNotAnInteger:
+            page = paginator.page(1)
+        except EmptyPage:
+            page = paginator.page(paginator.num_pages)
+
+        pagination_params = urlencode({
+            'query': query,
+        })
+
+        return self.render_to_response({
+            'paginator': paginator,
+            'page': page,
+            'pagination_params': pagination_params,
+            'conversation': conversation,
+        })
+
     def get(self, request, conversation):
-        pass
+        return self._render_groups(request, conversation)
 
     def post(self, request, conversation):
-        pass
+        group_keys = request.POST.getlist('group')
+        conversation.groups.clear()
+        for group_key in group_keys:
+            conversation.add_group(group_key)
+        conversation.save()
+
+        return self.redirect_to(self.get_next_view(conversation),
+                                conversation_key=conversation.key)
 
 
 class ConversationViewDefinitionBase(object):

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -393,6 +393,17 @@ class AggregatesConversationView(ConversationTemplateView):
             content_type='text/csv; charset=utf-8')
 
 
+class EditConversationGroupsView(ConversationTemplateView):
+    view_name = 'edit_groups'
+    path_suffix = 'edit_groups/'
+
+    def get(self, request, conversation):
+        pass
+
+    def post(self, request, conversation):
+        pass
+
+
 class ConversationViewDefinitionBase(object):
     """Definition of conversation UI.
 
@@ -410,6 +421,7 @@ class ConversationViewDefinitionBase(object):
     # This doesn't include ConversationActionView because that's special.
     DEFAULT_CONVERSATION_VIEWS = (
         ShowConversationView,
+        EditConversationGroupsView,
         StartConversationView,
         ConfirmConversationView,
         StopConversationView,


### PR DESCRIPTION
Currently clicking on edit contacts leads to a contact selection screen somewhere under the wizard (it should probably be part of the conversation views) and the save button on the screen it redirects to isn't hooked up.
