### PR TITLE
Run Javascript tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+node_js:
+  - "0.10"
 services:
   - riak
   - redis-server
@@ -14,7 +16,9 @@ install:
   - "pip install -r requirements.pip --use-mirrors"
   - "pip install -r requirements-pytest.pip --use-mirrors"
   - "pip install coveralls --use-mirrors"
+  - "npm install"
 script:
   - VUMITEST_REDIS_DB=1 ./run-tests.sh
+  - grunt test
 after_success:
   - coveralls

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,6 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('test:client', [
-    'bower',
     'jst:templates',
     'karma:dev'
   ]);

--- a/js_paths.yml
+++ b/js_paths.yml
@@ -96,9 +96,9 @@ tests:
       - 'go/apps/**/test_vumi_app.js'
   client:
     vendor:
-      - 'bower_components/chai/chai.js'
-      - 'bower_components/sinon/index.js'
-      - 'bower_components/jquery-simulate/jquery.simulate.js'
+      - 'go/base/static/vendor/chai/js/chai.js'
+      - 'go/base/static/vendor/sinon/js/index.js'
+      - 'go/base/static/vendor/jquery-simulate/js/jquery.simulate.js'
     spec:
       - 'go/base/static/js/test/testHelpers/testHelpers.js'
       - 'go/base/static/js/test/testHelpers/testHelpers.test.js'


### PR DESCRIPTION
Currently the Vumi Go Javascript tests aren't run by Travis. See https://github.com/praekelt/go-nike-ghr/blob/develop/.travis.yml for how we might start hooking this up as an additional set of tests for Travis to run.
