### PR TITLE
Unable to export vxpolls data for survey with lots of users

### DIFF
--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -26,7 +26,11 @@ class SendSurveyAction(ConversationAction):
 class DownloadUserDataAction(ConversationAction):
     action_name = 'download_user_data'
     action_display_name = 'Download User Data'
-    redirect_to = 'user_data'
+
+    def perform_action(self, action_data):
+        from go.apps.surveys.tasks import export_vxpolls_data
+        return export_vxpolls_data.delay(self._conv.user_account.key,
+                                  self._conv.key)
 
 
 class ConversationDefinition(ConversationDefinitionBase):

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -1,5 +1,6 @@
 from go.vumitools.conversation.definition import (
     ConversationDefinitionBase, ConversationAction)
+from go.apps.surveys.tasks import export_vxpolls_data
 
 
 class SendSurveyAction(ConversationAction):
@@ -28,7 +29,6 @@ class DownloadUserDataAction(ConversationAction):
     action_display_name = 'Download User Data'
 
     def perform_action(self, action_data):
-        from go.apps.surveys.tasks import export_vxpolls_data
         return export_vxpolls_data.delay(self._conv.user_account.key,
                                          self._conv.key)
 

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -30,7 +30,7 @@ class DownloadUserDataAction(ConversationAction):
     def perform_action(self, action_data):
         from go.apps.surveys.tasks import export_vxpolls_data
         return export_vxpolls_data.delay(self._conv.user_account.key,
-                                  self._conv.key)
+                                         self._conv.key)
 
 
 class ConversationDefinition(ConversationDefinitionBase):

--- a/go/apps/surveys/tasks.py
+++ b/go/apps/surveys/tasks.py
@@ -1,0 +1,42 @@
+from StringIO import StringIO
+from zipfile import ZipFile, ZIP_DEFLATED
+
+from celery.task import task
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+
+from go.vumitools.api import VumiUserApi
+from go.base.models import UserProfile
+
+from go.apps.surveys.view_definition import get_poll_config
+
+
+@task(ignore_result=True)
+def export_vxpolls_data(account_key, conversation_key):
+    """
+    Export the data from a vxpoll and send it as a zipped attachment
+    via email.
+    """
+    api = VumiUserApi.from_config_sync(account_key, settings.VUMI_API_CONFIG)
+    user_profile = UserProfile.objects.get(user_account=account_key)
+    conversation = api.get_wrapped_conversation(conversation_key)
+
+    poll_id = 'poll-%s' % (conversation.key,)
+    pm, poll_data = get_poll_config(poll_id)
+    poll = pm.get(poll_id)
+    csv_data = pm.export_user_data_as_csv(poll)
+    email = EmailMessage(
+        'Survey export for: %s' % (conversation.name,),
+        'Please find the data for the survey %s attached.\n' % (
+            conversation.name),
+        settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
+
+    zipio = StringIO()
+    zf = ZipFile(zipio, "a", ZIP_DEFLATED)
+    zf.writestr("survey-data-export.csv", csv_data)
+    zf.close()
+
+    email.attach('survey-data-export.zip', zipio.getvalue(),
+                 'application/zip')
+    email.send()

--- a/go/apps/surveys/view_definition.py
+++ b/go/apps/surveys/view_definition.py
@@ -99,18 +99,6 @@ class SurveyEditView(ConversationTemplateView):
         })
 
 
-class UserDataView(ConversationTemplateView):
-    view_name = 'user_data'
-    path_suffix = 'users.csv'
-
-    def get(self, request, conversation):
-        poll_id = 'poll-%s' % (conversation.key,)
-        pm, poll_data = get_poll_config(poll_id)
-        poll = pm.get(poll_id)
-        csv_data = pm.export_user_data_as_csv(poll)
-        return HttpResponse(csv_data, content_type='application/csv')
-
-
 class SendSurveyForm(BootstrapForm):
     # TODO: Something better than this?
     pass
@@ -118,10 +106,6 @@ class SendSurveyForm(BootstrapForm):
 
 class ConversationViewDefinition(ConversationViewDefinitionBase):
     edit_view = SurveyEditView
-
-    extra_views = (
-        UserDataView,
-    )
 
     action_forms = {
         'send_survey': SendSurveyForm,

--- a/go/settings.py
+++ b/go/settings.py
@@ -238,6 +238,7 @@ CELERY_IMPORTS = (
     "go.contacts.tasks",
     "go.account.tasks",
     "go.conversation.tasks",
+    "go.apps.surveys.tasks",
 )
 CELERY_RESULT_BACKEND = "amqp"
 EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'


### PR DESCRIPTION
It takes too long to collect all the data and haproxy kills the web request. We should turn this into a celery task that sends an email (or redirects somewhere once the download is ready).
