### PR TITLE
Clean up test classes

### DIFF
--- a/go/api/go_api/session.py
+++ b/go/api/go_api/session.py
@@ -12,7 +12,8 @@ class SessionStore(SessionBase):
     """
     def __init__(self, session_key=None):
         super(SessionStore, self).__init__(session_key)
-        self.session_manager = vumi_api().session_manager
+        self.vumi_api = vumi_api()
+        self.session_manager = self.vumi_api.session_manager
 
     def encode(self, data):
         """Replace Django's pickle serialization with a null-op.

--- a/go/api/go_api/tests/test_auth.py
+++ b/go/api/go_api/tests/test_auth.py
@@ -13,7 +13,7 @@ from go.api.go_api.auth import (
     GoUserRealm, GoUserSessionAccessChecker, GoUserAuthSessionWrapper)
 from go.api.go_api.session_manager import SessionManager
 from go.vumitools.api import VumiApi
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 
 import mock
 
@@ -41,16 +41,12 @@ class GoUserRealmTestCase(TestCase):
                           realm.requestAvatar, u"user", mind)
 
 
-class GoUserSessionAccessCheckerTestCase(TestCase, GoPersistenceMixin):
+class GoUserSessionAccessCheckerTestCase(GoTestCase):
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(GoUserSessionAccessCheckerTestCase, self).setUp()
         self.redis = yield self.get_redis_manager()
         self.sm = SessionManager(self.redis)
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield self._persist_tearDown()
 
     @inlineCallbacks
     def test_request_avatar_id(self):
@@ -87,19 +83,15 @@ class GoUserSessionAccessCheckerTestCase(TestCase, GoPersistenceMixin):
         self.assertTrue(errored)
 
 
-class GoUserAuthSessionWrapperTestCase(TestCase, GoPersistenceMixin):
+class GoUserAuthSessionWrapperTestCase(GoTestCase):
 
     use_riak = True
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(GoUserAuthSessionWrapperTestCase, self).setUp()
         self.config = self.mk_config({})
         self.vumi_api = yield VumiApi.from_config_async(self.config)
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield self._persist_tearDown()
 
     def mk_request(self, user=None, password=None):
         request = DummyRequest([''])

--- a/go/api/go_api/tests/test_go_api.py
+++ b/go/api/go_api/tests/test_go_api.py
@@ -7,22 +7,19 @@ from txjsonrpc.jsonrpclib import Fault
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.trial.unittest import TestCase
 from twisted.web.server import Site
 
-from vumi.tests.utils import VumiWorkerTestCase
 from vumi.utils import http_request
 
 from go.vumitools.account.models import GoConnector, RoutingTableHelper
 from go.vumitools.api import VumiApi
-from go.vumitools.tests.utils import GoAppWorkerTestMixin
+from go.vumitools.tests.utils import AppWorkerTestCase
 from go.api.go_api.api_types import RoutingEntryType, EndpointType
 from go.api.go_api.go_api import GoApiWorker, GoApiServer
 
 
-class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
+class GoApiServerTestCase(AppWorkerTestCase):
 
-    use_riak = True
     worker_name = 'GoApiServer'
     transport_name = 'sphex'
     transport_type = 'sphex_type'
@@ -439,20 +436,7 @@ class GoApiServerTestCase(TestCase, GoAppWorkerTestMixin):
                                  u"no such sub-handler unknown")
 
 
-class GoApiWorkerTestCase(VumiWorkerTestCase, GoAppWorkerTestMixin):
-
-    use_riak = True
-
-    def setUp(self):
-        self._persist_setUp()
-        super(GoApiWorkerTestCase, self).setUp()
-
-    @inlineCallbacks
-    def tearDown(self):
-        for worker in self._workers:
-            if worker.running:
-                yield worker.stopService()
-        yield self._persist_tearDown()
+class GoApiWorkerTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def get_api_worker(self, config=None, start=True, auth=True):

--- a/go/api/go_api/tests/test_session.py
+++ b/go/api/go_api/tests/test_session.py
@@ -1,14 +1,15 @@
 """Tests for go.api.go_api.session."""
 
-from unittest import TestCase
-
 from go.api.go_api.session import SessionStore, CreateError
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 
 
-class SessionStoreTestCase(TestCase, GoPersistenceMixin):
+class SessionStoreTestCase(GoTestCase):
     def mk_session_store(self, session_key=None):
         ss = SessionStore(session_key)
+        # We don't grab the Riak manager here because we don't use Riak in
+        # these tests.
+        self._persist_redis_managers.append(ss.vumi_api.redis)
         return (ss, ss.session_manager)
 
     def test_init(self):

--- a/go/api/go_api/tests/test_session_manager.py
+++ b/go/api/go_api/tests/test_session_manager.py
@@ -3,22 +3,17 @@
 import json
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from go.api.go_api.session_manager import SessionManager, GO_USER_ACCOUNT_KEY
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 
 
-class SessionManagerTestCase(TestCase, GoPersistenceMixin):
+class SessionManagerTestCase(GoTestCase):
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(SessionManagerTestCase, self).setUp()
         self.redis = yield self.get_redis_manager()
         self.sm = SessionManager(self.redis)
-
-    @inlineCallbacks
-    def tearDown(self):
-        yield self._persist_tearDown()
 
     @inlineCallbacks
     def mk_session(self, session_id, session):

--- a/go/apps/dialogue/tests/test_dialogue_api.py
+++ b/go/apps/dialogue/tests/test_dialogue_api.py
@@ -1,20 +1,17 @@
 """Tests for go.apps.dialogue.dialogue_api."""
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from go.apps.dialogue.dialogue_api import DialogueActionDispatcher
 from go.vumitools.api import VumiApi
-from go.vumitools.tests.utils import GoAppWorkerTestMixin
+from go.vumitools.tests.utils import AppWorkerTestCase
 
 
-class DialogueActionDispatcherTestCase(TestCase, GoAppWorkerTestMixin):
-
-    use_riak = True
+class DialogueActionDispatcherTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(DialogueActionDispatcherTestCase, self).setUp()
         self.config = self.mk_config({})
         self.vumi_api = yield VumiApi.from_config_async(self.config)
         self.account = yield self.mk_user(self.vumi_api, u'user')

--- a/go/routers/keyword/tests/test_vumi_app.py
+++ b/go/routers/keyword/tests/test_vumi_app.py
@@ -7,7 +7,7 @@ from go.routers.keyword.vumi_app import KeywordRouter
 
 class TestKeywordRouter(RouterWorkerTestCase):
 
-    application_class = KeywordRouter
+    router_class = KeywordRouter
 
     @inlineCallbacks
     def setUp(self):

--- a/go/vumitools/account/tests/test_models.py
+++ b/go/vumitools/account/tests/test_models.py
@@ -3,29 +3,25 @@ import copy
 import mock
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 from vumi.tests.utils import UTCNearNow, LogCatcher
 
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 from go.vumitools.account.models import (
     AccountStore, RoutingTableHelper, GoConnector, GoConnectorError)
 from go.vumitools.account.old_models import AccountStoreVNone, AccountStoreV1
 
 
-class UserAccountTestCase(GoPersistenceMixin, TestCase):
+class UserAccountTestCase(GoTestCase):
     use_riak = True
 
     def setUp(self):
-        self._persist_setUp()
+        super(UserAccountTestCase, self).setUp()
         self.manager = self.get_riak_manager()
         self.store = AccountStore(self.manager)
 
         # Some old stores for testing migrations.
         self.store_v1 = AccountStoreV1(self.manager)
         self.store_vnone = AccountStoreVNone(self.manager)
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     def assert_user(self, user, **fields):
         def assert_field(value, name, default):
@@ -89,7 +85,7 @@ class UserAccountTestCase(GoPersistenceMixin, TestCase):
         self.assert_user(user, tags=None, routing_table=None)
 
 
-class RoutingTableHelperTestCase(TestCase):
+class RoutingTableHelperTestCase(GoTestCase):
 
     CONV_1 = "CONVERSATION:dummy:1"
     CONV_2 = "CONVERSATION:dummy:2"
@@ -401,7 +397,7 @@ class RoutingTableHelperTestCase(TestCase):
         self.assertRaises(ValueError, rt.validate_all_entries)
 
 
-class GoConnectorTestCase(TestCase):
+class GoConnectorTestCase(GoTestCase):
     def test_create_conversation_connector(self):
         c = GoConnector.for_conversation("conv_type_1", "12345")
         self.assertEqual(c.ctype, GoConnector.CONVERSATION)

--- a/go/vumitools/channel/tests/test_models.py
+++ b/go/vumitools/channel/tests/test_models.py
@@ -3,14 +3,13 @@
 """Tests for go.vumitools.channel.models."""
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 from go.vumitools.account import AccountStore
 from go.vumitools.channel.models import ChannelStore, CheapPlasticChannel
 
 
-class TestChannel(TestCase):
+class TestChannel(GoTestCase):
 
     def make_channel(self, tagpool_metadata={}):
         return CheapPlasticChannel("pool", "tag", tagpool_metadata, "batch1")
@@ -36,20 +35,16 @@ class TestChannel(TestCase):
         self.assertFalse(channel.supports_replies())
 
 
-class TestChannelStore(GoPersistenceMixin, TestCase):
+class TestChannelStore(GoTestCase):
     use_riak = True
-    timeout = 5
 
     @inlineCallbacks
     def setUp(self):
-        yield self._persist_setUp()
+        super(TestChannelStore, self).setUp()
         self.manager = self.get_riak_manager()
         self.account_store = AccountStore(self.manager)
         self.account = yield self.mk_user(self, u'user')
         self.channel_store = ChannelStore.from_user_account(self.account)
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     @inlineCallbacks
     def test_get_channel_by_tag(self):

--- a/go/vumitools/router/tests/test_models.py
+++ b/go/vumitools/router/tests/test_models.py
@@ -3,27 +3,22 @@
 """Tests for go.vumitools.router.models."""
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
-from go.vumitools.tests.utils import model_eq, GoPersistenceMixin
+from go.vumitools.tests.utils import model_eq, GoTestCase
 from go.vumitools.account import AccountStore
 from go.vumitools.router.models import RouterStore
 
 
-class TestRouter(GoPersistenceMixin, TestCase):
+class TestRouter(GoTestCase):
     use_riak = True
-    timeout = 5
 
     @inlineCallbacks
     def setUp(self):
-        yield self._persist_setUp()
+        super(TestRouter, self).setUp()
         self.manager = self.get_riak_manager()
         self.account_store = AccountStore(self.manager)
         self.account = yield self.mk_user(self, u'user')
         self.router_store = RouterStore.from_user_account(self.account)
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     def assert_status(self, router, expected_status_name, archived=False):
         for status_name in ['starting', 'running', 'stopping', 'stopped']:
@@ -58,20 +53,16 @@ class TestRouter(GoPersistenceMixin, TestCase):
         self.assert_status(router, 'stopped', archived=True)
 
 
-class TestRouterStore(GoPersistenceMixin, TestCase):
+class TestRouterStore(GoTestCase):
     use_riak = True
-    timeout = 5
 
     @inlineCallbacks
     def setUp(self):
-        yield self._persist_setUp()
+        super(TestRouterStore, self).setUp()
         self.manager = self.get_riak_manager()
         self.account_store = AccountStore(self.manager)
         self.account = yield self.mk_user(self, u'user')
         self.router_store = RouterStore.from_user_account(self.account)
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     def assert_models_equal(self, m1, m2):
         self.assertTrue(model_eq(m1, m2),

--- a/go/vumitools/tests/test_contact.py
+++ b/go/vumitools/tests/test_contact.py
@@ -3,21 +3,20 @@
 """Tests for go.vumitools.contact."""
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
-from go.vumitools.tests.utils import model_eq, GoPersistenceMixin
+from go.vumitools.tests.utils import model_eq, GoTestCase
 from go.vumitools.account import AccountStore
 from go.vumitools.contact import (
     ContactStore, ContactError, ContactNotFoundError)
 from go.vumitools.opt_out import OptOutStore
 
 
-class TestContactStore(GoPersistenceMixin, TestCase):
+class TestContactStore(GoTestCase):
     use_riak = True
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(TestContactStore, self).setUp()
         self.manager = self.get_riak_manager()
         self.account_store = AccountStore(self.manager)
         # We pass `self` in as the VumiApi object here, because mk_user() just
@@ -28,9 +27,6 @@ class TestContactStore(GoPersistenceMixin, TestCase):
         self.store_alt = ContactStore.from_user_account(self.account_alt)
         yield self.store.contacts.enable_search()
         yield self.store_alt.contacts.enable_search()
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     def assert_models_equal(self, m1, m2):
         self.assertTrue(model_eq(m1, m2),

--- a/go/vumitools/tests/test_conversation.py
+++ b/go/vumitools/tests/test_conversation.py
@@ -6,11 +6,10 @@ from uuid import uuid4
 from datetime import datetime
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 
 from vumi.persist.model import ModelMigrationError
 
-from go.vumitools.tests.utils import model_eq, GoPersistenceMixin
+from go.vumitools.tests.utils import model_eq, GoTestCase
 from go.vumitools.account import AccountStore
 from go.vumitools.conversation import ConversationStore
 from go.vumitools.opt_out import OptOutStore
@@ -19,22 +18,18 @@ from go.vumitools.conversation.old_models import (
     ConversationVNone, ConversationV1, ConversationV2)
 
 
-class TestConversationStore(GoPersistenceMixin, TestCase):
+class TestConversationStore(GoTestCase):
     use_riak = True
-    timeout = 5
 
     @inlineCallbacks
     def setUp(self):
-        yield self._persist_setUp()
+        super(TestConversationStore, self).setUp()
         self.manager = self.get_riak_manager()
         self.account_store = AccountStore(self.manager)
         self.account = yield self.mk_user(self, u'user')
         self.optout_store = OptOutStore.from_user_account(self.account)
         self.conv_store = ConversationStore.from_user_account(self.account)
         self.contact_store = ContactStore.from_user_account(self.account)
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     def assert_models_equal(self, m1, m2):
         self.assertTrue(model_eq(m1, m2),

--- a/go/vumitools/tests/test_credit.py
+++ b/go/vumitools/tests/test_credit.py
@@ -2,24 +2,20 @@
 
 import uuid
 
-from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks
 
 from go.vumitools.credit import CreditManager
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 
 
-class TestCreditManager(TestCase, GoPersistenceMixin):
+class TestCreditManager(GoTestCase):
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(TestCreditManager, self).setUp()
         redis = yield self.get_redis_manager()
         self.cm = CreditManager(redis)
         self.user_id = uuid.uuid4().hex
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     @inlineCallbacks
     def test_get_credit(self):

--- a/go/vumitools/tests/test_metrics_worker.py
+++ b/go/vumitools/tests/test_metrics_worker.py
@@ -3,33 +3,24 @@
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import Clock, LoopingCall
 
-from vumi.tests.utils import VumiWorkerTestCase
-
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoWorkerTestCase
 from go.vumitools import metrics_worker
 
 
-class GoMetricsWorkerTestCase(VumiWorkerTestCase, GoPersistenceMixin):
-    use_riak = True
+class GoMetricsWorkerTestCase(GoWorkerTestCase):
+    worker_class = metrics_worker.GoMetricsWorker
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
         super(GoMetricsWorkerTestCase, self).setUp()
         self.clock = Clock()
         self.patch(metrics_worker, 'LoopingCall', self.looping_call)
         self.worker = yield self.get_metrics_worker()
 
-    @inlineCallbacks
-    def tearDown(self):
-        yield super(GoMetricsWorkerTestCase, self).tearDown()
-        yield self._persist_tearDown()
-
     def get_metrics_worker(self, config=None, start=True):
         if config is None:
             config = {}
-        return self.get_worker(
-            self.mk_config(config), metrics_worker.GoMetricsWorker, start)
+        return self.get_worker(self.mk_config(config), start)
 
     def rkey(self, name):
         return name

--- a/go/vumitools/tests/test_token_manager.py
+++ b/go/vumitools/tests/test_token_manager.py
@@ -1,26 +1,20 @@
-from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks
 
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 from go.vumitools.token_manager import (TokenManager, InvalidToken,
                                         MalformedToken, TokenManagerException)
 
 from mock import patch
 
 
-class TokenManagerTestCase(GoPersistenceMixin, TestCase):
-
-    use_riak = False
+class TokenManagerTestCase(GoTestCase):
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(TokenManagerTestCase, self).setUp()
         self.redis = yield self.get_redis_manager()
         self.tm = TokenManager(
                         self.redis.sub_manager('token_manager'))
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     @inlineCallbacks
     def test_token_generation(self):

--- a/go/vumitools/tests/test_utils.py
+++ b/go/vumitools/tests/test_utils.py
@@ -1,25 +1,22 @@
-from twisted.trial.unittest import TestCase, SkipTest
+from twisted.trial.unittest import SkipTest
 from twisted.internet.defer import inlineCallbacks
 
 from vumi.message import TransportUserMessage
 
 from go.vumitools.api import VumiApi
 from go.vumitools.utils import MessageMetadataHelper
-from go.vumitools.tests.utils import GoPersistenceMixin
+from go.vumitools.tests.utils import GoTestCase
 
 
-class MessageMetadataHelperTestCase(GoPersistenceMixin, TestCase):
+class MessageMetadataHelperTestCase(GoTestCase):
     use_riak = True
 
     @inlineCallbacks
     def setUp(self):
-        self._persist_setUp()
+        super(MessageMetadataHelperTestCase, self).setUp()
         self.vumi_api = yield VumiApi.from_config_async(self._persist_config)
         self.account = yield self.mk_user(self.vumi_api, u'user')
         self.user_api = self.vumi_api.get_user_api(self.account.key)
-
-    def tearDown(self):
-        return self._persist_tearDown()
 
     def create_conversation(self, conversation_type=u'bulk_message',
                             name=u'name', description=u'desc', config={}):


### PR DESCRIPTION
We're constructing test classes from mixins in a bunch of places when we should just be using some preconstructed base classes. (This work is factored out of some stuff I started to do in #246.)
