### PR TITLE
Can't delete a contact from a group

### DIFF
--- a/go/contacts/templates/contacts/group_detail.html
+++ b/go/contacts/templates/contacts/group_detail.html
@@ -7,7 +7,7 @@
 
 {% block content_actions_right %}
     <div class="table-form-view-buttons pull-left">
-        <button class="btn" data-action="delete" disabled="disabled">Delete</button>
+        <button class="btn" data-action="remove" disabled="disabled">Remove Contact(s)</button>
     </div>
     <div class="pull-left ">
         With group:

--- a/go/contacts/templates/contacts/group_detail.html
+++ b/go/contacts/templates/contacts/group_detail.html
@@ -22,6 +22,7 @@
 
 {% block content_main_list %}
 <form class="table-form-view" method="post" action="">
+    {% csrf_token %}
     {% include "contacts/contact_list_table.html" %}
 </form>
 {% endblock %}

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -155,6 +155,15 @@ def _static_group(request, contact_store, group):
                           'The export is scheduled and should '
                           'complete within a few minutes.')
             return redirect(_group_url(group.key))
+        if '_remove' in request.POST:
+            contacts = request.POST.getlist('contact')
+            for person_key in contacts:
+                contact = contact_store.get_contact_by_key(person_key)
+                contact.groups.remove(group)
+                contact.save()
+            messages.info(
+                request,
+                '%d Contacts removed from group' % len(contacts))
         elif '_delete_group_contacts' in request.POST:
             tasks.delete_group_contacts.delay(
                 request.user_api.user_account_key, group.key)


### PR DESCRIPTION
I took the following steps:
- I am on a group page: e.g. https://go.vumi.org/contacts/group/5844c59dd26045b2955ee284413e3f3e/
- I check the box next to a contact row
- I click the delete btn in the header
- I get an error screen (attached)

Note: I don't get this error when deleting a contact from the contacts screen (i.e. not from a group)

![screen shot 2013-08-26 at 1 21 40 pm](https://f.cloud.github.com/assets/1521387/1025361/afa3e178-0e41-11e3-8c7f-df18b2d7bbfb.png)

![screen shot 2013-08-26 at 1 19 36 pm](https://f.cloud.github.com/assets/1521387/1025362/b6760c9c-0e41-11e3-889b-68535b2a80b7.png)
