### PR TITLE
"Start campaign" button doesn't do anything

### DIFF
--- a/go/contacts/templates/contacts/group_detail.html
+++ b/go/contacts/templates/contacts/group_detail.html
@@ -14,7 +14,6 @@
         <button class="btn" data-toggle="modal" data-target="#delGroup">Delete</button>
         <button class="btn" data-toggle="modal" data-target="#editGroup">Rename</button>
         <button class="btn" data-toggle="modal" data-target="#expContactFrm">Export</button>
-        <button class="btn" data-toggle="modal" data-target="#startCampaign">Start campaign</button>
     </div>
 
 

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -195,26 +195,6 @@
   {% csrf_token %}
 	</form>
 </div><!--/delGroup-->
-
-<div class="modal hide fade" id="startCampaign">
-  <div class="modal-header">
-    <a class="close" data-dismiss="modal">×</a>
-    <h3>Start Campaign</h3>
-  </div>
-  {# TODO: What would the URL be? #}
-  <form class="form-horizontal" method="POST" action="{% url 'contacts:group' group_key=group.key %}">
-  <div class="modal-body">
-        <fieldset>
-          <p>Do you want to start a campaign with this group?</p>
-        </fieldset>
-  </div>
-  <div class="modal-footer">
-    <a href="#" class="btn" data-dismiss="modal">Cancel</a>
-    <button type="submit" name='_start_campaign' class="btn btn-primary" data-loading-text="starting campaign...">Start Campaign</button>
-  </div>
-  {% csrf_token %}
-  </form>
-</div><!--/startCampaign -->
 {% endif %}
 
 {% if smart_group_form %}


### PR DESCRIPTION
On a group page (e.g. https://go.vumi.org/contacts/group/c7de0a0dfdc6423cb16c50a12c0529d6/)
There is a "start campaign" button in the header (see screenshot)
- Click on the "start campaign" button 
- a popup confirmation screen is displayed
- Click the "start campaign" button in the popup
- Nothing happens

Please remove the "start campaign" button from the header till we can figure out the user flow for this action.

![screen shot 2013-08-15 at 12 12 54 pm](https://f.cloud.github.com/assets/1521387/968108/15ac0c5e-0594-11e3-8923-ab6eaa44efae.png)
