### PR TITLE
SMS confirmation messages should not be displayed in the Inbox

### DIFF
--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -215,6 +215,23 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
             messages.append((msg_in, msg_out, ack))
         return messages
 
+    def add_message_to_conv(self, conversation, reply=False, sensitive=False):
+        msg = TransportUserMessage(
+            to_addr='9292',
+            from_addr='from-addr',
+            content='hello',
+            transport_type='sms',
+            transport_name='sphex')
+        if sensitive:
+            msg['helper_metadata']['go'] = {'sensitive': True}
+        self.api.mdb.add_inbound_message(msg, batch_id=conversation.batch.key)
+        if reply:
+            msg_out = msg.reply('hi')
+            if sensitive:
+                msg_out['helper_metadata']['go'] = {'sensitive': True}
+            self.api.mdb.add_outbound_message(
+                msg_out, batch_id=conversation.batch.key)
+
     def add_channel_to_conversation(self, conv, tag):
         # TODO: This is a duplicate of the method in
         #       go.vumitools.test.utils.GoAppWorkerTestMixin but

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -574,6 +574,28 @@ class TestConversationViews(BaseConversationViewTestCase):
         # the first page.
         self.assertContains(response, '&amp;p=0', 0)
 
+    def test_message_list_no_sensitive_msgs(self):
+        conv = self.create_conversation(
+            conversation_type=u'dummy', started=True)
+
+        def assert_messages(count):
+            r_in = self.client.get(
+                self.get_view_url(conv, 'message_list'),
+                {'direction': 'inbound'})
+            self.assertContains(r_in, 'from-addr', count)
+            r_out = self.client.get(
+                self.get_view_url(conv, 'message_list'),
+                {'direction': 'outbound'})
+            self.assertContains(r_out, 'from-addr', count)
+
+        assert_messages(0)
+        self.add_message_to_conv(conv, reply=True)
+        assert_messages(1)
+        self.add_message_to_conv(conv, reply=True, sensitive=True)
+        assert_messages(1)
+        self.add_message_to_conv(conv, reply=True)
+        assert_messages(2)
+
     def test_reply_on_inbound_messages_only(self):
         # Fake the routing setup.
         self.monkey_patch(

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -221,11 +221,11 @@ class MessageListView(ConversationTemplateView):
         inbound_message_paginator = Paginator(
             PagedMessageCache(conversation.count_replies(),
                 lambda start, stop: conversation.received_messages(
-                    start, stop, batch_id)), 20)
+                    start, stop)), 20)
         outbound_message_paginator = Paginator(
             PagedMessageCache(conversation.count_sent_messages(),
-                lambda start, stop: conversation.sent_messages(start, stop,
-                    batch_id)), 20)
+                lambda start, stop: conversation.sent_messages(
+                    start, stop)), 20)
 
         tag_context = {
             'batch_id': batch_id,


### PR DESCRIPTION
From Rachel:

Hey Ben,

Quick UI note - previously, Simon had done the code so you couldn't see the message sent for confirmation on the platform (since it's a security measure, showing it on the platform defeats the purpose) - on the new UI, it shows up as a sent message so you can see the URL on the platform. 

Cheers,
Rachel

![screen shot 2013-09-02 at 11 14 58 am](https://f.cloud.github.com/assets/1521387/1066289/03542148-13b0-11e3-8225-6aed95790a25.png)
