### PR TITLE
Clicking 'save' btn on survey screen does not direct user to 'show' page

### DIFF
--- a/go/apps/dialogue/templates/dialogue/edit.html
+++ b/go/apps/dialogue/templates/dialogue/edit.html
@@ -1,5 +1,6 @@
 {% extends "conversation/edit.html" %}
 {% load url from future %}
+{% load conversation_tags %}
 
 {% block content_extraclass %}campaigns dialogue{% endblock %}
 
@@ -17,7 +18,7 @@
   </div>
 
   <div class="pull-right">
-    <a href="{% url 'conversations:index' %}">Cancel</a>
+    <a href="{% conversation_screen conversation %}">Cancel</a>
     <button id="save" class="btn btn-primary">Save</button>
   </div>
 {% endblock %}

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -26,6 +26,9 @@ class DialogueTestCase(DjangoGoApplicationTestCase):
         expected = poll.copy()
         expected["campaign_id"] = self.user_api.user_account_key
         expected["conversation_key"] = conv.key
+        expected["urls"] = {
+            "show": self.get_view_url('show')
+        }
         model_data = response.context["model_data"]
         self.assertEqual(json.loads(model_data), expected)
 

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -30,6 +30,11 @@ class DialogueEditView(ConversationTemplateView):
         model_data = {
             'campaign_id': request.user_api.user_account_key,
             'conversation_key': conversation.key,
+            'urls': {
+                'show': self.get_view_url(
+                    'show',
+                    conversation_key=conversation.key)
+            }
         }
         model_data.update(r.json['result']['poll'])
 

--- a/go/base/static/js/src/apps/dialogue/models.js
+++ b/go/base/static/js/src/apps/dialogue/models.js
@@ -176,6 +176,10 @@
 
     relations: [{
       type: Backbone.HasOne,
+      key: 'urls',
+      relatedModel: Model
+    }, {
+      type: Backbone.HasOne,
       key: 'poll_metadata',
       relatedModel: DialogueMetadataModel
     }, {
@@ -197,6 +201,7 @@
 
     defaults: {
       states: [],
+      urls: {},
       connections: [],
       poll_metadata: {}
     }

--- a/go/base/static/js/src/apps/dialogue/views.js
+++ b/go/base/static/js/src/apps/dialogue/views.js
@@ -23,8 +23,7 @@
       });
 
       this.listenTo(this.save, 'success', function() {
-        // TODO better way of specifying urls than 'hardcoding' them
-        go.utils.redirect('/conversations/' + this.model.id + '/');
+        go.utils.redirect(this.model.get('urls').get('show'));
       });
 
       go.apps.dialogue.style.initialize();

--- a/go/base/static/js/src/apps/dialogue/views.js
+++ b/go/base/static/js/src/apps/dialogue/views.js
@@ -22,6 +22,11 @@
         useNotifier: true
       });
 
+      this.listenTo(this.save, 'success', function() {
+        // TODO better way of specifying urls than 'hardcoding' them
+        go.utils.redirect('/conversations/' + this.model.id + '/');
+      });
+
       go.apps.dialogue.style.initialize();
     },
 

--- a/go/base/static/js/test/tests/apps/dialogue/testHelpers.js
+++ b/go/base/static/js/test/tests/apps/dialogue/testHelpers.js
@@ -11,6 +11,9 @@
     conversation_key: 'conversation-1',
     poll_metadata: {repeatable: false},
     start_state: {uuid: 'state1'},
+    urls: {
+      show: 'conversation:show:conversation-1'
+    },
     states: [{
       uuid: 'state1',
       name: 'Message 1',

--- a/go/base/static/js/test/tests/apps/dialogue/views.test.js
+++ b/go/base/static/js/test/tests/apps/dialogue/views.test.js
@@ -89,6 +89,16 @@ describe("go.apps.dialogue.views", function() {
 
           assert.include(view.save.notifier.$el.text(), "Save successful!");
         });
+
+        it("should redirect the user to the conversation show page",
+        function() {
+          server.respondWith('{}');
+
+          view.$('#save').click();
+          server.respond();
+
+          assert.equal(location, '/conversations/conversation-1/');
+        });
       });
     });
 

--- a/go/base/static/js/test/tests/apps/dialogue/views.test.js
+++ b/go/base/static/js/test/tests/apps/dialogue/views.test.js
@@ -97,7 +97,7 @@ describe("go.apps.dialogue.views", function() {
           view.$('#save').click();
           server.respond();
 
-          assert.equal(location, '/conversations/conversation-1/');
+          assert.equal(location, 'conversation:show:conversation-1');
         });
       });
     });


### PR DESCRIPTION
- I set up my survey screens on the survey creator page
- I clicked the 'save' btn on the survey creator page
- I remained on the survey creator page once I received the "save successful" notification

![screen shot 2013-09-04 at 4 39 16 pm](https://f.cloud.github.com/assets/1521387/1081013/183f5ffc-1570-11e3-8c1e-cd04bf9f7a30.png)
I should be directed to the 'show' screen automatically once the save has completed successfully
