### PR TITLE
survey app control messages can get stuck.

### DIFF
--- a/go/vumitools/opt_out/models.py
+++ b/go/vumitools/opt_out/models.py
@@ -29,7 +29,7 @@ class OptOutStore(PerAccountStore):
         opt_out_id = self.opt_out_id(addr_type, addr_value)
         opt_out = self.opt_outs(opt_out_id,
                 user_account=self.user_account_key,
-                message=message.get('message_id'))
+                message=unicode(message.get('message_id')))
         yield opt_out.save()
         returnValue(opt_out)
 

--- a/go/vumitools/opt_out/models.py
+++ b/go/vumitools/opt_out/models.py
@@ -45,8 +45,12 @@ class OptOutStore(PerAccountStore):
     def list_opt_outs(self):
         return self.list_keys(self.opt_outs)
 
+    @Manager.calls_manager
     def opt_outs_for_addresses(self, addr_type, addresses):
+        if not addresses:
+            returnValue([])
         keys = ["%s:%s" % (addr_type, address) for address in addresses]
         mr = self.manager.mr_from_keys(self.opt_outs, keys)
         mr.filter_not_found()
-        return mr.get_keys()
+        opt_out_keys = yield mr.get_keys()
+        returnValue(opt_out_keys)

--- a/go/vumitools/opt_out/models.py
+++ b/go/vumitools/opt_out/models.py
@@ -27,9 +27,16 @@ class OptOutStore(PerAccountStore):
     @Manager.calls_manager
     def new_opt_out(self, addr_type, addr_value, message):
         opt_out_id = self.opt_out_id(addr_type, addr_value)
+        message_id = message.get('message_id')
+        if isinstance(message_id, str):
+            # guard against bug-let in vumi messages that causes
+            # message ids to be bytestrings when they're first
+            # created but unicode after being de-serialized from
+            # the wire.
+            message_id = message_id.decode('ascii')
         opt_out = self.opt_outs(opt_out_id,
                 user_account=self.user_account_key,
-                message=unicode(message.get('message_id')))
+                message=message_id)
         yield opt_out.save()
         returnValue(opt_out)
 

--- a/go/vumitools/opt_out/tests/test_models.py
+++ b/go/vumitools/opt_out/tests/test_models.py
@@ -1,0 +1,116 @@
+"""Tests for go.vumitools.opt_out.models."""
+
+from datetime import datetime, timedelta
+
+from twisted.internet.defer import inlineCallbacks
+
+from vumi.message import TransportUserMessage
+
+from go.vumitools.tests.utils import GoTestCase
+from go.vumitools.account import AccountStore
+from go.vumitools.opt_out.models import OptOutStore
+
+
+class TestOptOutStore(GoTestCase):
+
+    use_riak = True
+
+    @inlineCallbacks
+    def setUp(self):
+        super(TestOptOutStore, self).setUp()
+        self.manager = self.get_riak_manager()
+        self.account_store = AccountStore(self.manager)
+        self.account = yield self.mk_user(self, u'user')
+        self.opt_out_store = OptOutStore.from_user_account(self.account)
+
+    def mkmsg_in(self, **kw):
+        # TODO: replace all these copies of mkmsg_in with a single helper
+        opts = {
+            'content': 'hello world', 'to_addr': '12345', 'from_addr': '67890',
+            'transport_name': 'dummy_transport', 'transport_type': 'dummy',
+        }
+        opts.update(kw)
+        msg = TransportUserMessage(**opts)
+        return msg
+
+    def test_setup_proxies(self):
+        self.assertTrue(hasattr(self.opt_out_store, 'opt_outs'))
+        self.assertEqual(self.opt_out_store.opt_outs.bucket, 'optout')
+
+    def test_opt_out_id(self):
+        self.assertEqual(self.opt_out_store.opt_out_id("msisdn", "+1234"),
+                         "msisdn:+1234")
+
+    @inlineCallbacks
+    def test_new_opt_out(self):
+        msg = self.mkmsg_in(content="STOP")
+        opt_out = yield self.opt_out_store.new_opt_out(
+            "msisdn", "+1234", msg)
+        # check opt out is correct
+        self.assertEqual(opt_out.key,
+                         self.opt_out_store.opt_out_id("msisdn", "+1234"))
+        self.assertEqual(opt_out.user_account.key, self.account.key)
+        self.assertEqual(opt_out.message, msg['message_id'])
+        self.assertTrue(datetime.utcnow() - opt_out.created_at
+                        < timedelta(minutes=1))
+        # check that opt out was saved
+        opt_out_2 = yield self.opt_out_store.opt_outs.load(opt_out.key)
+        self.assertEqual(opt_out_2.message, unicode(msg['message_id']))
+
+    @inlineCallbacks
+    def test_get_opt_out(self):
+        msg = self.mkmsg_in()
+        opt_out = yield self.opt_out_store.get_opt_out("msisdn", "+1234")
+        self.assertEqual(opt_out, None)
+        yield self.opt_out_store.new_opt_out("msisdn", "+1234", msg)
+        opt_out = yield self.opt_out_store.get_opt_out("msisdn", "+1234")
+        self.assertEqual(opt_out.message, msg['message_id'])
+
+    @inlineCallbacks
+    def test_delete_opt_out(self):
+        store = self.opt_out_store
+        yield store.new_opt_out(
+            "msisdn", "+1234", self.mkmsg_in())
+        self.assertNotEqual((yield store.get_opt_out("msisdn", "+1234")),
+                            None)
+        yield store.delete_opt_out("msisdn", "+1234")
+        self.assertEqual((yield store.get_opt_out("msisdn", "+1234")),
+                         None)
+
+    @inlineCallbacks
+    def test_delete_opt_out_that_doesnt_exist(self):
+        yield self.opt_out_store.delete_opt_out("msisdn", "+1234")
+
+    @inlineCallbacks
+    def test_list_opt_outs(self):
+        addrs = [("msisdn", str(i)) for i in range(5)]
+        for addr_type, addr in addrs:
+            yield self.opt_out_store.new_opt_out(
+                addr_type, addr, self.mkmsg_in())
+        keys = sorted((yield self.opt_out_store.list_opt_outs()))
+        expected_keys = sorted(self.opt_out_store.opt_out_id(addr_type, addr)
+                               for addr_type, addr in addrs)
+        self.assertEqual(keys, expected_keys)
+
+    @inlineCallbacks
+    def test_list_opt_outs_empty(self):
+        opt_outs = yield self.opt_out_store.list_opt_outs()
+        self.assertEqual(opt_outs, [])
+
+    @inlineCallbacks
+    def test_opt_outs_for_addresses(self):
+        addrs = [("msisdn", str(i)) for i in range(5)]
+        for addr_type, addr in addrs:
+            yield self.opt_out_store.new_opt_out(
+                addr_type, addr, self.mkmsg_in())
+        self.assertEqual(
+            sorted((yield self.opt_out_store.opt_outs_for_addresses(
+                "msisdn", ["0", "2", "3"]))),
+            [self.opt_out_store.opt_out_id("msisdn", str(i))
+             for i in (0, 2, 3)])
+
+    @inlineCallbacks
+    def test_opt_outs_for_addresses_with_no_addresses(self):
+        opt_outs = yield self.opt_out_store.opt_outs_for_addresses(
+            "msisdn", [])
+        self.assertEqual(opt_outs, [])


### PR DESCRIPTION
Something's got Riak complaining about inputs in a M/R all of a sudden.

At the moment 3 of the 4 workers have a control message that's stuck because of this.

```
2013-09-19 21:50:07+0000 [HTTP11ClientProtocol,client] Unhandled error in Deferred:
2013-09-19 21:50:07+0000 [HTTP11ClientProtocol,client] Unhandled Error
        Traceback (most recent call last):
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 397, in errback
            self._startRunCallbacks(fail)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 464, in _startRunCallbacks
            self._runCallbacks()
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 551, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1101, in gotResult
            _inlineCallbacks(r, g, deferred)
        --- <exception caught here> ---
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/service.py", line 283, in read_messages
            yield self.consume(message)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/service.py", line 302, in consume
            message.content.body))
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/mnt/praekelt/vumi-go/go/apps/surveys/vumi_app.py", line 121, in process_command_send_survey
            for contact in (yield contacts):
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/mnt/praekelt/vumi-go/go/vumitools/conversation/utils.py", line 497, in _filter_opted_out_contacts
            address_type, addresses)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1043, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 382, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/riakasaurus/mapreduce.py", line 234, in run
            result = yield t.mapred(self._inputs, query, timeout)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1045, in _inlineCallbacks
            result = g.send(result)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/riakasaurus/transport/http_transport.py", line 479, in mapred
              (repr(response[0]),repr(response[1])))
          exceptions.Exception: Error running MapReduce operation. Headers: {'date': 'Thu, 19 Sep 2013 21:50:07 GMT', 'content-type': 'text/plain', 'http_code': 400, 'server': 'MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)'} Body: 'An error occurred parsing the "inputs" field.\n"No inputs were given.\\n"'
```
