### PR TITLE
Link to messages from the conversation overview page

### DIFF
--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -34,7 +34,7 @@
                     <td class="status {{ conversation.get_status }}">{{ conversation.get_status }}</td>
                     <td>{{ conversation.count_replies|add:conversation.count_sent_messages }} </td>
                     <!-- <td></td> -->
-                    <td>{{ conversation.created_at|naturaltime }}</td>
+                    <td title="{{conversation.created_at }}">{{ conversation.created_at|naturalday }}</td>
                     <td>
                         <a href="{% conversation_screen conversation 'message_list' %}">Messages</a>
                         {# <a href="{% url 'todo' %}">Reports</a> #}
@@ -44,7 +44,7 @@
                     </td>
                 </tr>
                 {% endfor %}
-                
+
             {% else %}
             <tr>
                 <td colspan="9">

--- a/go/conversation/templates/conversation/show.html
+++ b/go/conversation/templates/conversation/show.html
@@ -88,9 +88,10 @@
                             <li><a href="{% conversation_action conversation action.action_name %}" class="btn">{{ action.action_display_name }}</a></li>
                         {% endif %}
                     {% endwith %}
-                {% empty %}
-                    <li>This conversation has no actions.</li>
                 {% endfor %}
+                <li>
+                    <a class="btn" href="{% conversation_screen conversation 'message_list' %}">View Messages</a>
+                </li>
             </ul>
         </div>
         {% endif %}


### PR DESCRIPTION
Add a link to the conversation's messages from the conversation overview page (see screenshot)

![screen shot 2013-08-20 at 3 07 13 pm](https://f.cloud.github.com/assets/1521387/993392/9cdf9ea8-0999-11e3-807e-bfa8154f0a30.png)
