### PR TITLE
Remove a bunch of old conversation cruft (part 2)

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -19,7 +19,7 @@ class BulkSendAction(ConversationAction):
 
     def perform_action(self, action_data):
         return self.send_command(
-            'bulk_send', batch_id=self._conv.get_latest_batch_key(),
+            'bulk_send', batch_id=self._conv.batch.key,
             msg_options={}, content=action_data['message'],
             delivery_class=self._conv.delivery_class,
             dedupe=action_data['dedupe'])

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -294,7 +294,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'bulk_send',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.get_latest_batch_key(), msg_options={},
+            batch_id=conversation.batch.key, msg_options={},
             delivery_class=conversation.delivery_class,
             content='I am ham, not spam.', dedupe=True))
 
@@ -312,7 +312,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'bulk_send',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.get_latest_batch_key(), msg_options={},
+            batch_id=conversation.batch.key, msg_options={},
             delivery_class=conversation.delivery_class,
             content='I am ham, not spam.', dedupe=False))
 
@@ -349,7 +349,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 command_data=dict(
-                    batch_id=conversation.get_latest_batch_key(),
+                    batch_id=conversation.batch.key,
                     to_addr=u'+27761234567', msg_options={
                         'helper_metadata': {'go': {'sensitive': True}},
                     },
@@ -377,7 +377,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
             'bulk_send',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.get_latest_batch_key(), msg_options={},
+            batch_id=conversation.batch.key, msg_options={},
             delivery_class=conversation.delivery_class,
             content='I am ham, not spam.', dedupe=True))
 
@@ -431,7 +431,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
                          [self.conversation.user_account.key,
                           self.conversation.key])
         self.assertEqual(reply_to_cmd['kwargs']['command_data'], {
-            'batch_id': conversation.get_latest_batch_key(),
+            'batch_id': conversation.batch.key,
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],

--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -85,7 +85,7 @@ class TestBulkMessageApplication(AppWorkerTestCase):
     def test_consume_events(self):
         conversation = yield self.setup_conversation()
         yield self.start_conversation(conversation)
-        batch_id = yield conversation.get_latest_batch_key()
+        batch_id = conversation.batch.key
         yield self.dispatch_command(
             "bulk_send",
             user_account_key=conversation.user_account.key,
@@ -134,7 +134,7 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         }
         conversation = yield self.setup_conversation()
         yield self.start_conversation(conversation)
-        batch_id = yield conversation.get_latest_batch_key()
+        batch_id = conversation.batch.key
         yield self.dispatch_command(
             "send_message",
             user_account_key=conversation.user_account.key,
@@ -165,7 +165,7 @@ class TestBulkMessageApplication(AppWorkerTestCase):
     def test_process_command_send_message_in_reply_to(self):
         conversation = yield self.setup_conversation()
         yield self.start_conversation(conversation)
-        batch_id = yield conversation.get_latest_batch_key()
+        batch_id = conversation.batch.key
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
         yield self.store_inbound_msg(msg)
         command = VumiApiCommand.command(

--- a/go/apps/bulk_message/vumi_app.py
+++ b/go/apps/bulk_message/vumi_app.py
@@ -107,10 +107,8 @@ class BulkMessageApplication(GoApplicationWorker):
 
         msg_mdh = self.get_metadata_helper(message)
         conv = yield msg_mdh.get_conversation()
-        # XXX: This is a really horrible idea.
-        batch_key = yield conv.get_latest_batch_key()
-        if conv and batch_key:
-            window_id = self.get_window_id(conv.key, batch_key)
+        if conv:
+            window_id = self.get_window_id(conv.key, conv.batch.key)
             flight_key = yield self.window_manager.get_internal_id(window_id,
                                 message['message_id'])
             yield self.window_manager.remove_key(window_id, flight_key)

--- a/go/apps/dialogue/definition.py
+++ b/go/apps/dialogue/definition.py
@@ -21,7 +21,7 @@ class SendDialogueAction(ConversationAction):
 
     def perform_action(self, action_data):
         return self.send_command(
-            'send_dialogue', batch_id=self._conv.get_latest_batch_key(),
+            'send_dialogue', batch_id=self._conv.batch.key,
             delivery_class=self._conv.delivery_class)
 
 

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -304,7 +304,7 @@ class DialogueTestCase(DjangoGoApplicationTestCase):
                          'dialogue_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
         self.assertEqual(reply_to_cmd['kwargs']['command_data'], {
-            'batch_id': conversation.get_latest_batch_key(),
+            'batch_id': conversation.batch.key,
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],

--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -86,14 +86,12 @@ class DialogueApplicationTestCase(AppWorkerTestCase):
         yield conversation.save()
         returnValue(conversation)
 
-    @inlineCallbacks
     def send_send_dialogue_command(self, conversation):
-        batch_id = yield conversation.get_latest_batch_key()
-        yield self.dispatch_command(
+        return self.dispatch_command(
             "send_dialogue",
             user_account_key=self.user_account.key,
             conversation_key=conversation.key,
-            batch_id=batch_id,
+            batch_id=conversation.batch.key,
             delivery_class=conversation.delivery_class,
         )
 
@@ -148,17 +146,16 @@ class DialogueApplicationTestCase(AppWorkerTestCase):
             'transport_type': 'sphex',
             'helper_metadata': {'foo': {'bar': 'baz'}},
         }
-        batch_id = yield conversation.get_latest_batch_key()
         yield self.dispatch_command(
             "send_message",
             user_account_key=self.user_account.key,
             conversation_key=conversation.key,
             command_data={
-            "batch_id": batch_id,
-            "to_addr": "123456",
-            "content": "hello world",
-            "msg_options": msg_options,
-        })
+                "batch_id": conversation.batch.key,
+                "to_addr": "123456",
+                "content": "hello world",
+                "msg_options": msg_options,
+            })
 
         [msg] = yield self.get_dispatched_messages()
         self.assertEqual(msg.payload['to_addr'], "123456")
@@ -179,7 +176,6 @@ class DialogueApplicationTestCase(AppWorkerTestCase):
     def test_process_command_send_message_in_reply_to(self):
         conversation = yield self.setup_conversation()
         yield self.start_conversation(conversation)
-        batch_id = yield conversation.get_latest_batch_key()
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
         yield self.store_inbound_msg(msg)
         yield self.dispatch_command(
@@ -187,7 +183,7 @@ class DialogueApplicationTestCase(AppWorkerTestCase):
             user_account_key=self.user_account.key,
             conversation_key=conversation.key,
             command_data={
-            "batch_id": batch_id,
+                "batch_id": conversation.batch.key,
                 "to_addr": "to_addr",
                 "content": "foo",
                 u'msg_options': {

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -173,17 +173,16 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
             'transport_type': 'sphex',
             'helper_metadata': {'foo': {'bar': 'baz'}},
         }
-        batch_id = yield conversation.get_latest_batch_key()
         yield self.dispatch_command(
             "send_message",
             user_account_key=self.user_account.key,
             conversation_key=conversation.key,
             command_data={
-            "batch_id": batch_id,
-            "to_addr": "123456",
-            "content": "hello world",
-            "msg_options": msg_options,
-        })
+                "batch_id": conversation.batch.key,
+                "to_addr": "123456",
+                "content": "hello world",
+                "msg_options": msg_options,
+            })
 
         [msg] = yield self.get_dispatched_messages()
         self.assertEqual(msg.payload['to_addr'], "123456")
@@ -204,7 +203,6 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
     def test_process_command_send_message_in_reply_to(self):
         conversation = yield self.setup_conversation()
         yield self.start_conversation(conversation)
-        batch_id = yield conversation.get_latest_batch_key()
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
         yield self.store_inbound_msg(msg)
         yield self.dispatch_command(
@@ -212,7 +210,7 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
             user_account_key=self.user_account.key,
             conversation_key=conversation.key,
             command_data={
-            "batch_id": batch_id,
+                "batch_id": conversation.batch.key,
                 "to_addr": "to_addr",
                 "content": "foo",
                 u'msg_options': {

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -210,18 +210,16 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         conv1 = yield self.create_conversation(config={
                 'schedule': {'recurring': 'daily', 'time': '00:01:40'}})
         yield self.start_conversation(conv1)
-        batch_id1 = conv1.get_batch_keys()[0]
 
         conv2 = yield self.create_conversation(config={
                 'schedule': {'recurring': 'daily', 'time': '00:02:30'}})
         yield self.start_conversation(conv2)
-        batch_id2 = conv2.get_batch_keys()[0]
 
         yield self.create_conversation(config={
                 'schedule': {'recurring': 'daily', 'time': '00:02:30'}})
 
         [c1, c2] = yield self.app.get_conversations(
-            [[batch_id1, conv1.key], [batch_id2, conv2.key]])
+            [[conv1.batch.key, conv1.key], [conv2.batch.key, conv2.key]])
 
         self.assertEqual(sorted([c1.key, c2.key]),
                          sorted([conv1.key, conv2.key]))

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -137,7 +137,6 @@ class SequentialSendApplication(GoApplicationWorker):
     def send_scheduled_messages(self, conv):
         config = self.get_config_for_conversation(conv)
         messages = config.messages
-        batch_id = conv.get_batch_keys()[0]
         message_options = {}
         conv.set_go_helper_metadata(
             message_options.setdefault('helper_metadata', {}))
@@ -158,7 +157,7 @@ class SequentialSendApplication(GoApplicationWorker):
                     continue
 
                 yield self.send_message(
-                    batch_id, to_addr, messages[message_index],
+                    conv.batch.key, to_addr, messages[message_index],
                     message_options)
 
                 contact.extra[index_key] = u'%s' % (message_index + 1)

--- a/go/apps/sna/handlers.py
+++ b/go/apps/sna/handlers.py
@@ -99,12 +99,11 @@ class USSDMenuCompletionHandler(SNAEventHandler):
 
         conversation = yield user_api.get_wrapped_conversation(
                                                 conversation_key)
-        batch_id = yield conversation.get_latest_batch_key()
 
         yield conversation.dispatch_command(
             'send_message', account_key, conversation.key,
             command_data={
-                'batch_id': batch_id,
+                'batch_id': conversation.batch.key,
                 'to_addr': from_addr,
                 'content': content,
                 'msg_options': {},

--- a/go/apps/sna/test_handlers.py
+++ b/go/apps/sna/test_handlers.py
@@ -141,7 +141,7 @@ class USSDMenuCompletionHandlerTestCase(EventHandlerTestCase):
         self.assertEqual(send_msg_cmd['command'], 'send_message')
         self.assertEqual(send_msg_cmd['kwargs'], {
             'command_data': {
-                'batch_id': (yield self.conversation.get_latest_batch_key()),
+                'batch_id': self.conversation.batch.key,
                 'content': 'english sms',
                 'to_addr': self.contact.msisdn,
                 'msg_options': {},

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -19,7 +19,7 @@ class SendSurveyAction(ConversationAction):
 
     def perform_action(self, action_data):
         return self.send_command(
-            'send_survey', batch_id=self._conv.get_latest_batch_key(),
+            'send_survey', batch_id=self._conv.batch.key,
             msg_options={}, delivery_class=self._conv.delivery_class)
 
 

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -346,7 +346,7 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
                          'survey_application')
         self.assertEqual(reply_to_cmd['command'], 'send_message')
         self.assertEqual(reply_to_cmd['kwargs']['command_data'], {
-            'batch_id': conversation.get_latest_batch_key(),
+            'batch_id': conversation.batch.key,
             'conversation_key': conversation.key,
             'content': 'foo',
             'to_addr': msg['from_addr'],

--- a/go/apps/surveys/tests/test_vumi_app.py
+++ b/go/apps/surveys/tests/test_vumi_app.py
@@ -133,7 +133,7 @@ class TestSurveyApplication(AppWorkerTestCase):
 
     @inlineCallbacks
     def send_send_survey_command(self, conversation):
-        batch_id = yield self.conversation.get_latest_batch_key()
+        batch_id = self.conversation.batch.key
         yield self.dispatch_command(
             "send_survey",
             user_account_key=self.user_account.key,
@@ -270,7 +270,7 @@ class TestSurveyApplication(AppWorkerTestCase):
             'helper_metadata': {'foo': {'bar': 'baz'}},
         }
         yield self.start_conversation(self.conversation)
-        batch_id = yield self.conversation.get_latest_batch_key()
+        batch_id = self.conversation.batch.key
         yield self.dispatch_command(
             "send_message",
             user_account_key=self.user_account.key,
@@ -300,7 +300,7 @@ class TestSurveyApplication(AppWorkerTestCase):
     @inlineCallbacks
     def test_process_command_send_message_in_reply_to(self):
         yield self.start_conversation(self.conversation)
-        batch_id = yield self.conversation.get_latest_batch_key()
+        batch_id = self.conversation.batch.key
         msg = self.mkmsg_in(message_id=uuid.uuid4().hex)
         yield self.store_inbound_msg(msg)
         command = VumiApiCommand.command(

--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -171,7 +171,7 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
     def add_messages_to_conv(self, message_count, conversation, reply=False,
                              ack=False, start_date=None, time_multiplier=10):
         now = start_date or datetime.now().date()
-        batch_key = conversation.get_latest_batch_key()
+        batch_key = conversation.batch.key
 
         messages = []
         for i in range(message_count):

--- a/go/conversation/templatetags/conversation_tags.py
+++ b/go/conversation/templatetags/conversation_tags.py
@@ -56,7 +56,7 @@ def show_conversation_messages(context, conversation, direction=None,
         messages.
     """
 
-    batch_id = batch_id or conversation.get_latest_batch_key()
+    batch_id = batch_id or conversation.batch.key
     direction = 'outbound' if direction == 'outbound' else 'inbound'
 
     # Paginator starts counting at 1 so 0 would also be invalid

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -4,7 +4,6 @@ import logging
 import functools
 import re
 from StringIO import StringIO
-from urllib import urlencode
 
 from django.conf import settings
 from django.views.generic import View, TemplateView
@@ -216,7 +215,7 @@ class MessageListView(ConversationTemplateView):
         query = request.GET.get('q', None)
         token = None
 
-        batch_id = conversation.get_latest_batch_key()
+        batch_id = conversation.batch.key
 
         # Paginator starts counting at 1 so 0 would also be invalid
         inbound_message_paginator = Paginator(
@@ -290,7 +289,7 @@ class MessageListView(ConversationTemplateView):
         conversation.dispatch_command(
             'send_message', user_api.user_account_key, conversation.key,
             command_data={
-                "batch_id": conversation.get_latest_batch_key(),
+                "batch_id": conversation.batch.key,
                 "conversation_key": conversation.key,
                 "to_addr": inbound_message['from_addr'],
                 "content": content,
@@ -316,7 +315,8 @@ class MessageListView(ConversationTemplateView):
             else:
                 messages.error(request,
                     'Something went wrong. Please try again.')
-        return self.redirect_to('message_list', conversation_key=conversation.key)
+        return self.redirect_to(
+            'message_list', conversation_key=conversation.key)
 
 
 class EditConversationDetailView(ConversationTemplateView):

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -199,9 +199,8 @@ class GoWorkerMixin(object):
 
         log.msg('Reconciling cache for %s' % (conversation_key,))
         message_store = user_api.api.mdb
-        for batch_key in conv.get_batch_keys():
-            if (yield message_store.needs_reconciliation(batch_key, delta)):
-                yield message_store.reconcile_cache(batch_key)
+        if (yield message_store.needs_reconciliation(conv.batch.key, delta)):
+            yield message_store.reconcile_cache(conv.batch.key)
         log.msg('Cache reconciled for %s' % (conversation_key,))
 
     @inlineCallbacks

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -376,7 +376,6 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def do_search(self, conv, direction, *args, **kwargs):
-        batch_key = kwargs.get('batch_key', self.conv.batch.key)
         search_callback = {
             'inbound': conv.find_inbound_messages_matching,
             'outbound': conv.find_outbound_messages_matching,
@@ -389,7 +388,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
         kwargs.update({'wait': True})
         token = yield search_callback(*args, **kwargs)
-        messages = yield results_callback(token, batch_key=batch_key)
+        messages = yield results_callback(token)
         returnValue(messages)
 
     @inlineCallbacks

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -106,49 +106,39 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
         returnValue(events)
 
     @inlineCallbacks
-    def test_get_latest_batch_key(self):
-        batch_key = yield self.conv.get_latest_batch_key()
-        self.assertEqual(batch_key, self.conv.batch.key)
-
-    @inlineCallbacks
     def test_count_replies(self):
         yield self.conv.start()
-        yield self.store_inbound((yield self.conv.get_latest_batch_key()))
+        yield self.store_inbound(self.conv.batch.key)
         self.assertEqual((yield self.conv.count_replies()), 10)
 
     @inlineCallbacks
     def test_count_sent_messages(self):
         yield self.conv.start()
-        yield self.store_outbound((yield self.conv.get_latest_batch_key()))
+        yield self.store_outbound(self.conv.batch.key)
         self.assertEqual((yield self.conv.count_sent_messages()), 10)
 
     @inlineCallbacks
     def test_count_inbound_uniques(self):
         yield self.conv.start()
-        yield self.store_inbound(
-            (yield self.conv.get_latest_batch_key()), count=5)
+        yield self.store_inbound(self.conv.batch.key, count=5)
         self.assertEqual((yield self.conv.count_inbound_uniques()), 5)
         yield self.store_inbound(
-            (yield self.conv.get_latest_batch_key()),
-            count=5, addr_template='from')
+            self.conv.batch.key, count=5, addr_template='from')
         self.assertEqual((yield self.conv.count_inbound_uniques()), 6)
 
     @inlineCallbacks
     def test_count_outbound_uniques(self):
         yield self.conv.start()
-        yield self.store_outbound(
-            (yield self.conv.get_latest_batch_key()), count=5)
+        yield self.store_outbound(self.conv.batch.key, count=5)
         self.assertEqual((yield self.conv.count_outbound_uniques()), 5)
         yield self.store_outbound(
-            (yield self.conv.get_latest_batch_key()),
-            count=5, addr_template='from')
+            self.conv.batch.key, count=5, addr_template='from')
         self.assertEqual((yield self.conv.count_outbound_uniques()), 6)
 
     @inlineCallbacks
     def test_received_messages(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20)
+        yield self.store_inbound(self.conv.batch.key, count=20)
         received_messages = yield self.conv.received_messages()
         self.assertEqual(len(received_messages), 20)
         self.assertEqual(len((yield self.conv.received_messages(0, 5))), 5)
@@ -158,11 +148,10 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_received_messages_include_sensitive(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20, helper_metadata={
-            'go': {
-                'sensitive': True,
-            }})
+        yield self.store_inbound(
+            self.conv.batch.key, count=20, helper_metadata={
+                'go': {'sensitive': True},
+            })
         self.assertEqual([], (yield self.conv.received_messages()))
         self.assertEqual(
             20,
@@ -171,11 +160,10 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_received_messages_include_sensitive_and_scrub(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20, helper_metadata={
-            'go': {
-                'sensitive': True,
-            }})
+        yield self.store_inbound(
+            self.conv.batch.key, count=20, helper_metadata={
+                'go': {'sensitive': True},
+            })
 
         def scrubber(msg):
             msg['content'] = 'scrubbed'
@@ -190,16 +178,14 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_received_messages_dictionary(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        [msg] = yield self.store_inbound(batch_key, count=1)
+        [msg] = yield self.store_inbound(self.conv.batch.key, count=1)
         [reply] = yield self.conv.received_messages()
         self.assertEqual(msg['message_id'], reply['message_id'])
 
     @inlineCallbacks
     def test_sent_messages(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20)
+        yield self.store_outbound(self.conv.batch.key, count=20)
         sent_messages = yield self.conv.sent_messages()
         self.assertEqual(len(sent_messages), 20)
         self.assertEqual(len((yield self.conv.sent_messages(0, 5))), 5)
@@ -209,11 +195,10 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_sent_messages_include_sensitive(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20, helper_metadata={
-            'go': {
-                'sensitive': True,
-            }})
+        yield self.store_outbound(
+            self.conv.batch.key, count=20, helper_metadata={
+                'go': {'sensitive': True},
+            })
         self.assertEqual([], (yield self.conv.sent_messages()))
         self.assertEqual(
             20,
@@ -222,11 +207,10 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_sent_messages_include_sensitive_and_scrub(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20, helper_metadata={
-            'go': {
-                'sensitive': True,
-            }})
+        yield self.store_outbound(
+            self.conv.batch.key, count=20, helper_metadata={
+                'go': {'sensitive': True},
+            })
 
         def scrubber(msg):
             msg['content'] = 'scrubbed'
@@ -241,8 +225,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_sent_messages_dictionary(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        [msg] = yield self.store_outbound(batch_key, count=1)
+        [msg] = yield self.store_outbound(self.conv.batch.key, count=1)
         [sent_message] = yield self.conv.sent_messages()
         self.assertEqual(msg['message_id'], sent_message['message_id'])
 
@@ -288,8 +271,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_get_progress_status(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        outbound = yield self.store_outbound(batch_key, count=10)
+        outbound = yield self.store_outbound(self.conv.batch.key, count=10)
         yield self.store_event(outbound, 'ack', count=8)
         yield self.store_event(outbound, 'nack', count=2)
         yield self.store_event(outbound, 'delivery', count=4,
@@ -312,8 +294,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     def test_get_progress_percentage_acks(self):
         yield self.conv.start()
         self.assertEqual((yield self.conv.get_progress_percentage()), 0)
-        batch_key = yield self.conv.get_latest_batch_key()
-        outbound = yield self.store_outbound(batch_key, count=10)
+        outbound = yield self.store_outbound(self.conv.batch.key, count=10)
         yield self.store_event(outbound, 'ack', count=8)
         self.assertEqual((yield self.conv.get_progress_percentage()), 80)
 
@@ -321,8 +302,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     def test_get_progress_percentage_nacks(self):
         yield self.conv.start()
         self.assertEqual((yield self.conv.get_progress_percentage()), 0)
-        batch_key = yield self.conv.get_latest_batch_key()
-        outbound = yield self.store_outbound(batch_key, count=10)
+        outbound = yield self.store_outbound(self.conv.batch.key, count=10)
         yield self.store_event(outbound, 'nack', count=8)
         self.assertEqual((yield self.conv.get_progress_percentage()), 80)
 
@@ -373,8 +353,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_get_inbound_throughput(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20, time_multiplier=0)
+        yield self.store_inbound(
+            self.conv.batch.key, count=20, time_multiplier=0)
         # 20 messages in 5 minutes = 4 messages per minute
         self.assertEqual(
             (yield self.conv.get_inbound_throughput()), 4)
@@ -385,8 +365,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_get_outbound_throughput(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20, time_multiplier=0)
+        yield self.store_outbound(
+            self.conv.batch.key, count=20, time_multiplier=0)
         # 20 messages in 5 minutes = 4 messages per minute
         self.assertEqual(
             (yield self.conv.get_outbound_throughput()), 4)
@@ -396,8 +376,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def do_search(self, conv, direction, *args, **kwargs):
-        batch_key = kwargs.get(
-            'batch_key', (yield self.conv.get_latest_batch_key()))
+        batch_key = kwargs.get('batch_key', self.conv.batch.key)
         search_callback = {
             'inbound': conv.find_inbound_messages_matching,
             'outbound': conv.find_outbound_messages_matching,
@@ -416,8 +395,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_find_inbound_messages_matching(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20)
+        yield self.store_inbound(self.conv.batch.key, count=20)
         matching = yield self.do_search(self.conv, 'inbound', 'hello')
         self.assertEqual(len(matching), 20)
         matching = yield self.do_search(self.conv, 'inbound', 'hello world 1')
@@ -428,8 +406,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_find_inbound_messages_matching_flags(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20)
+        yield self.store_inbound(self.conv.batch.key, count=20)
         matching = yield self.do_search(self.conv, 'inbound', 'HELLO',
                                         flags="i")
         self.assertEqual(len(matching), 20)
@@ -440,8 +417,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_find_inbound_messages_matching_flags_custom_key(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_inbound(batch_key, count=20)
+        yield self.store_inbound(self.conv.batch.key, count=20)
         matching = yield self.do_search(self.conv, 'inbound', 'FROM',
                                         flags='i', key='msg.from_addr')
         self.assertEqual(len(matching), 20)
@@ -452,8 +428,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_find_outbound_messages_matching(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20)
+        yield self.store_outbound(self.conv.batch.key, count=20)
         matching = yield self.do_search(self.conv, 'outbound', 'hello')
         self.assertEqual(len(matching), 20)
         matching = yield self.do_search(self.conv, 'outbound', 'hello world 1')
@@ -465,8 +440,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_find_outbound_messages_matching_flags(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20)
+        yield self.store_outbound(self.conv.batch.key, count=20)
         matching = yield self.do_search(self.conv, 'outbound', 'HELLO',
                                         flags='i')
         self.assertEqual(len(matching), 20)
@@ -477,8 +451,7 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_find_outbound_messages_matching_flags_custom_key(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20)
+        yield self.store_outbound(self.conv.batch.key, count=20)
         matching = yield self.do_search(self.conv, 'outbound', 'TO', flags='i',
                                         key='msg.to_addr')
         self.assertEqual(len(matching), 20)
@@ -489,8 +462,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_get_aggregate_keys(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20, time_multiplier=12)
+        yield self.store_outbound(
+            self.conv.batch.key, count=20, time_multiplier=12)
         inbound_aggregate = yield self.conv.get_aggregate_keys('inbound')
         self.assertEqual(inbound_aggregate, [])
         outbound_aggregate = yield self.conv.get_aggregate_keys('outbound')
@@ -506,8 +479,8 @@ class ConversationWrapperTestCase(AppWorkerTestCase):
     @inlineCallbacks
     def test_get_aggregate_count(self):
         yield self.conv.start()
-        batch_key = yield self.conv.get_latest_batch_key()
-        yield self.store_outbound(batch_key, count=20, time_multiplier=12)
+        yield self.store_outbound(
+            self.conv.batch.key, count=20, time_multiplier=12)
         inbound_aggregate = yield self.conv.get_aggregate_count('inbound')
         self.assertEqual(inbound_aggregate, [])
         outbound_aggregate = yield self.conv.get_aggregate_count('outbound')

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -39,10 +39,7 @@ class ConversationWrapper(object):
         self.c.set_status_finished()
         yield self.c.save()
         yield self._remove_from_routing_table()
-        yield self._release_batches()
-
-    def _release_batches(self):
-        return self.mdb.batch_done(self.batch.key)
+        yield self.mdb.batch_done(self.batch.key)
 
     def __getattr__(self, name):
         # Proxy anything we don't have back to the wrapped conversation.

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -39,7 +39,6 @@ class ConversationWrapper(object):
         self.c.set_status_finished()
         yield self.c.save()
         yield self._remove_from_routing_table()
-        yield self.mdb.batch_done(self.batch.key)
 
     def __getattr__(self, name):
         # Proxy anything we don't have back to the wrapped conversation.

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -336,8 +336,7 @@ class ConversationStoringMiddleware(GoStoringMiddleware):
         from go.vumitools.utils import MessageMetadataHelper
         mdh = MessageMetadataHelper(self.vumi_api, msg)
         conversation = yield mdh.get_conversation()
-        batch_id = yield conversation.get_latest_batch_key()
-        returnValue(batch_id)
+        returnValue(conversation.batch.key)
 
 
 class RouterStoringMiddleware(GoStoringMiddleware):

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -327,7 +327,7 @@ class ConversationStoringMiddlewareTestCase(MiddlewareTestCase):
         msg = self.mkmsg_in()
         self.add_conversation_md_to_msg(msg, self.conv)
         yield self.mw.handle_inbound(msg, 'default')
-        batch_id = yield self.conv.get_latest_batch_key()
+        batch_id = self.conv.batch.key
         msg_ids = yield self.vumi_api.mdb.batch_inbound_keys(batch_id)
         self.assertEqual(msg_ids, [msg['message_id']])
 
@@ -336,7 +336,7 @@ class ConversationStoringMiddlewareTestCase(MiddlewareTestCase):
         msg = self.mkmsg_out()
         self.add_conversation_md_to_msg(msg, self.conv)
         yield self.mw.handle_outbound(msg, 'default')
-        batch_id = yield self.conv.get_latest_batch_key()
+        batch_id = self.conv.batch.key
         msg_ids = yield self.vumi_api.mdb.batch_outbound_keys(batch_id)
         self.assertEqual(msg_ids, [msg['message_id']])
 

--- a/go/vumitools/tests/utils.py
+++ b/go/vumitools/tests/utils.py
@@ -193,13 +193,13 @@ class GoWorkerTestMixin(GoPersistenceMixin):
 
     def store_outbound_msg(self, msg, conv=None, batch_id=None):
         if batch_id is None and conv is not None:
-            [batch_id] = conv.get_batch_keys()
+            batch_id = conv.batch.key
         return self.user_api.api.mdb.add_outbound_message(
             msg, batch_id=batch_id)
 
     def store_inbound_msg(self, msg, conv=None, batch_id=None):
         if batch_id is None and conv is not None:
-            [batch_id] = conv.get_batch_keys()
+            batch_id = conv.batch.key
         return self.user_api.api.mdb.add_inbound_message(
             msg, batch_id=batch_id)
 


### PR DESCRIPTION
Now that #624 has landed we can clean up a bunch of the now-obsolete helpers and abstractions we have in the conversation code, starting with `get_batches()` and `get_latest_batch()`.
