### PR TITLE
Update metric name construction for app workers

### DIFF
--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -231,8 +231,8 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         yield self.dispatch_command(
             'collect_metrics', conversation_key=conv.key,
             user_account_key=self.user_account.key)
-        metrics = self.poll_metrics('%s.%s' % (self.user_account.key,
-                                               conv.key))
+        metrics = self.poll_metrics(
+            '%s.conversations.%s' % (self.user_account.key, conv.key))
         self.assertEqual({
                 u'messages_sent': [2],
                 u'messages_received': [1],

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -330,11 +330,11 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
         url = '%s/%s/metrics.json' % (self.url, self.conversation.key)
         response = yield http_request_full(
             url, json.dumps(metric_data), self.auth_headers, method='PUT')
-
+ 
         self.assertEqual(response.code, http.OK)
 
         [metric1, metric2] = self.app.metrics._metrics
-        self.assertEqual(metric1.name, '%s%s.%s.vumi.test.v1' % (
+        self.assertEqual(metric1.name, '%s%s.stores.%s.vumi.test.v1' % (
             self.config['metrics_prefix'], self.account.key,
             'metrics_store'))
         self.assertEqual(metric1.aggs, ('sum',))

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -291,8 +291,8 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         yield self.dispatch_command(
             'collect_metrics', conversation_key=conv.key,
             user_account_key=self.user_account.key)
-        metrics = self.poll_metrics('%s.%s' % (self.user_account.key,
-                                               conv.key))
+        metrics = self.poll_metrics(
+            '%s.conversations.%s' % (self.user_account.key, conv.key))
         self.assertEqual({
                 u'messages_sent': [0],
                 u'messages_received': [0],

--- a/go/apps/subscription/tests/test_vumi_app.py
+++ b/go/apps/subscription/tests/test_vumi_app.py
@@ -115,8 +115,8 @@ class TestSubscriptionApplication(AppWorkerTestCase):
         yield self.dispatch_command(
             'collect_metrics', conversation_key=self.conv.key,
             user_account_key=self.user_account.key)
-        metrics = self.poll_metrics('%s.%s' % (self.user_account.key,
-                                               self.conv.key))
+        metrics = self.poll_metrics(
+            '%s.conversations.%s' % (self.user_account.key, self.conv.key))
         self.assertEqual({
                 u'foo.subscribed': [2],
                 u'foo.unsubscribed': [0],

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -290,13 +290,13 @@ class GoWorkerMixin(object):
         metric.set(value)
 
     def publish_conversation_metric(self, conversation, name, value, agg=None):
-        name = "%s.%s.%s" % (
+        name = "%s.conversations.%s.%s" % (
             conversation.user_account.key, conversation.key, name)
         self.publish_metric(name, value, agg)
 
     def publish_account_metric(self, user_account_key, store, name, value,
                                agg=None):
-        name = "%s.%s.%s" % (user_account_key, store, name)
+        name = "%s.stores.%s.%s" % (user_account_key, store, name)
         self.publish_metric(name, value, agg)
 
     @inlineCallbacks


### PR DESCRIPTION
Currently, converstation metrics are constructed in the form `<prefix>.<account_key>.<conversation_key>.<metric_name>.<agg_method>`, and account metrics in the form  `<prefix>.<account_key>.<store_name>.<metric_name>.<agg_method>`. The plan is to change these to  `<prefix>.<account_key>.conversations.<conversation_key>.<metric_name>.<agg_method>` and `<prefix>.<account_key>.stores.<store_name>.<metric_name>.<agg_method>` respectively.
