### PR TITLE
Useful error pages

### DIFF
--- a/go/base/static/css/error.less
+++ b/go/base/static/css/error.less
@@ -1,0 +1,18 @@
+.error.main-container {
+  text-align: center;
+
+  .error-content {
+    margin: 30px;
+
+    .title {
+      font-size: 10em;
+      line-height: 2em;
+      color: #aaa;
+    }
+
+    .reason {
+      font-size: 2.5em;
+      color: #f2f1ed;
+    }
+  }
+}

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -659,3 +659,18 @@ button {
 .table-form-view-buttons {
   margin: 0 1em 0 0;
 }
+.error.main-container {
+  text-align: center;
+}
+.error.main-container .error-content {
+  margin: 30px;
+}
+.error.main-container .error-content .title {
+  font-size: 10em;
+  line-height: 2em;
+  color: #aaa;
+}
+.error.main-container .error-content .reason {
+  font-size: 2.5em;
+  color: #f2f1ed;
+}

--- a/go/base/static/css/vumigo.less
+++ b/go/base/static/css/vumigo.less
@@ -302,3 +302,4 @@ a:link, button {
 @import "contacts.less";
 @import "accounts.less";
 @import "tables.less";
+@import "error.less";

--- a/go/templates/404.html
+++ b/go/templates/404.html
@@ -1,5 +1,4 @@
 {% extends "error.html" %}
-{% load url from future %}
 
 {% block error_title %}404{% endblock %}
 {% block error_reason %}The page you are trying to access doesn't exist.{% endblock %}

--- a/go/templates/404.html
+++ b/go/templates/404.html
@@ -1,5 +1,5 @@
-{% extends "base.html" %}
+{% extends "error.html" %}
+{% load url from future %}
 
-{% block content %}
-    404: The page you are trying to access doesn't exist.
-{% endblock %}
+{% block error_title %}404{% endblock %}
+{% block error_reason %}The page you are trying to access doesn't exist.{% endblock %}

--- a/go/templates/500.html
+++ b/go/templates/500.html
@@ -1,5 +1,4 @@
-{% extends "base.html" %}
+{% extends "error.html" %}
 
-{% block content %}
-    500: Something went wrong
-{% endblock %}
+{% block error_title %}500{% endblock %}
+{% block error_reason %}Something went wrong{% endblock %}

--- a/go/templates/base.html
+++ b/go/templates/base.html
@@ -30,7 +30,7 @@
 
 </head>
 <body>
-    <div class="container-fluid main-container">
+    <div class="container-fluid main-container {% block container_extraclass %}{% endblock %}">
 
         <!--[if lt IE 7]>
         <p class=chromeframe>

--- a/go/templates/error.html
+++ b/go/templates/error.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block container_extraclass %}error{% endblock %}
+
+{% block content %}
+  <div class='error-content'>
+    <h1 class='title'>{% block error_title %}{{ error_title }}{% endblock %}</h1>
+    <span class='reason'>{% block error_reason %}{{ error_reason }}{%endblock %}</span>
+  </div>
+{% endblock %}


### PR DESCRIPTION
We currently have empty error pages, which makes it really hard to figure out what's going wrong. At the very least we should have "404" and "500" pages that tell the client that there was a problem.

We haven't noticed this much before because we run locally with `DEBUG=True`, but it made #588 harder to debug.
