### PR TITLE
Change text on 'save' buttons

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -5,6 +5,7 @@ from go.vumitools.conversation.definition import (
 class BulkSendAction(ConversationAction):
     action_name = 'bulk_send'
     action_display_name = 'Write and send bulk message'
+    action_display_verb = 'Send message'
 
     needs_confirmation = True
 

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -48,6 +48,7 @@ class BulkMessageTestCase(DjangoGoApplicationTestCase):
         self.assertEqual([], self.get_api_commands_sent())
         self.assertContains(response, 'name="message"')
         self.assertContains(response, '<h1>Write and send bulk message</h1>')
+        self.assertContains(response, '>Send message</button>')
 
     def test_action_bulk_send_no_group(self):
         self.setup_conversation(started=True)

--- a/go/apps/surveys/definition.py
+++ b/go/apps/surveys/definition.py
@@ -27,6 +27,7 @@ class SendSurveyAction(ConversationAction):
 class DownloadUserDataAction(ConversationAction):
     action_name = 'download_user_data'
     action_display_name = 'Download User Data'
+    action_display_verb = 'Send CSV via e-mail'
 
     def perform_action(self, action_data):
         return export_vxpolls_data.delay(self._conv.user_account.key,

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -152,7 +152,17 @@ class SurveyTestCase(DjangoGoApplicationTestCase):
             'rock', 'jazz', 'techno'])
         self.assertEqual(question['label'], 'favorite music')
 
-    def test_export_user_data(self):
+    def test_action_export_user_data_get(self):
+        self.setup_conversation(started=True, with_group=True,
+                                with_channel=True)
+        response = self.client.get(
+            self.get_action_view_url('download_user_data'))
+        conversation = response.context[0].get('conversation')
+        self.assertEqual(conversation.name, self.TEST_CONVERSATION_NAME)
+        self.assertEqual([], self.get_api_commands_sent())
+        self.assertContains(response, '>Send CSV via e-mail</button>')
+
+    def test_action_export_user_data_post(self):
         self.setup_conversation()
         pm, poll = self.create_poll(self.conversation, questions=[{
                 'copy': 'question-1',

--- a/go/conversation/templates/conversation/action.html
+++ b/go/conversation/templates/conversation/action.html
@@ -4,7 +4,7 @@
 
 {% block content_actions_right %}
 <div class="pull-right">
-    <button type="submit" name="submit" class="btn btn-primary" value="Save">{{ action.action_display_verb|default:"Save" }}</button>
+    <button type="submit" name="submit" class="btn btn-primary" value="Apply">{{ action.action_display_verb|default:"Save" }}</button>
 </div>
 {% endblock %}
 

--- a/go/conversation/templates/conversation/action.html
+++ b/go/conversation/templates/conversation/action.html
@@ -1,10 +1,10 @@
 {% extends "app.html" %}
 
-{% block content_title %}{{ action_display_name }}{% endblock %}
+{% block content_title %}{{ action.action_display_name }}{% endblock %}
 
 {% block content_actions_right %}
 <div class="pull-right">
-    <button type="submit" name="submit" class="btn btn-primary" value="Save">Save</button>
+    <button type="submit" name="submit" class="btn btn-primary" value="Save">{{ action.action_display_verb|default:"Save" }}</button>
 </div>
 {% endblock %}
 
@@ -39,5 +39,5 @@
 {% block ondomready %}
     $('.actions .right button').on('click', function(e) {
         $('#conversation_action').submit();
-    });    
+    });
 {% endblock %}

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -478,7 +478,7 @@ class ConversationActionView(ConversationTemplateView):
         return self.render_to_response({
             'conversation': conversation,
             'form': form,
-            'action_display_name': self.action.action_display_name,
+            'action': self.action,
         })
 
     @check_action_is_enabled

--- a/go/vumitools/conversation/definition.py
+++ b/go/vumitools/conversation/definition.py
@@ -38,7 +38,10 @@ class ConversationAction(object):
     """
 
     action_name = None
+    # title to display for action
     action_display_name = None
+    # verb phrase describing the action in second person
+    action_display_verb = None
     needs_confirmation = False
 
     # Some actions are only possible under certain conditions.


### PR DESCRIPTION
- From the show page, I click on "write and send bulk message" btn
- I land on the /action/bulk_send page
- I define my message and click 'save'
- Change the wording of the button from 'save' to 'send'

This is requested by Indrani and makes sense to me.

![screen shot 2013-09-19 at 11 40 04 am](https://f.cloud.github.com/assets/1521387/1171809/b459ed9e-210f-11e3-9e16-0fb6358291e4.png)

Also on the /action/download_user_data page which I access by clicking on the 'download user data' button the conversation show page
Change the button text from 'save' to 'download'

![screen shot 2013-09-19 at 11 46 34 am](https://f.cloud.github.com/assets/1521387/1171837/4bf9fd6a-2110-11e3-90a8-987fa2082985.png)
