### PR TITLE
Allow for GroupsResource to list all known groups.

### DIFF
--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -705,3 +705,34 @@ class GroupsResource(SandboxResource):
         returnValue(self.reply(
             command, success=True, count=member_count, group=group.get_data()))
 
+    @inlineCallbacks
+    def handle_list(self, api, command):
+        """
+        List all known groups
+
+        Command fields: None
+
+        Success reply fields:
+            - ``success``: set to ``true``
+            - ``groups``: A list of dictionaries with group data
+
+        Failure reply fields:
+            - ``success``: set to ``false``
+            - ``reason``: Reason for the failure
+
+        Example:
+        .. code-block:: javascript
+            api.request(
+                'groups.list', {},
+                function(reply) { api.log_info(reply.groups); });
+        """
+        try:
+            contact_store = self._contact_store_for_api(api)
+            groups = yield contact_store.list_groups()
+        except (SandboxError,) as e:
+            log.warning(str(e))
+            returnValue(self.reply(command, success=False, reason=unicode(e)))
+
+        returnValue(self.reply(
+            command, success=True,
+            groups=[group.get_data() for group in groups]))

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -647,3 +647,14 @@ class TestGroupsResource(ResourceTestCaseBase, GoPersistenceMixin):
             'count_members', key=group.key)
         self.assertTrue(reply['success'])
         self.assertEqual(reply['count'], 1)
+
+    @inlineCallbacks
+    def test_handle_list(self):
+        gr1 = yield self.new_group(u'group 1')
+        gr2 = yield self.new_group(u'group 2')
+        reply = yield self.dispatch_command('list')
+        self.assertTrue(reply['success'])
+        self.assertEqual(set(['group 1', 'group 2']),
+            set([gr['name'] for gr in reply['groups']]))
+        self.assertEqual(set([gr1.key, gr2.key]),
+            set([gr['key'] for gr in reply['groups']]))


### PR DESCRIPTION
GroupsResource currently can only list all groups by searching for something that happens to match everything.
