### PR TITLE
New contacts uploaded via CSV not added to contact group

### DIFF
--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -192,12 +192,17 @@ class ContactsTestCase(BaseContactsTestCase):
         return self.client.post(group_url, defaults)
 
     def test_contact_upload_into_new_group(self):
+        # Add an existing group to ensure we don't by mistake choose it instead
+        # of the new group when redirecting to complete the upload
+        existing_group = self.contact_store.new_group(TEST_GROUP_NAME)
+
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
                         'fixtures', 'sample-contacts.csv'))
 
         response = self.client.post(reverse('contacts:people'), {
             'file': csv_file,
             'name': 'a new group',
+            'contact_group': existing_group.key
         })
 
         group = newest(self.contact_store.list_groups())

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -355,7 +355,7 @@ def _people(request):
                             new_group_form.cleaned_data['name'])
 
                 # We could be using an existing contact group.
-                if request.POST.get('contact_group'):
+                elif request.POST.get('contact_group'):
                     select_group_form = SelectContactGroupForm(
                         request.POST, groups=contact_store.list_groups())
                     if select_group_form.is_valid():


### PR DESCRIPTION
I took the following steps:
- on the contacts page: https://go.vumi.org/contacts/people/
- clicked the "Import contacts" button
- selected "import a spreadsheet" from the pop up
- selected a CSV from my local files
- defined a new group name (n.b. I did not decide to add the contacts to an existing group)
- clicked "upload contacts" button
- matched the sample to the fields provided in the ensuing pop up and clicked 'ok'
- am then directed to the groups page where the contacts that were in my CSV are displayed
- I then click on 'groups' in the left nav
- I click on the name of the group "Sample Group"
- I am directed to the "Sample Group" page that displays no contacts

Also: I had three contacts in my CSV, one of those contacts is displayed twice. i.e. a total of 4 contacts are displayed.

![screen shot 2013-08-26 at 1 07 42 pm](https://f.cloud.github.com/assets/1521387/1025316/92735170-0e40-11e3-9a33-1db2ad53fa5a.png)

![screen shot 2013-08-26 at 1 09 04 pm](https://f.cloud.github.com/assets/1521387/1025314/7a7f7b8e-0e40-11e3-80a2-cc80c196cc88.png)

![screen shot 2013-08-26 at 1 11 29 pm](https://f.cloud.github.com/assets/1521387/1025309/5d83ad3e-0e40-11e3-9770-f8de56bf4cda.png)

![screen shot 2013-08-26 at 1 11 35 pm](https://f.cloud.github.com/assets/1521387/1025300/4076aad4-0e40-11e3-86b7-0aef76fcedb5.png)
