### PR TITLE
Jsbox is not happy when there's no Javascript to run.

### DIFF
--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -112,6 +112,13 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
         yield self.dispatch_to_conv(msg, conversation)
 
     @inlineCallbacks
+    def test_user_message_no_javascript(self):
+        conversation = yield self.setup_conversation(config={})
+        yield self.start_conversation(conversation)
+        msg = self.mkmsg_in()
+        yield self.dispatch_to_conv(msg, conversation)
+
+    @inlineCallbacks
     def test_user_message_sandbox_id(self):
         conversation = yield self.setup_conversation(
             config=self.mk_conv_config('on_inbound_message'))

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -116,7 +116,10 @@ class JsBoxApplicationTestCase(AppWorkerTestCase):
         conversation = yield self.setup_conversation(config={})
         yield self.start_conversation(conversation)
         msg = self.mkmsg_in()
-        yield self.dispatch_to_conv(msg, conversation)
+        with LogCatcher() as lc:
+            yield self.dispatch_to_conv(msg, conversation)
+            self.assertTrue("No JS for conversation: %s" % (conversation.key,)
+                            in lc.messages())
 
     @inlineCallbacks
     def test_user_message_sandbox_id(self):


### PR DESCRIPTION
```
2013-10-03 12:47:02+0000 [HTTP11ClientProtocol,client] Unhandled error in Deferred:
2013-10-03 12:47:02+0000 [HTTP11ClientProtocol,client] Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1070, in _inlineCallbacks
            result = g.send(result)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/application/sandbox.py", line 854, in process_message_in_sandbox
            status = yield self._process_in_sandbox(sandbox_protocol, sandbox_init)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/application/sandbox.py", line 843, in _process_in_sandbox
            d.addCallbacks(on_start, log.error)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 293, in addCallbacks
            self._runCallbacks()
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 575, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/application/sandbox.py", line 836, in on_start
            sandbox_protocol.api.sandbox_init()
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/application/sandbox.py", line 624, in sandbox_init
            resource.sandbox_init(self)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/application/sandbox.py", line 412, in sandbox_init
            javascript = self.app_worker.javascript_for_api(api)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/application/sandbox.py", line 966, in javascript_for_api
            return api.config.javascript
          File "/var/praekelt/vumi-go/go/apps/jsbox/vumi_app.py", line 37, in javascript
            return self.jsbox['javascript']
        exceptions.TypeError: 'NoneType' object has no attribute '__getitem__'

```
