### PR TITLE
Clean up code that pokes the message store directly

### DIFF
--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -20,6 +20,7 @@ from vumi.config import ConfigContext
 from vumi import log
 
 from go.apps.http_api.auth import ConversationRealm, ConversationAccessChecker
+from go.vumitools.utils import MessageMetadataHelper
 
 
 class BaseResource(resource.Resource):
@@ -150,19 +151,15 @@ class MessageStream(StreamResource):
         user_account = request.getUser()
         conversation = yield self.get_conversation(user_account)
 
-        # Using the proxy's load() directly instead of
-        # `mdb.get_inbound_message(msg_id)` because that gives us the
-        # actual message, not the OutboundMessage. We need the
-        # OutboundMessage to get the batch and verify the `user_account`
-        reply_to = yield self.vumi_api.mdb.inbound_messages.load(in_reply_to)
+        reply_to = yield self.vumi_api.mdb.get_inbound_message(in_reply_to)
         if reply_to is None:
             request.setResponseCode(http.BAD_REQUEST)
             request.write('Invalid in_reply_to value')
             request.finish()
             return
 
-        batch_id = reply_to.batch.key
-        if batch_id is None or batch_id not in conversation.get_batch_keys():
+        reply_to_mdh = MessageMetadataHelper(self.vumi_api, reply_to)
+        if reply_to_mdh.get_conversation_key() != conversation.key:
             request.setResponseCode(http.BAD_REQUEST)
             request.write('Invalid in_reply_to value')
             request.finish()
@@ -176,7 +173,7 @@ class MessageStream(StreamResource):
         helper_metadata = conversation.set_go_helper_metadata()
 
         msg = yield self.worker.reply_to(
-            reply_to.msg, content, continue_session,
+            reply_to, content, continue_session,
             helper_metadata=helper_metadata)
 
         request.setResponseCode(http.OK)

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -159,11 +159,13 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
                                             Headers(self.auth_headers))
 
         msg1 = self.mkmsg_out(content='in 1', message_id='1')
+        self.conversation.set_go_helper_metadata(msg1['helper_metadata'])
         yield self.store_outbound_msg(msg1, self.conversation)
         ack1 = self.mkmsg_ack(user_message_id=msg1['message_id'])
         yield self.dispatch_event(ack1)
 
         msg2 = self.mkmsg_out(content='in 1', message_id='2')
+        self.conversation.set_go_helper_metadata(msg2['helper_metadata'])
         yield self.store_outbound_msg(msg2, self.conversation)
         ack2 = self.mkmsg_ack(user_message_id=msg2['message_id'])
         yield self.dispatch_event(ack2)
@@ -253,6 +255,8 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_in_reply_to(self):
         inbound_msg = self.mkmsg_in(content='in 1', message_id='1')
+        self.conversation.set_go_helper_metadata(
+            inbound_msg['helper_metadata'])
         yield self.store_inbound_msg(inbound_msg, self.conversation)
 
         msg = {
@@ -417,6 +421,7 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
         yield self.conversation.save()
 
         msg1 = self.mkmsg_out(content='in 1', message_id='1')
+        self.conversation.set_go_helper_metadata(msg1['helper_metadata'])
         yield self.store_outbound_msg(msg1, self.conversation)
         ack1 = self.mkmsg_ack(user_message_id=msg1['message_id'])
         event_d = self.dispatch_event(ack1)
@@ -484,6 +489,7 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_process_command_send_message_in_reply_to(self):
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
+        self.conversation.set_go_helper_metadata(msg['helper_metadata'])
         yield self.vumi_api.mdb.add_inbound_message(msg)
         command = VumiApiCommand.command(
             'worker', 'send_message',

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -162,13 +162,13 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
         self.conversation.set_go_helper_metadata(msg1['helper_metadata'])
         yield self.store_outbound_msg(msg1, self.conversation)
         ack1 = self.mkmsg_ack(user_message_id=msg1['message_id'])
-        yield self.dispatch_event(ack1)
+        yield self.dispatch_event_to_conv(ack1, self.conversation)
 
         msg2 = self.mkmsg_out(content='in 1', message_id='2')
         self.conversation.set_go_helper_metadata(msg2['helper_metadata'])
         yield self.store_outbound_msg(msg2, self.conversation)
         ack2 = self.mkmsg_ack(user_message_id=msg2['message_id'])
-        yield self.dispatch_event(ack2)
+        yield self.dispatch_event_to_conv(ack2, self.conversation)
 
         ra1 = yield events.get()
         ra2 = yield events.get()
@@ -424,7 +424,7 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
         self.conversation.set_go_helper_metadata(msg1['helper_metadata'])
         yield self.store_outbound_msg(msg1, self.conversation)
         ack1 = self.mkmsg_ack(user_message_id=msg1['message_id'])
-        event_d = self.dispatch_event(ack1)
+        event_d = self.dispatch_event_to_conv(ack1, self.conversation)
 
         req = yield self.push_calls.get()
         posted_json_data = req.content.read()

--- a/go/apps/http_api/vumi_app.py
+++ b/go/apps/http_api/vumi_app.py
@@ -183,22 +183,8 @@ class StreamingHTTPWorker(GoApplicationWorker):
             log.warning('Unable to find message %s for event %s.' % (
                 event['user_message_id'], event['event_id']))
 
-        msg_md = outbound_message.msg['helper_metadata']
-        # First, try look up the things we need in the message metadata.
-        account_key = msg_md.get('go', {}).get('user_account')
-        if account_key is not None:
-            user_api = self.get_user_api(account_key)
-            conv_key = msg_md['go'].get('conversation_key')
-        else:
-            # Fall back to looking up by batch. (Ugh.)
-            # TODO: This can probably just be removed.
-            batch = yield outbound_message.batch.get()
-            account_key = batch.metadata['user_account']
-            user_api = self.get_user_api(account_key)
-            conversations = user_api.conversation_store.conversations
-            mr = conversations.index_lookup('batches', batch.key)
-            [conv_key] = yield mr.get_keys()
-        conversation = yield user_api.get_wrapped_conversation(conv_key)
+        config = yield self.get_message_config(event)
+        conversation = config.get_conversation()
         push_event_url = self.get_api_config(conversation, 'push_event_url')
         if push_event_url:
             resp = yield self.push(push_event_url, event)

--- a/go/base/management/commands/go_account_stats.py
+++ b/go/base/management/commands/go_account_stats.py
@@ -134,11 +134,8 @@ class Command(BaseCommand):
             batch_key, message_store.batch_outbound_count(batch_key),))
 
     def do_batch_key_breakdown(self, message_store, batch_key):
-        inbound_keys = message_store.inbound_messages.index_lookup(
-            'batch', batch_key).get_keys()
-
-        outbound_keys = message_store.outbound_messages.index_lookup(
-            'batch', batch_key).get_keys()
+        inbound_keys = message_store.batch_inbound_keys(batch_key)
+        outbound_keys = message_store.batch_outbound_keys(batch_key)
 
         inbound = list(get_inbound(message_store, inbound_keys))
         outbound = list(get_outbound(message_store, outbound_keys))

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -252,6 +252,10 @@ class GoAppWorkerTestMixin(GoWorkerTestMixin):
         conv.set_go_helper_metadata(msg['helper_metadata'])
         return self.dispatch(msg)
 
+    def dispatch_event_to_conv(self, event, conv):
+        conv.set_go_helper_metadata(event['helper_metadata'])
+        return self.dispatch_event(event)
+
 
 class GoRouterWorkerTestMixin(GoWorkerTestMixin):
 


### PR DESCRIPTION
This is necessary to make Go work with the changes in praekelt/vumi#586, shouldn't break with older vumi versions.
