### PR TITLE
For dialogues accept both the number and text response by default

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -12,6 +12,12 @@ function poll_tester(poll) {
     });
 }
 
+function clone(obj) {
+  var dup = {};
+  for (var k in obj) { dup[k] = obj[k]; }
+  return dup;
+}
+
 describe("choice states", function() {
     var tester;
 
@@ -78,6 +84,28 @@ describe("choice states", function() {
             var contact = app.api.find_contact('ussd', '+2731234567');
             assert.equal(contact['extras-message-1'], 'value-2');
         }).done(done, done);
+    });
+
+    describe("if 'accept_labels' is enabled", function() {
+      beforeEach(function() {
+          var poll = clone(dummy_polls.simple_poll);
+          poll.accept_labels = true;
+          tester = poll_tester(poll);
+      });
+
+      it("should accept both label and number based answers", function(done) {
+        var p = tester.check_state({
+            user: {current_state: "choice-1"},
+            helper_metadata: {delivery_class: 'ussd'},
+            content: "Blue",
+            next_state: "end-1",
+            response: (
+                "^Thank you for taking our survey$"
+            ),
+            continue_session: false
+        });
+        p.then(done, done);
+      });
     });
 });
 

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -31,6 +31,10 @@ function DialogueStateCreator() {
                   ? poll.start_state.uuid
                   : null;
 
+                self.accept_labels = 'accept_labels' in poll
+                  ? poll.accept_labels
+                  : true;
+
                 var states = poll.states || [];
                 self.state_creators = {};
                 states.forEach(function(state_description) {
@@ -133,13 +137,16 @@ function DialogueStateCreator() {
                     state_description.store_as,
                     endpoint.value,
                     im
-                )
+                );
                 p.add_callback(function() {
                     done(self.get_next_state(endpoint.uuid));
                 });
             },
             state_description.text,
-            choices
+            choices,
+            null,
+            null,
+            {accept_labels: self.accept_labels}
         );
     };
 


### PR DESCRIPTION
This issue came from Eve, who is using Vumi Go in Tanzania to run Afropinions.

Eve:
- set up a dialogue over SMS
- when she dialed in she was unable to move past the first question

The reason was that she was responding with the actual 'text' answer, and not the number. for e.g. responding 'red', not '1' to the question 'what is your favorite color'.

In the old UI, the user could define the answer choices. In this example they would be '1', 'red', '2', 'blue' etc

In the new dialogue UI, we should accept either the number or the text by default, instead of the current solution, which is to only accept the number.

![screen shot 2013-09-17 at 12 59 57 pm](https://f.cloud.github.com/assets/1521387/1156531/ed358a9c-1f89-11e3-8987-c2d289030ba2.png)
