### PR TITLE
Clicking 'save' button on 'edits_group' page does not direct back to the 'show' page

### DIFF
--- a/go/base/static/js/src/contacts/models.js
+++ b/go/base/static/js/src/contacts/models.js
@@ -6,7 +6,7 @@
 
   var GroupModel = Model.extend({
     relations: [{
-      type: Backbone.HasMany,
+      type: Backbone.HasOne,
       key: 'urls',
       relatedModel: Model
     }],

--- a/go/base/static/js/src/contacts/models.js
+++ b/go/base/static/js/src/contacts/models.js
@@ -14,7 +14,8 @@
   });
 
   var GroupCollection = Backbone.Collection.extend({
-    model: GroupModel
+    model: GroupModel,
+    comparator: 'name'
   });
 
   _.extend(exports, {

--- a/go/base/static/js/src/conversation/groups.js
+++ b/go/base/static/js/src/conversation/groups.js
@@ -62,6 +62,7 @@
       });
       this.listenTo(this.save, 'success', function() {
         bootbox.alert("Groups saved successfully.");
+        go.utils.redirect(this.model.get('urls').get('show'));
       });
     },
 

--- a/go/base/static/js/src/conversation/models.js
+++ b/go/base/static/js/src/conversation/models.js
@@ -12,6 +12,10 @@
     },
 
     relations: [{
+      type: Backbone.HasOne,
+      key: 'urls',
+      relatedModel: Model
+    }, {
       type: Backbone.HasMany,
       key: 'groups',
       relatedModel: 'go.contacts.models.GroupModel',

--- a/go/base/static/js/test/tests/conversation/groups.test.js
+++ b/go/base/static/js/test/tests/conversation/groups.test.js
@@ -11,7 +11,10 @@ describe("go.conversation.groups", function() {
 
     beforeEach(function() {
       group = new GroupRowView({
-        model: new GroupModel({key: 'group1'})
+        model: new GroupModel({
+          key: 'group1',
+          urls: {show: 'contacts:group:group1'}
+        })
       });
     });
 
@@ -68,16 +71,20 @@ describe("go.conversation.groups", function() {
           groups: [{
             key: 'group1',
             name: 'Group1',
-            inConversation: false
+            inConversation: false,
+            urls: {show: 'contacts:group:group1'}
           }, {
             key: 'group2',
             name: 'Group2',
-            inConversation: true
+            inConversation: true,
+            urls: {show: 'contacts:group:group2'}
           }, {
             key: 'group3',
             name: 'Group3',
-            inConversation: true
-          }]
+            inConversation: true,
+            urls: {show: 'contacts:group:group3'}
+          }],
+          urls: {show: 'conversations:conversation1:show'}
         })
       });
     });
@@ -142,9 +149,19 @@ describe("go.conversation.groups", function() {
       });
 
       describe("if the save action was successful", function() {
+        var location;
+
+        beforeEach(function() {
+          location = null;
+          sinon.stub(go.utils, 'redirect', function(url) { location = url; });
+        });
+
+        afterEach(function() {
+          go.utils.redirect.restore();
+        });
+
         it("should notify the user", function() {
           server.respondWith('{}');
-
           assert(noElExists('.modal'));
 
           view.$('.save').click();
@@ -154,6 +171,17 @@ describe("go.conversation.groups", function() {
           assert.include(
             $('.modal').text(),
             "Groups saved successfully");
+        });
+
+        it("should redirect the user to the conversation show page",
+        function() {
+          server.respondWith('{}');
+          assert(noElExists('.modal'));
+
+          view.$('.save').click();
+          server.respond();
+
+          assert.equal(location, 'conversations:conversation1:show');
         });
       });
 

--- a/go/base/static/js/test/tests/conversation/groups.test.js
+++ b/go/base/static/js/test/tests/conversation/groups.test.js
@@ -67,15 +67,15 @@ describe("go.conversation.groups", function() {
           key: 'conversation1',
           groups: [{
             key: 'group1',
-            name: 'Spam',
+            name: 'Group1',
             inConversation: false
           }, {
             key: 'group2',
-            name: 'Group 2',
+            name: 'Group2',
             inConversation: true
           }, {
             key: 'group3',
-            name: 'Group 3',
+            name: 'Group3',
             inConversation: true
           }]
         })
@@ -103,7 +103,7 @@ describe("go.conversation.groups", function() {
 
         view
           .$('.search')
-          .val('Spam')
+          .val('Group1')
           .trigger($.Event('input'));
 
         assert(oneElExists(view.$('[data-uuid=group1]')));

--- a/go/base/static/js/test/tests/conversation/models.test.js
+++ b/go/base/static/js/test/tests/conversation/models.test.js
@@ -26,7 +26,8 @@ describe("go.conversation.models", function() {
           name: 'Group 3',
           inConversation: true,
           urls: {show: 'contacts:group:group3'}
-        }]
+        }],
+        urls: {show: 'conversations:conversation1:show'}
       });
     });
 

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -87,13 +87,22 @@ class ConversationTestCase(VumiGoDjangoTestCase):
         conv.save()
 
         groups_url = reverse('conversations:conversation', kwargs={
-            'conversation_key': conv.key, 'path_suffix': 'edit_groups/'})
+            'conversation_key': conv.key,
+            'path_suffix': 'edit_groups/'
+        })
 
         response = self.client.get(groups_url)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.context['model_data']), {
             'key': conv.key,
+            'urls': {
+                'show': reverse(
+                    'conversations:conversation', kwargs={
+                        'conversation_key': conv.key,
+                        'path_suffix': ''
+                    })
+            },
             'groups': [{
                 'key': group2.key,
                 'name': u'Contact Group 2',
@@ -101,7 +110,7 @@ class ConversationTestCase(VumiGoDjangoTestCase):
                 'urls': {
                     'show': reverse(
                         'contacts:group',
-                        kwargs={'group_key': group2.key})
+                        kwargs={'group_key': group2.key}),
                 },
             }, {
                 'key': group1.key,
@@ -110,7 +119,7 @@ class ConversationTestCase(VumiGoDjangoTestCase):
                 'urls': {
                     'show': reverse(
                         'contacts:group',
-                        kwargs={'group_key': group1.key})
+                        kwargs={'group_key': group1.key}),
                 },
             }]
         })

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -573,10 +573,15 @@ class EditConversationGroupsView(ConversationTemplateView):
                 'urls': {
                     'show': reverse(
                         'contacts:group',
-                        kwargs={'group_key': group.key})
+                        kwargs={'group_key': group.key}),
                 },
                 'inConversation': group.key in selected_groups,
-            } for group in groups]
+            } for group in groups],
+            'urls': {
+                'show': self.get_view_url(
+                    'show',
+                    conversation_key=conversation.key)
+            },
         }
 
         return self.render_to_response({


### PR DESCRIPTION
These are the steps I took:
- on the conversation 'show' page: 
- clicked on the 'edit' button next to the Contact Groups header
- on the 'edit_groups' page I selected multiple groups and clicked 'save'
- I clicked the 'OK' button on the 'groups saved successfully' pop up
- I am then returned to the 'edit_groups' page

I should be directed back to the conversation show page after saving my groups.

Also, the groups on the 'edit_groups' page should be sorted by group name

![screen shot 2013-08-26 at 9 38 19 am](https://f.cloud.github.com/assets/1521387/1024379/27c99040-0e23-11e3-9ddc-2e01571271fd.png)
