### PR TITLE
Sequential Send UI disallows specifying message content with line breaks

### DIFF
--- a/go/apps/sequential_send/view_definition.py
+++ b/go/apps/sequential_send/view_definition.py
@@ -13,7 +13,7 @@ class ScheduleForm(forms.Form):
 
 
 class MessageForm(forms.Form):
-    message = forms.CharField()
+    message = forms.CharField(widget=forms.Textarea)
 
 
 class BaseMessageFormSet(forms.formsets.BaseFormSet):


### PR DESCRIPTION
Currently a text input field is provided for saving text in.
Sometimes one needs to specify a message with more structure using new lines, to do that we need to use textareas for storing input.
