### PR TITLE
Display timestamp in "Last edited" column

### DIFF
--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -34,7 +34,7 @@
                     <td class="status {{ conversation.get_status }}">{{ conversation.get_status }}</td>
                     <td>{{ conversation.count_replies|add:conversation.count_sent_messages }} </td>
                     <!-- <td></td> -->
-                    <td>{{ conversation.created_at|naturaltime }}</td>
+                    <td title="{{conversation.created_at }}">{{ conversation.created_at|naturalday }}</td>
                     <td>
                         <a href="{% conversation_screen conversation 'message_list' %}">Messages</a>
                         {# <a href="{% url 'todo' %}">Reports</a> #}
@@ -44,7 +44,7 @@
                     </td>
                 </tr>
                 {% endfor %}
-                
+
             {% else %}
             <tr>
                 <td colspan="9">


### PR DESCRIPTION
On the dashboard, under the "Last edited" column we currently show: weeks, days, since the last edit.

Instead, let's show the timestamp of the last edit in the format (written month, day, year) e.g. October 4, 2009

![screen shot 2013-08-20 at 2 54 03 pm](https://f.cloud.github.com/assets/1521387/993346/2bb03b08-0998-11e3-9328-23d781330c67.png)
