### PR TITLE
Router start and stop command processing shouldn't inherit directly from conversations handlers

### DIFF
--- a/go/routers/keyword/tests/test_vumi_app.py
+++ b/go/routers/keyword/tests/test_vumi_app.py
@@ -52,18 +52,24 @@ class TestKeywordRouter(RouterWorkerTestCase):
             rmeta.push_hop(outbound_dst, outbound_src)
 
     @inlineCallbacks
-    def test_start_and_stop(self):
-        router = yield self.setup_router({})
-        router_api = self.user_api.get_router_api(
-            router.router_type, router.key)
+    def test_start(self):
+        router = yield self.setup_router({}, started=False)
         self.assertTrue(router.stopped())
         self.assertFalse(router.running())
 
-        yield router_api.start_router()
+        yield self.start_router(router)
+        router = yield self.user_api.get_router(router.key)
         self.assertFalse(router.stopped())
         self.assertTrue(router.running())
 
-        yield router_api.stop_router()
+    @inlineCallbacks
+    def test_stop(self):
+        router = yield self.setup_router({}, started=True)
+        self.assertFalse(router.stopped())
+        self.assertTrue(router.running())
+
+        yield self.stop_router(router)
+        router = yield self.user_api.get_router(router.key)
         self.assertTrue(router.stopped())
         self.assertFalse(router.running())
 

--- a/go/routers/keyword/tests/test_vumi_app.py
+++ b/go/routers/keyword/tests/test_vumi_app.py
@@ -51,6 +51,7 @@ class TestKeywordRouter(RouterWorkerTestCase):
         for outbound_src, outbound_dst in rev_hops:
             rmeta.push_hop(outbound_dst, outbound_src)
 
+    @inlineCallbacks
     def test_start_and_stop(self):
         router = yield self.setup_router({})
         router_api = self.user_api.get_router_api(

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -13,6 +13,8 @@ from go.vumitools.api import VumiApiCommand, VumiApi, VumiApiEvent
 from go.vumitools.utils import MessageMetadataHelper
 from go.vumitools.conversation.models import (
     CONVERSATION_STARTING, CONVERSATION_STOPPING)
+from go.vumitools.router.models import (
+    ROUTER_STARTING, ROUTER_STOPPING)
 
 
 class OneShotMetricManager(MetricManager):
@@ -144,49 +146,6 @@ class GoWorkerMixin(object):
             return self.process_unknown_cmd(cmd_method_name, *args, **kwargs)
 
     @inlineCallbacks
-    def process_command_start(self, user_account_key, conversation_key):
-        log.info("Starting conversation '%s' for user '%s'." % (
-            conversation_key, user_account_key))
-        conv = yield self.get_conversation(user_account_key, conversation_key)
-        if conv is None:
-            log.warning(
-                "Trying to start missing conversation '%s' for user '%s'." % (
-                    conversation_key, user_account_key))
-            return
-        status = conv.get_status()
-        if status != CONVERSATION_STARTING:
-            log.warning(
-                "Trying to start conversation '%s' for user '%s' with invalid "
-                "status: %s" % (conversation_key, user_account_key, status))
-            return
-        conv.set_status_started()
-        yield conv.save()
-
-    @inlineCallbacks
-    def process_command_stop(self, user_account_key, conversation_key):
-        conv = yield self.get_conversation(user_account_key, conversation_key)
-        if conv is None:
-            log.warning(
-                "Trying to stop missing conversation '%s' for user '%s'." % (
-                    conversation_key, user_account_key))
-            return
-        status = conv.get_status()
-        if status != CONVERSATION_STOPPING:
-            log.warning(
-                "Trying to stop conversation '%s' for user '%s' with invalid "
-                "status: %s" % (conversation_key, user_account_key, status))
-            return
-        conv.set_status_stopped()
-        yield conv.save()
-
-    def process_command_initial_action_hack(self, *args, **kwargs):
-        # HACK: This lets us do whatever we used to do when we got a `start'
-        # message without having horrible app-specific view logic.
-        # TODO: Remove this when we've decoupled the various conversation
-        # actions from the lifecycle.
-        pass
-
-    @inlineCallbacks
     def process_command_collect_metrics(self, conversation_key,
                                         user_account_key):
         key_tuple = (conversation_key, user_account_key)
@@ -266,6 +225,10 @@ class GoWorkerMixin(object):
     def get_conversation(self, user_account_key, conversation_key):
         user_api = self.get_user_api(user_account_key)
         return user_api.get_wrapped_conversation(conversation_key)
+
+    def get_router(self, user_account_key, router_key):
+        user_api = self.get_user_api(user_account_key)
+        return user_api.get_router(router_key)
 
     def get_metadata_helper(self, msg):
         return MessageMetadataHelper(self.vumi_api, msg)
@@ -385,6 +348,49 @@ class GoApplicationMixin(GoWorkerMixin):
 
         returnValue(self.get_config_for_conversation(conversation))
 
+    @inlineCallbacks
+    def process_command_start(self, user_account_key, conversation_key):
+        log.info("Starting conversation '%s' for user '%s'." % (
+            conversation_key, user_account_key))
+        conv = yield self.get_conversation(user_account_key, conversation_key)
+        if conv is None:
+            log.warning(
+                "Trying to start missing conversation '%s' for user '%s'." % (
+                    conversation_key, user_account_key))
+            return
+        status = conv.get_status()
+        if status != CONVERSATION_STARTING:
+            log.warning(
+                "Trying to start conversation '%s' for user '%s' with invalid "
+                "status: %s" % (conversation_key, user_account_key, status))
+            return
+        conv.set_status_started()
+        yield conv.save()
+
+    @inlineCallbacks
+    def process_command_stop(self, user_account_key, conversation_key):
+        conv = yield self.get_conversation(user_account_key, conversation_key)
+        if conv is None:
+            log.warning(
+                "Trying to stop missing conversation '%s' for user '%s'." % (
+                    conversation_key, user_account_key))
+            return
+        status = conv.get_status()
+        if status != CONVERSATION_STOPPING:
+            log.warning(
+                "Trying to stop conversation '%s' for user '%s' with invalid "
+                "status: %s" % (conversation_key, user_account_key, status))
+            return
+        conv.set_status_stopped()
+        yield conv.save()
+
+    def process_command_initial_action_hack(self, *args, **kwargs):
+        # HACK: This lets us do whatever we used to do when we got a `start'
+        # message without having horrible app-specific view logic.
+        # TODO: Remove this when we've decoupled the various conversation
+        # actions from the lifecycle.
+        pass
+
 
 class GoRouterMixin(GoWorkerMixin):
     def get_config_for_router(self, router):
@@ -404,6 +410,40 @@ class GoRouterMixin(GoWorkerMixin):
         router = yield msg_mdh.get_router()
 
         returnValue(self.get_config_for_router(router))
+
+    @inlineCallbacks
+    def process_command_start(self, user_account_key, router_key):
+        log.info("Starting router '%s' for user '%s'." % (
+            router_key, user_account_key))
+        router = yield self.get_router(user_account_key, router_key)
+        if router is None:
+            log.warning(
+                "Trying to start missing router '%s' for user '%s'." % (
+                    router_key, user_account_key))
+            return
+        if not router.starting():
+            log.warning(
+                "Trying to start router '%s' for user '%s' with invalid "
+                "status: %s" % (router_key, user_account_key, router.status))
+            return
+        router.set_status_started()
+        yield router.save()
+
+    @inlineCallbacks
+    def process_command_stop(self, user_account_key, router_key):
+        router = yield self.get_router(user_account_key, router_key)
+        if router is None:
+            log.warning(
+                "Trying to stop missing router '%s' for user '%s'." % (
+                    router_key, user_account_key))
+            return
+        if not router.stopping():
+            log.warning(
+                "Trying to stop router '%s' for user '%s' with invalid "
+                "status: %s" % (router_key, user_account_key, router.status))
+            return
+        router.set_status_stopped()
+        yield router.save()
 
 
 class GoApplicationConfig(ApplicationWorker.CONFIG_CLASS, GoWorkerConfigMixin):

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -311,6 +311,26 @@ class GoRouterWorkerTestMixin(GoWorkerTestMixin):
         return self.user_api.new_router(
             router_type, name, description, config, **kw)
 
+    @inlineCallbacks
+    def start_router(self, router):
+        router_api = self.user_api.get_router_api(
+            router.router_type, router.key)
+        yield router_api.start_router(router)
+        for cmd in self.get_dispatcher_commands():
+            yield self.dispatch_command(
+                cmd.payload['command'], *cmd.payload['args'],
+                **cmd.payload['kwargs'])
+
+    @inlineCallbacks
+    def stop_router(self, router):
+        router_api = self.user_api.get_router_api(
+            router.router_type, router.key)
+        yield router_api.stop_router(router)
+        for cmd in self.get_dispatcher_commands():
+            yield self.dispatch_command(
+                cmd.payload['command'], *cmd.payload['args'],
+                **cmd.payload['kwargs'])
+
     def add_router_md_to_msg(self, msg, router, endpoint=None):
         msg.payload.setdefault('helper_metadata', {})
         md = MessageMetadataHelper(self.vumi_api, msg)


### PR DESCRIPTION
Error log:

```
2013-08-18 13:20:33+0000 [WorkerAMQClient,client] Unhandled Error
        Traceback (most recent call last):
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1101, in gotResult
            _inlineCallbacks(r, g, deferred)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1045, in _inlineCallbacks
            result = g.send(result)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/service.py", line 283, in read_messages
            yield self.consume(message)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1187, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1045, in _inlineCallbacks
            result = g.send(result)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/service.py", line 302, in consume
            message.content.body))
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/service.py", line 335, in consume_message
            return self.callback(message)
          File "/mnt/praekelt/vumi-go/go/vumitools/app_worker.py", line 142, in consume_control_command
            return cmd_method(*args, **kwargs)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1178, in unwindGenerator
            gen = f(*args, **kwargs)
        exceptions.TypeError: process_command_start() got an unexpected keyword argument 'router_key'
```
