### PR TITLE
Message confirmation screen formatting display is broken

### DIFF
--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -9,6 +9,17 @@
   }
 }
 
+.confirm {
+  .details {
+    margin-left: 24px;
+
+    .conversation {
+      th:first-child {
+        width: 100px;
+      }
+    }
+  }
+}
 
 .dialogue {
   .actions {

--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -13,7 +13,7 @@
   .details {
     margin-left: 24px;
 
-    .conversation {
+    table {
       th:first-child {
         width: 100px;
       }

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -248,6 +248,12 @@ button {
   font-size: 11px;
   width: 90%;
 }
+.confirm .details {
+  margin-left: 24px;
+}
+.confirm .details .conversation th:first-child {
+  width: 100px;
+}
 .dialogue .actions .sidebar {
   background: #d9d8d3;
 }

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -251,7 +251,7 @@ button {
 .confirm .details {
   margin-left: 24px;
 }
-.confirm .details .conversation th:first-child {
+.confirm .details table th:first-child {
   width: 100px;
 }
 .dialogue .actions .sidebar {

--- a/go/conversation/templates/conversation/confirm.html
+++ b/go/conversation/templates/conversation/confirm.html
@@ -2,19 +2,18 @@
 
 {% block content_extraclass %}confirm{% endblock %}
 
-{% block content_title %}{{ action_display_name }} confirmation{% endblock %}
+{% block content_title %}{{ action_name }} confirmation{% endblock %}
 
 {% block content_main %}
     {% include "base/includes/messages.html" %}
 
     <div class='row-fluid details'>
-        <div class='span7'>
+        {% if not success %}
+          <p>Please review the details below and click confirm if everything is in order.</p>
+        {% endif %}
+
+        <div class='span6'>
             <h4>Conversation details</h4>
-            <p>
-            {% if not success %}
-                Please review the details below and click confirm if everything is in order.
-            {% endif %}
-            </p>
             <table class="conversation table table-bordered">
                 <thead>
                     <tr>
@@ -48,10 +47,24 @@
                 </tbody>
             </table>
 
+            {% if action_details %}
+            <h4>Action details</h4>
+            <table class="action table table-bordered">
+                <tbody>
+                    {% for name, value in action_details.items %}
+                    <tr>
+                        <th>{{ name }}</th>
+                        <td>{{ value }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% endif %}
+
             {% if not success %}
             <form method="post">
                 {{form}}
-                <div class="form-actions">
+                <div>
                     <input type="submit" class="btn btn-primary" data-loading-text="saving..." value="Confirm">
                 </div>
                 {% csrf_token %}

--- a/go/conversation/templates/conversation/confirm.html
+++ b/go/conversation/templates/conversation/confirm.html
@@ -1,50 +1,63 @@
-{% extends "base.html" %}
-{% load url from future %}
+{% extends "app.html" %}
 
-{% block content %}
-<div>
-    <img src="{{STATIC_URL}}pics/header/logo.png"/>
-    {% if success %}
-    <h2>Conversation confirmed</h2>
-    {% else %}
-    <h2>Please Confirm</h2>
-    {% endif %}
+{% block content_extraclass %}confirm{% endblock %}
+
+{% block content_title %}{{ action_display_name }} confirmation{% endblock %}
+
+{% block content_main %}
     {% include "base/includes/messages.html" %}
-    <p>
-    {% if not success %}
-        You are about to start a conversation. Please review the details below
-        and click confirm if everything is in order.
-    {% endif %}
-    </p>
-    <table class="table table-bordered">
-        <thead>
-            <tr>
-                <th colspan="2">{{conversation.name}}</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <th>Message:</th>
-                <td>{{conversation.description}}</td>
-            </tr>
-            <tr>
-                <th>Groups:</th>
-                <td>
-                    {% for group in conversation.get_groups %}
-                        <span class="label label-inverse">{{group.name}}</span>
-                    {% endfor %}
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-{% if not success %}
-<form method="post">
-    {{form}}
-    <div class="form-actions">
-        <input type="submit" class="btn btn-primary" data-loading-text="saving..." value="Confirm">
+
+    <div class='row-fluid details'>
+        <div class='span7'>
+            <h4>Conversation details</h4>
+            <p>
+            {% if not success %}
+                Please review the details below and click confirm if everything is in order.
+            {% endif %}
+            </p>
+            <table class="conversation table table-bordered">
+                <thead>
+                    <tr>
+                        <th colspan="2">{{ conversation.name }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th>Description</th>
+                        <td>{{ conversation.description }}</td>
+                    </tr>
+                    <tr>
+                        <th>Type</th>
+                        <td>{{ conversation.conversation_type }}</td>
+                    </tr>
+                    <tr>
+                        <th>Channels</th>
+                        <td>
+                            {% for channel in conversation.get_channels %}
+                                <span class="label label-inverse">{{ channel.name }}</span>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    <th>Groups</th>
+                        <td>
+                            {% for group in conversation.get_groups %}
+                                <span class="label label-inverse">{{ group.name }}</span>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            {% if not success %}
+            <form method="post">
+                {{form}}
+                <div class="form-actions">
+                    <input type="submit" class="btn btn-primary" data-loading-text="saving..." value="Confirm">
+                </div>
+                {% csrf_token %}
+            </form>
+            {% endif %}
+        </div>
     </div>
-    {% csrf_token %}
-</form>
-{% endif %}
+
 {% endblock %}

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -84,15 +84,19 @@ class ConfirmConversationView(ConversationTemplateView):
         token_manager = DjangoTokenManager(request.user_api.api.token_manager)
         token = request.GET.get('token')
         token_data = token_manager.verify_get(token)
-        params = token_data['extra_params']
 
         if not token_data:
             raise Http404
 
+        params = token_data['extra_params']
+        action_name = params.get('action_display_name')
+        action_details = params.get('action_data').get('display', {})
+
         return self.render_to_response({
             'success': False,
             'conversation': conversation,
-            'action_display_name': params.get('action_display_name'),
+            'action_name': action_name,
+            'action_details': action_details,
             'form': ConfirmConversationForm(initial={'token': token}),
         })
 
@@ -389,13 +393,16 @@ class ConversationActionView(ConversationTemplateView):
 
     @check_action_is_enabled
     def post(self, request, conversation):
-        action_data = {}
+        action_data = {'display': {}}
         form_cls = self.view_def.get_action_form(self.action.action_name)
         if form_cls is not None:
             form = form_cls(request.POST)
             if not form.is_valid():
                 return self._render_form(request, conversation, form)
             action_data = form.cleaned_data
+            action_data['display'] = dict(
+                (form[k].label, v)
+                for k, v in action_data.iteritems())
 
         if self.action.needs_confirmation:
             user_account = request.user_api.get_user_account()


### PR DESCRIPTION
If a user has enabled SMS confirmation for their account, they have to confirm that a message can be delivered, before it is actually delivered. The user confirms the message in a web view, the URL of which is included in the SMS confirmation message that they receive.

The confirmation page web view was not updated with the new UI - the formatting is very broken (see screenshot) For example the text is black on a black background. Please can you apply the latest styling to this page so it's legible and looks decent.

![screen shot 2013-08-16 at 11 39 07 am](https://f.cloud.github.com/assets/1521387/974513/8f065366-0657-11e3-8ca7-893acf7224be.png)
