### PR TITLE
Better conversation and router management commands

### DIFF
--- a/go/base/command_utils.py
+++ b/go/base/command_utils.py
@@ -1,0 +1,53 @@
+from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+
+from go.base.utils import vumi_api_for_user
+
+
+def make_command_opt_str(command_name):
+    return '--%s' % (command_name.replace('_', '-'),)
+
+
+def make_command_option(command_name, **kw):
+    opt_str = make_command_opt_str(command_name)
+    return make_option(
+        opt_str, dest='command', action='append_const', const=command_name,
+        **kw)
+
+
+class BaseGoAccountCommand(BaseCommand):
+    ACCOUNT_OPTIONS = [
+        make_option('--email-address',
+                    dest='email_address',
+                    help='Email address for the Vumi Go user'),
+    ]
+    LOCAL_OPTIONS = []
+    option_list = (
+        BaseCommand.option_list
+        + tuple(ACCOUNT_OPTIONS)
+        + tuple(LOCAL_OPTIONS)
+    )
+
+    def handle(self, *args, **options):
+        if 'email_address' not in options:
+            raise CommandError("--email-address must be specified")
+        try:
+            self.user = User.objects.get(email=options['email_address'])
+        except User.DoesNotExist, e:
+            raise CommandError(e)
+
+        self.user_api = vumi_api_for_user(self.user)
+
+        commands = options.get('command', [])
+        if not commands:
+            return self.handle_no_command(*args, **options)
+        if len(commands) > 1:
+            raise CommandError(
+                "Multiple command options provided, only one allowed: %s" % (
+                    ' '.join(make_command_opt_str(cmd) for cmd in commands)))
+        return getattr(self, 'handle_command_%s' % commands)(*args, **options)
+
+    def handle_no_command(*args, **options):
+        raise CommandError('Please specify an action')

--- a/go/base/command_utils.py
+++ b/go/base/command_utils.py
@@ -18,17 +18,15 @@ def make_command_option(command_name, **kw):
 
 
 class BaseGoAccountCommand(BaseCommand):
-    ACCOUNT_OPTIONS = [
+    option_list = BaseCommand.option_list + (
         make_option('--email-address',
                     dest='email_address',
                     help='Email address for the Vumi Go user'),
-    ]
-    LOCAL_OPTIONS = []
-    option_list = (
-        BaseCommand.option_list
-        + tuple(ACCOUNT_OPTIONS)
-        + tuple(LOCAL_OPTIONS)
     )
+
+    def list_commands(self):
+        return [opt.const for opt in self.option_list
+                if opt.action == 'append_const' and opt.dest == 'command']
 
     def handle(self, *args, **options):
         if 'email_address' not in options:
@@ -49,5 +47,8 @@ class BaseGoAccountCommand(BaseCommand):
                     ' '.join(make_command_opt_str(cmd) for cmd in commands)))
         return getattr(self, 'handle_command_%s' % commands)(*args, **options)
 
-    def handle_no_command(*args, **options):
-        raise CommandError('Please specify an action')
+    def handle_no_command(self, *args, **options):
+        raise CommandError(
+            'Please specify one of the following actions: %s' % (
+                ' '.join(make_command_opt_str(cmd)
+                         for cmd in self.list_commands())))

--- a/go/base/management/commands/go_manage_conversation.py
+++ b/go/base/management/commands/go_manage_conversation.py
@@ -12,6 +12,7 @@ class Command(BaseGoAccountCommand):
     option_list = BaseGoAccountCommand.option_list + (
         make_command_option(
             'list', help='List the active conversations in this account.'),
+        make_command_option('show', help='Display a conversation'),
         make_command_option(
             'show_config', help='Display the config for a conversation'),
         make_command_option('start', help='Start a conversation'),
@@ -38,6 +39,11 @@ class Command(BaseGoAccountCommand):
         for i, c in enumerate(conversations):
             self.stdout.write("%d. %s (type: %s, key: %s)\n"
                               % (i, c.name, c.conversation_type, c.key))
+
+    def handle_command_show(self, *args, **options):
+        conversation = self.get_conversation(options)
+        self.stdout.write(pformat(conversation.get_data()))
+        self.stdout.write("\n")
 
     def handle_command_show_config(self, *args, **options):
         conversation = self.get_conversation(options)

--- a/go/base/management/commands/go_manage_conversation.py
+++ b/go/base/management/commands/go_manage_conversation.py
@@ -1,64 +1,78 @@
 from optparse import make_option
 from pprint import pformat
 
-from django.core.management.base import BaseCommand, CommandError
-from django.contrib.auth.models import User
+from django.core.management.base import CommandError
 
-from go.base.utils import vumi_api_for_user
+from go.base.command_utils import BaseGoAccountCommand, make_command_option
 
 
-class Command(BaseCommand):
+class Command(BaseGoAccountCommand):
     help = "Manage conversations."
 
     LOCAL_OPTIONS = [
-        make_option('--email-address',
-                    dest='email_address',
-                    help='Email address for the Vumi Go user'),
+        make_command_option(
+            'list', help='List the active conversations in this account.'),
+        make_command_option(
+            'show_config', help='Display the config for a conversation'),
+        make_command_option('start', help='Start a conversation'),
+        make_command_option('stop', help='Stop a conversation'),
+        make_command_option('archive', help='Archive a conversation'),
+
         make_option('--conversation-key',
                     dest='conversation_key',
                     help='The conversation key'),
-        make_option('--list',
-                    dest='list_conversations',
-                    action='store_true', default=False,
-                    help='List the active conversations in this account.'),
-        make_option('--show-config',
-                    dest='show_config',
-                    action='store_true', default=False,
-                    help='Display the config for a conversation'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
 
-    def handle(self, *args, **options):
-        try:
-            user = User.objects.get(email=options['email_address'])
-        except User.DoesNotExist, e:
-            raise CommandError(e)
-
-        user_api = vumi_api_for_user(user)
-
-        if options.get('list_conversations'):
-            self.list_conversations(user_api)
-            return
-
+    def get_conversation(self, options):
         if 'conversation_key' not in options:
             raise CommandError('Please specify a conversation key')
-        conversation = user_api.get_wrapped_conversation(
+        conversation = self.user_api.get_wrapped_conversation(
             options['conversation_key'])
         if conversation is None:
             raise CommandError('Conversation does not exist')
+        return conversation
 
-        if options.get('show_config'):
-            self.show_config(conversation)
-        else:
-            raise CommandError('Please specify an action')
-
-    def list_conversations(self, user_api):
-        conversations = user_api.active_conversations()
+    def handle_command_list(self, *args, **options):
+        conversations = self.user_api.active_conversations()
         conversations.sort(key=lambda c: c.created_at)
         for i, c in enumerate(conversations):
             self.stdout.write("%d. %s (type: %s, key: %s)\n"
                               % (i, c.name, c.conversation_type, c.key))
 
-    def show_config(self, conversation):
+    def handle_command_show_config(self, *args, **options):
+        conversation = self.get_conversation(options)
         self.stdout.write(pformat(conversation.config))
         self.stdout.write("\n")
+
+    def handle_command_start(self, *apps, **options):
+        conversation = self.get_conversation(options)
+        if conversation.archived():
+            raise CommandError('Archived conversations cannot be started')
+        if conversation.running() or conversation.stopping():
+            raise CommandError('Conversation already running')
+
+        self.stdout.write("Starting conversation...\n")
+        conversation.start()
+        self.stdout.write("Conversation started\n")
+
+    def handle_command_stop(self, *apps, **options):
+        conversation = self.get_conversation(options)
+        if conversation.archived():
+            raise CommandError('Archived conversations cannot be stopped')
+        if conversation.stopped():
+            raise CommandError('Conversation already stopped')
+
+        self.stdout.write("Stopping conversation...\n")
+        conversation.stop_conversation()
+        self.stdout.write("Conversation stopped\n")
+
+    def handle_command_archive(self, *apps, **options):
+        conversation = self.get_conversation(options)
+        if conversation.archived():
+            raise CommandError('Archived conversations cannot be archived')
+        if not conversation.stopped():
+            raise CommandError('Only stopped conversations can be archived')
+
+        self.stdout.write("Archiving conversation...\n")
+        conversation.archive_conversation()
+        self.stdout.write("Conversation archived\n")

--- a/go/base/management/commands/go_manage_conversation.py
+++ b/go/base/management/commands/go_manage_conversation.py
@@ -9,7 +9,7 @@ from go.base.command_utils import BaseGoAccountCommand, make_command_option
 class Command(BaseGoAccountCommand):
     help = "Manage conversations."
 
-    LOCAL_OPTIONS = [
+    option_list = BaseGoAccountCommand.option_list + (
         make_command_option(
             'list', help='List the active conversations in this account.'),
         make_command_option(
@@ -21,7 +21,7 @@ class Command(BaseGoAccountCommand):
         make_option('--conversation-key',
                     dest='conversation_key',
                     help='The conversation key'),
-    ]
+    )
 
     def get_conversation(self, options):
         if 'conversation_key' not in options:

--- a/go/base/management/commands/go_manage_router.py
+++ b/go/base/management/commands/go_manage_router.py
@@ -12,6 +12,7 @@ class Command(BaseGoAccountCommand):
     option_list = BaseGoAccountCommand.option_list + (
         make_command_option(
             'list', help='List the active routers in this account.'),
+        make_command_option('show', help='Display a router'),
         make_command_option(
             'show_config', help='Display the config for a router'),
         make_command_option('start', help='Start a router'),
@@ -37,6 +38,11 @@ class Command(BaseGoAccountCommand):
         for i, c in enumerate(routers):
             self.stdout.write("%d. %s (type: %s, key: %s)\n"
                               % (i, c.name, c.router_type, c.key))
+
+    def handle_command_show(self, *args, **options):
+        router = self.get_router(options)
+        self.stdout.write(pformat(router.get_data()))
+        self.stdout.write("\n")
 
     def handle_command_show_config(self, *args, **options):
         router = self.get_router(options)

--- a/go/base/management/commands/go_manage_router.py
+++ b/go/base/management/commands/go_manage_router.py
@@ -9,7 +9,7 @@ from go.base.command_utils import BaseGoAccountCommand, make_command_option
 class Command(BaseGoAccountCommand):
     help = "Manage routers."
 
-    LOCAL_OPTIONS = [
+    option_list = BaseGoAccountCommand.option_list + (
         make_command_option(
             'list', help='List the active routers in this account.'),
         make_command_option(
@@ -21,7 +21,7 @@ class Command(BaseGoAccountCommand):
         make_option('--router-key',
                     dest='router_key',
                     help='The router key'),
-    ]
+    )
 
     def get_router(self, options):
         if 'router_key' not in options:

--- a/go/base/management/commands/go_manage_router.py
+++ b/go/base/management/commands/go_manage_router.py
@@ -1,0 +1,80 @@
+from optparse import make_option
+from pprint import pformat
+
+from django.core.management.base import CommandError
+
+from go.base.command_utils import BaseGoAccountCommand, make_command_option
+
+
+class Command(BaseGoAccountCommand):
+    help = "Manage routers."
+
+    LOCAL_OPTIONS = [
+        make_command_option(
+            'list', help='List the active routers in this account.'),
+        make_command_option(
+            'show_config', help='Display the config for a router'),
+        make_command_option('start', help='Start a router'),
+        make_command_option('stop', help='Stop a router'),
+        make_command_option('archive', help='Archive a router'),
+
+        make_option('--router-key',
+                    dest='router_key',
+                    help='The router key'),
+    ]
+
+    def get_router(self, options):
+        if 'router_key' not in options:
+            raise CommandError('Please specify a router key')
+        router = self.user_api.get_router(options['router_key'])
+        if router is None:
+            raise CommandError('Router does not exist')
+        return router
+
+    def handle_command_list(self, *args, **options):
+        routers = self.user_api.active_routers()
+        routers.sort(key=lambda c: c.created_at)
+        for i, c in enumerate(routers):
+            self.stdout.write("%d. %s (type: %s, key: %s)\n"
+                              % (i, c.name, c.router_type, c.key))
+
+    def handle_command_show_config(self, *args, **options):
+        router = self.get_router(options)
+        self.stdout.write(pformat(router.config))
+        self.stdout.write("\n")
+
+    def handle_command_start(self, *apps, **options):
+        router = self.get_router(options)
+        if router.archived():
+            raise CommandError('Archived routers cannot be started')
+        if router.running() or router.stopping():
+            raise CommandError('Router already running')
+
+        self.stdout.write("Starting router...\n")
+        rapi = self.user_api.get_router_api(router.router_type, router.key)
+        rapi.start_router()
+        self.stdout.write("Router started\n")
+
+    def handle_command_stop(self, *apps, **options):
+        router = self.get_router(options)
+        if router.archived():
+            raise CommandError('Archived routers cannot be stopped')
+        if router.stopped():
+            raise CommandError('Router already stopped')
+
+        self.stdout.write("Stopping router...\n")
+        rapi = self.user_api.get_router_api(router.router_type, router.key)
+        rapi.stop_router()
+        self.stdout.write("Router stopped\n")
+
+    def handle_command_archive(self, *apps, **options):
+        router = self.get_router(options)
+        if router.archived():
+            raise CommandError('Archived routers cannot be archived')
+        if not router.stopped():
+            raise CommandError('Only stopped routers can be archived')
+
+        self.stdout.write("Archiving router...\n")
+        rapi = self.user_api.get_router_api(router.router_type, router.key)
+        rapi.archive_router()
+        self.stdout.write("Router archived\n")

--- a/go/base/tests/test_command_utils.py
+++ b/go/base/tests/test_command_utils.py
@@ -1,0 +1,55 @@
+from optparse import make_option
+
+from django.core.management.base import CommandError
+
+from go.base.command_utils import BaseGoAccountCommand, make_command_option
+from go.base.tests.utils import GoAccountCommandTestCase
+
+
+class DummyGoDjangoAccountCommand(BaseGoAccountCommand):
+    LOCAL_OPTIONS = [
+        make_command_option('foo'),
+        make_command_option('bar'),
+        make_option('--opt', action='store', dest='opt'),
+    ]
+
+    def handle_command_foo(self, *args, **options):
+        self.stdout.write('foo\n')
+
+    def handle_command_bar(self, *args, **options):
+        self.stdout.write('bar: %s\n' % (options['opt'],))
+
+
+class TestBaseGoAccountCommand(GoAccountCommandTestCase):
+    command_class = DummyGoDjangoAccountCommand
+
+    def test_user_email_required(self):
+        self.assertRaisesRegexp(
+            CommandError, '--email-address must be specified',
+            self.command.handle)
+
+    def test_user_account_must_exist(self):
+        self.assertRaisesRegexp(
+            CommandError, 'User matching query does not exist',
+            self.command.handle, email_address='foo@bar')
+
+    def test_too_many_commands(self):
+        self.assert_command_error(
+            'Multiple command options provided, only one allowed: --foo --bar',
+            'foo', 'bar')
+
+    def test_no_command_default(self):
+        self.assert_command_error('Please specify an action')
+
+    def test_no_command_override(self):
+        def handle_no_command(*args, **options):
+            self.command.stdout.write('no command\n')
+
+        self.command.handle_no_command = handle_no_command
+        self.assert_command_output('no command\n')
+
+    def test_command_foo(self):
+        self.assert_command_output('foo\n', 'foo')
+
+    def test_command_bar(self):
+        self.assert_command_output('bar: hi\n', 'bar', opt='hi')

--- a/go/base/tests/test_command_utils.py
+++ b/go/base/tests/test_command_utils.py
@@ -7,11 +7,11 @@ from go.base.tests.utils import GoAccountCommandTestCase
 
 
 class DummyGoDjangoAccountCommand(BaseGoAccountCommand):
-    LOCAL_OPTIONS = [
+    option_list = BaseGoAccountCommand.option_list + (
         make_command_option('foo'),
         make_command_option('bar'),
         make_option('--opt', action='store', dest='opt'),
-    ]
+    )
 
     def handle_command_foo(self, *args, **options):
         self.stdout.write('foo\n')
@@ -39,7 +39,8 @@ class TestBaseGoAccountCommand(GoAccountCommandTestCase):
             'foo', 'bar')
 
     def test_no_command_default(self):
-        self.assert_command_error('Please specify an action')
+        self.assert_command_error(
+            'Please specify one of the following actions: --foo --bar')
 
     def test_no_command_override(self):
         def handle_no_command(*args, **options):

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -26,7 +26,6 @@ class TestGoManageConversation(GoAccountCommandTestCase):
     def test_show(self):
         conv = self.create_conversation()
         expected_output = "%s\n" % pformat(conv.get_data())
-        print expected_output
         self.assert_command_output(
             expected_output, 'show', conversation_key=conv.key)
 

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -1,3 +1,5 @@
+from pprint import pformat
+
 from mock import patch
 
 from go.base.tests.utils import GoAccountCommandTestCase
@@ -20,6 +22,13 @@ class TestGoManageConversation(GoAccountCommandTestCase):
         expected_output = "0. %s (type: %s, key: %s)\n" % (
             conv.name, conv.conversation_type, conv.key)
         self.assert_command_output(expected_output, 'list')
+
+    def test_show(self):
+        conv = self.create_conversation()
+        expected_output = "%s\n" % pformat(conv.get_data())
+        print expected_output
+        self.assert_command_output(
+            expected_output, 'show', conversation_key=conv.key)
 
     def test_show_config_no_conv(self):
         self.assert_command_error(

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -1,4 +1,3 @@
-from django.core.management.base import CommandError
 from mock import patch
 
 from go.base.tests.utils import GoAccountCommandTestCase

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -1,53 +1,84 @@
-from StringIO import StringIO
-
 from django.core.management.base import CommandError
+from mock import patch
 
-from go.base.tests.utils import VumiGoDjangoTestCase
+from go.base.tests.utils import GoAccountCommandTestCase
 from go.base.management.commands import go_manage_conversation
 
 
-class GoManageConversationTestCase(VumiGoDjangoTestCase):
-    use_riak = True
+class DummyMessageSender(object):
+    def __init__(self):
+        self.outbox = []
 
-    def setUp(self):
-        super(GoManageConversationTestCase, self).setUp()
-        self.setup_api()
-        self.setup_user_api()
-        self.command = go_manage_conversation.Command()
-        self.command.stdout = StringIO()
-        self.command.stderr = StringIO()
+    def send_command(self, command):
+        self.outbox.append(command)
 
-    def test_conv_sanity_checks(self):
-        self.assertRaisesRegexp(
-            CommandError,
-            'User matching query does not exist', self.command.handle,
-            email_address='foo@bar')
-        self.assertRaisesRegexp(
-            CommandError,
-            'Please specify a conversation key', self.command.handle,
-            email_address=self.django_user.email)
-        self.assertRaisesRegexp(
-            CommandError, 'Conversation does not exist',
-            self.command.handle, email_address=self.django_user.email,
-            conversation_key='foo')
 
-    def do_command(self, **kwargs):
-        return self.command.handle(email_address=self.django_user.email,
-                                   **kwargs)
+class TestGoManageConversation(GoAccountCommandTestCase):
+    command_class = go_manage_conversation.Command
 
     def test_list(self):
         conv = self.create_conversation()
-        self.do_command(list_conversations=True)
-        self.assertEqual(
-            self.command.stdout.getvalue(),
-            "0. %s (type: %s, key: %s)\n" % (
-                conv.name, conv.conversation_type, conv.key))
+        expected_output = "0. %s (type: %s, key: %s)\n" % (
+            conv.name, conv.conversation_type, conv.key)
+        self.assert_command_output(expected_output, 'list')
+
+    def test_show_config_no_conv(self):
+        self.assert_command_error(
+            'Please specify a conversation key', 'show_config')
+        self.assert_command_error(
+            'Conversation does not exist',
+            'show_config', conversation_key='foo')
 
     def test_show_config(self):
         conv = self.create_conversation(config={
             'http_api': {'api_tokens': ['token']},
         })
-        self.do_command(show_config=True, conversation_key=conv.key)
-        self.assertEqual(
-            self.command.stdout.getvalue(),
-            "{u'http_api': {u'api_tokens': [u'token']}}\n")
+        expected_output = "{u'http_api': {u'api_tokens': [u'token']}}\n"
+        self.assert_command_output(
+            expected_output, 'show_config', conversation_key=conv.key)
+
+    @patch('go.vumitools.api.SyncMessageSender')
+    def test_start_conversation(self, SyncMessageSender):
+        conv = self.create_conversation()
+        sender = DummyMessageSender()
+        SyncMessageSender.return_value = sender
+        self.assertEqual(conv.archive_status, 'active')
+        self.assertEqual(conv.get_status(), 'stopped')
+
+        self.assert_command_output(
+            'Starting conversation...\nConversation started\n',
+            'start', conversation_key=conv.key)
+
+        conv = self.user_api.get_wrapped_conversation(conv.key)
+        self.assertEqual(conv.get_status(), 'starting')
+        [start_command] = sender.outbox
+        self.assertEqual(start_command['command'], 'start')
+
+    @patch('go.vumitools.api.SyncMessageSender')
+    def test_stop_conversation(self, SyncMessageSender):
+        conv = self.create_conversation(started=True)
+        sender = DummyMessageSender()
+        SyncMessageSender.return_value = sender
+        self.assertEqual(conv.archive_status, 'active')
+        self.assertEqual(conv.get_status(), 'running')
+
+        self.assert_command_output(
+            'Stopping conversation...\nConversation stopped\n',
+            'stop', conversation_key=conv.key)
+
+        conv = self.user_api.get_wrapped_conversation(conv.key)
+        self.assertEqual(conv.get_status(), 'stopping')
+        [stop_command] = sender.outbox
+        self.assertEqual(stop_command['command'], 'stop')
+
+    def test_archive_conversation(self):
+        conv = self.create_conversation()
+        self.assertEqual(conv.archive_status, 'active')
+        self.assertEqual(conv.get_status(), 'stopped')
+
+        self.assert_command_output(
+            'Archiving conversation...\nConversation archived\n',
+            'archive', conversation_key=conv.key)
+
+        conv = self.user_api.get_wrapped_conversation(conv.key)
+        self.assertEqual(conv.archive_status, 'archived')

--- a/go/base/tests/test_go_manage_router.py
+++ b/go/base/tests/test_go_manage_router.py
@@ -1,3 +1,5 @@
+from pprint import pformat
+
 from mock import patch
 
 from go.base.tests.utils import GoAccountCommandTestCase
@@ -20,6 +22,12 @@ class TestGoManageRouter(GoAccountCommandTestCase):
         expected_output = "0. %s (type: %s, key: %s)\n" % (
             router.name, router.router_type, router.key)
         self.assert_command_output(expected_output, 'list')
+
+    def test_show(self):
+        router = self.create_router()
+        expected_output = "%s\n" % pformat(router.get_data())
+        self.assert_command_output(
+            expected_output, 'show', router_key=router.key)
 
     def test_show_config_no_router(self):
         self.assert_command_error(

--- a/go/base/tests/test_go_manage_router.py
+++ b/go/base/tests/test_go_manage_router.py
@@ -1,0 +1,83 @@
+from mock import patch
+
+from go.base.tests.utils import GoAccountCommandTestCase
+from go.base.management.commands import go_manage_router
+
+
+class DummyMessageSender(object):
+    def __init__(self):
+        self.outbox = []
+
+    def send_command(self, command):
+        self.outbox.append(command)
+
+
+class TestGoManageRouter(GoAccountCommandTestCase):
+    command_class = go_manage_router.Command
+
+    def test_list(self):
+        router = self.create_router()
+        expected_output = "0. %s (type: %s, key: %s)\n" % (
+            router.name, router.router_type, router.key)
+        self.assert_command_output(expected_output, 'list')
+
+    def test_show_config_no_router(self):
+        self.assert_command_error(
+            'Please specify a router key', 'show_config')
+        self.assert_command_error(
+            'Router does not exist',
+            'show_config', router_key='foo')
+
+    def test_show_config(self):
+        router = self.create_router(config={
+            'http_api': {'api_tokens': ['token']},
+        })
+        expected_output = "{u'http_api': {u'api_tokens': [u'token']}}\n"
+        self.assert_command_output(
+            expected_output, 'show_config', router_key=router.key)
+
+    @patch('go.vumitools.api.SyncMessageSender')
+    def test_start_router(self, SyncMessageSender):
+        router = self.create_router()
+        sender = DummyMessageSender()
+        SyncMessageSender.return_value = sender
+        self.assertEqual(router.archive_status, 'active')
+        self.assertEqual(router.status, 'stopped')
+
+        self.assert_command_output(
+            'Starting router...\nRouter started\n',
+            'start', router_key=router.key)
+
+        router = self.user_api.get_router(router.key)
+        self.assertEqual(router.status, 'starting')
+        [start_command] = sender.outbox
+        self.assertEqual(start_command['command'], 'start')
+
+    @patch('go.vumitools.api.SyncMessageSender')
+    def test_stop_router(self, SyncMessageSender):
+        router = self.create_router(started=True)
+        sender = DummyMessageSender()
+        SyncMessageSender.return_value = sender
+        self.assertEqual(router.archive_status, 'active')
+        self.assertEqual(router.status, 'running')
+
+        self.assert_command_output(
+            'Stopping router...\nRouter stopped\n',
+            'stop', router_key=router.key)
+
+        router = self.user_api.get_router(router.key)
+        self.assertEqual(router.status, 'stopping')
+        [stop_command] = sender.outbox
+        self.assertEqual(stop_command['command'], 'stop')
+
+    def test_archive_router(self):
+        router = self.create_router()
+        self.assertEqual(router.archive_status, 'active')
+        self.assertEqual(router.status, 'stopped')
+
+        self.assert_command_output(
+            'Archiving router...\nRouter archived\n',
+            'archive', router_key=router.key)
+
+        router = self.user_api.get_router(router.key)
+        self.assertEqual(router.archive_status, 'archived')

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -150,23 +150,21 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
             'description': u'hello world',
             'config': {},
         }
+        if started:
+            params['status'] = u'running'
         params.update(kwargs)
-        conv = self.user_api.wrap_conversation(
+        return self.user_api.wrap_conversation(
             self.user_api.new_conversation(**params))
 
-        if started:
-            conv.set_status_started()
-            conv.save()
-
-        return conv
-
-    def create_router(self, **kwargs):
+    def create_router(self, started=False, **kwargs):
         params = {
             'router_type': u'test_router_type',
             'name': u'router name',
             'description': u'hello world',
             'config': {},
         }
+        if started:
+            params['status'] = u'running'
         params.update(kwargs)
         return self.user_api.new_router(**params)
 

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -293,6 +293,18 @@ class GoAccountCommandTestCase(VumiGoDjangoTestCase):
         self.command.stderr = StringIO()
 
     def call_command(self, *command, **options):
+        # Make sure we have options for the command(s) specified
+        for cmd_name in command:
+            self.assertTrue(
+                cmd_name in self.command.list_commands(),
+                "Command '%s' has no command line option" % (cmd_name,))
+        # Make sure we have options for any option keys specified
+        opt_dests = set(opt.dest for opt in self.command.option_list)
+        for opt_dest in options:
+            self.assertTrue(
+                opt_dest in opt_dests,
+                "Option key '%s' has no command line option" % (opt_dest,))
+        # Call the command handler
         return self.command.handle(
             email_address=self.django_user.email, command=command, **options)
 


### PR DESCRIPTION
We currently have two management commands for conversations (`go_manage_conversation` and `go_start_conversation`) and none for routers. We need to consolidate the former and build the latter.
