### PR TITLE
Fix error in retrieving dialogue poll definition.

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -7,7 +7,7 @@ function poll_tester(poll) {
     return new vumigo.test_utils.ImTester(app.api, {
         async: true,
         custom_setup: function (api) {
-            api.config_store.poll = JSON.stringify(poll);
+            api.config_store.poll = poll;
         }
     });
 }

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -24,7 +24,7 @@ function DialogueStateCreator() {
 
     self.on_config_read = function(event) {
         var p = new Promise();
-        event.im.fetch_config_value("poll", true,
+        event.im.fetch_config_value("poll", false,
             function (poll) {
                 self.poll = poll;
 


### PR DESCRIPTION
Error log:

```
013-08-15 10:01:29+0000 [-] Starting sandbox ...
2013-08-15 10:01:29+0000 [-] Loading sandboxed code ...
2013-08-15 10:01:29+0000 [-] 
2013-08-15 10:01:29+0000 [-] undefined:31
2013-08-15 10:01:29+0000 [-]                 self.start_state = poll.start_state
2013-08-15 10:01:29+0000 [-]                                        ^
2013-08-15 10:01:29+0000 [-] TypeError: Cannot read property 'start_state' of null
```
