### PR TITLE
Account change confirmation email not received

### DIFF
--- a/go/account/tests.py
+++ b/go/account/tests.py
@@ -32,9 +32,14 @@ class AccountTestCase(VumiGoDjangoTestCase):
             'existing_password': 'password',
             '_account': True,
             })
+
         token_url = response.context['token_url']
-        self.confirm(token_url)
+
+        [email] = mail.outbox
+        self.assertTrue(token_url in email.body)
+
         # reload from db
+        self.confirm(token_url)
         user = User.objects.get(pk=self.django_user.pk)
         self.assertEqual(user.first_name, 'foo')
         self.assertEqual(user.last_name, 'bar')

--- a/go/account/views.py
+++ b/go/account/views.py
@@ -58,10 +58,13 @@ def details(request):
                     'token_url': token_manager.url_for_token(token),
                     })
 
-                send_mail('Confirm account detail changes',
-                    render_to_string('account/change_account_details_mail.txt',
-                        context), settings.DEFAULT_FROM_EMAIL,
-                        [request.user.email, 'support@vumi.org'])
+                send_mail(
+                    'Vumi Go account detail change confirmation',
+                    render_to_string(
+                        'account/change_account_details_mail.txt',
+                        context),
+                    settings.DEFAULT_FROM_EMAIL,
+                    [request.user.email, 'support@vumi.org'])
 
                 messages.info(request,
                     'Please confirm this change by clicking on the link '


### PR DESCRIPTION
On my account page: https://go.vumi.org/account/details/
I uncheck the box "Receive SMS to confirm start of campaign"
I then click 'save'
I get a notification saying the link has been sent to my email.
However I never receive the email with the confirmation 
