### PR TITLE
Groups view is showing both regular and smart groups

### DIFF
--- a/go/contacts/templates/contacts/contact_list.html
+++ b/go/contacts/templates/contacts/contact_list.html
@@ -17,7 +17,7 @@
             <input type="text" name="name" value="{{ query }}">
             <input type="text" name="query" value="name:{{ query }}">
         </div>
-        &nbsp; <button type="submit" name="_new_smart_group" id="search-filter-btn" class="btn btn-primary btn-small">Make Smart Group using these results.</button>    
+        &nbsp; <button id="search-filter-btn" class="btn btn-primary btn-small" data-toggle="modal" data-target="#createSmartGroup">Make Smart Group using these results.</button>    
     </form>
     {% endif %}
 </div>

--- a/go/contacts/templates/contacts/group_list_table.html
+++ b/go/contacts/templates/contacts/group_list_table.html
@@ -1,11 +1,13 @@
 {% load url from future %}
+{% load contact_tags %}
+
 <table class="table">
     <thead>
         <tr>
             <th><input type="checkbox"></th>
             <th>Name</th>
             <th>No. of contacts</th>
-            <th>Date created</th>
+            {# <th>Date created</th> #}
         </tr>
     </thead>
     <tbody>
@@ -19,13 +21,8 @@
                     {{ group.name }}
                 </a>
             </td>
-            <td>
-                {# TODO; length is bad #}
-                {{ group.backlinks.contacts|length }}
-            </td>
-            <td>
-                {# TODO: group date created #}
-            </td>
+            <td>{% size_of_group contact_store group %}</td>
+            {# <td> TODO: group date created</td> #}
         </tr>
     {% empty %}
         <tr>

--- a/go/contacts/templatetags/contact_tags.py
+++ b/go/contacts/templatetags/contact_tags.py
@@ -1,0 +1,9 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def size_of_group(contact_store, group):
+    return contact_store.count_contacts_for_group(group)

--- a/go/contacts/urls.py
+++ b/go/contacts/urls.py
@@ -3,7 +3,7 @@ from go.contacts import views
 
 urlpatterns = patterns('',
     url(r'^$', views.index, name='index'),
-    url(r'^groups/$', views.groups, name='groups'),
+    url(r'^groups/$', views.groups, name='groups', kwargs={'type': 'static'}),
     url(r'^groups/(?P<type>[\w ]+)/$', views.groups, name='groups_type'),
     # TODO: Is the group_name regex sane?
     url(r'^group/(?P<group_key>[\w ]+)/$', views.group, name='group'),

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -110,6 +110,7 @@ def groups(request, type=None):
         'page': page,
         'query': query,
         'contact_group_form': contact_group_form,
+        'contact_store': contact_store,
     })
 
 


### PR DESCRIPTION
On the contacts page: https://go.vumi.org/contacts/people/
- Click on the 'groups' tab in the left hand nav
- Both regular groups and smart groups are displayed
- Only regular groups should be displayed

![screen shot 2013-08-15 at 11 52 41 am](https://f.cloud.github.com/assets/1521387/968044/491f0260-0591-11e3-98d8-d6082be2824f.png)
