### PR TITLE
Allow connected dialogue states to be moveable

### DIFF
--- a/go/base/static/js/src/apps/dialogue/states/states.js
+++ b/go/base/static/js/src/apps/dialogue/states/states.js
@@ -246,7 +246,6 @@
     },
 
     events: {
-      'mousedown .titlebar': 'onTitlebarHold',
       'click .titlebar .remove': 'onRemove'
     },
 
@@ -263,11 +262,6 @@
       };
 
       this.switchMode(options.mode || 'preview', {render: false});
-    },
-
-    onTitlebarHold: function(e) {
-      if (this.isConnected()) { this.$el.addClass('locked'); }
-      else { this.$el.removeClass('locked'); }
     },
 
     onRemove: function(e) {
@@ -330,7 +324,6 @@
 
     sortableOptions: {
       items: '.item:not(.add-container)',
-      cancel: '.locked,input',
       handle: '.titlebar',
       placeholder: 'placeholder',
       sort: function() { jsPlumb.repaintEverything(); },

--- a/go/base/static/js/test/tests/apps/dialogue/states/states.test.js
+++ b/go/base/static/js/test/tests/apps/dialogue/states/states.test.js
@@ -473,7 +473,7 @@ describe("go.apps.dialogue.states", function() {
         diagram.render();
       });
 
-      it("should allow the state to be sorted if it isn't connected",
+      it("should allow the state to be sorted",
       function() {
         assert.deepEqual(
           states.keys(),
@@ -486,20 +486,6 @@ describe("go.apps.dialogue.states", function() {
         assert.deepEqual(
           states.keys(),
           ['state1','state3','state2','state4']);
-      });
-
-      it("should not let the state be sorted if it is connected", function() {
-        assert.deepEqual(
-          states.keys(),
-          ['state1','state2','state3','state4']);
-
-        $('[data-uuid="state1"] .titlebar')
-          .simulate('mousedown')
-          .simulate('drag', {dx: 150});
-
-        assert.deepEqual(
-          states.keys(),
-          ['state1','state2','state3','state4']);
       });
     });
 


### PR DESCRIPTION
We no longer need this restriction, since we aren't using vxpolls anymore.
