### PR TITLE
Allow Go tests to run against a variety of databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - "pip install overalls"
   - "npm install"
 before_script:
-  - "psql -c 'create user go with createdb with password "go";' -U postgres"
+  - "psql -c 'create user go with createdb with password \"go\";' -U postgres"
   - "psql -c 'create database go owner go;' -U postgres"
   - "export PYTHONPATH=."
   - "django-admin.py syncdb --migrate --noinput --settings=go.testsettings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - "pip install overalls"
   - "npm install"
 before_script:
-  - "psql -c 'create user go with createdb password \"go\";' -U postgres"
+  - "psql -c \"create user go with createdb password 'go';\" -U postgres"
   - "psql -c 'create database go owner go;' -U postgres"
   - "export PYTHONPATH=."
   - "django-admin.py syncdb --migrate --noinput --settings=go.testsettings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - "pip install overalls"
   - "npm install"
 before_script:
-  - "psql -c 'create user go with createdb with password \"go\";' -U postgres"
+  - "psql -c 'create user go with createdb password \"go\";' -U postgres"
   - "psql -c 'create database go owner go;' -U postgres"
   - "export PYTHONPATH=."
   - "django-admin.py syncdb --migrate --noinput --settings=go.testsettings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
 node_js:
   - "0.10"
+env:
+  - VUMITEST_REDIS_DB=1 VUMIGO_TEST_DB=postgres
 services:
   - riak
   - postgresql
@@ -24,7 +26,7 @@ before_script:
   - "export PYTHONPATH=."
   - "django-admin.py syncdb --migrate --noinput --settings=go.testsettings"
 script:
-  - VUMITEST_REDIS_DB=1 VUMIGO_TEST_DB=postgres ./run-tests.sh
+  - ./run-tests.sh
   - grunt test
 after_script:
   - "psql -c 'drop database go;' -U postgres"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ install:
   - "pip install overalls"
   - "npm install"
 before_script:
-  - "psql -c 'create user go with createdb;' -U postgres"
+  - "psql -c 'create user go with createdb with password "go";' -U postgres"
   - "psql -c 'create database go owner go;' -U postgres"
   - "export PYTHONPATH=."
   - "django-admin.py syncdb --migrate --noinput --settings=go.testsettings"
 script:
-  - VUMITEST_REDIS_DB=1 ./run-tests.sh
+  - VUMITEST_REDIS_DB=1 VUMIGO_TEST_DB=postgres ./run-tests.sh
   - grunt test
 after_script:
   - "psql -c 'drop database go;' -U postgres"

--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -13,6 +13,8 @@ ENDPOINT_DESCRIPTION_STRING = getattr(
 def get_connection_string():
     """Return the database connection string"""
     db = settings.DATABASES['default']
+    if 'postgres' not in db['ENGINE']:
+        raise ValueError("Billing API only supports PostGreSQL.")
     return "host='%s' dbname='%s' user='%s' password='%s'" \
         % (db.get('HOST', 'localhost'), db.get('NAME'), db.get('USER'),
            db.get('PASSWORD'))

--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -10,6 +10,18 @@ from go.billing import api
 from go.billing.utils import DummySite, DictRowConnectionPool
 
 
+DB_SUPPORTED = False
+try:
+    app_settings.get_connection_string()
+    DB_SUPPORTED = True
+except ValueError:
+    pass
+
+skipif_unsupported_db = pytest.mark.skipif(
+    "True" if not DB_SUPPORTED else "False",
+    reason="Billing API requires PostGreSQL")
+
+
 class UserTestCase(unittest.TestCase):
 
     @pytest.mark.django_db
@@ -27,6 +39,7 @@ class UserTestCase(unittest.TestCase):
     def tearDown(self):
         self.connection_pool.close()
 
+    @skipif_unsupported_db
     @pytest.mark.django_db
     @defer.inlineCallbacks
     def runTest(self):
@@ -79,6 +92,7 @@ class AccountTestCase(unittest.TestCase):
     def tearDown(self):
         self.connection_pool.close()
 
+    @skipif_unsupported_db
     @pytest.mark.django_db
     @defer.inlineCallbacks
     def runTest(self):
@@ -171,6 +185,7 @@ class CostTestCase(unittest.TestCase):
     def tearDown(self):
         self.connection_pool.close()
 
+    @skipif_unsupported_db
     @pytest.mark.django_db
     @defer.inlineCallbacks
     def runTest(self):
@@ -291,6 +306,7 @@ class TransactionTestCase(unittest.TestCase):
     def tearDown(self):
         self.connection_pool.close()
 
+    @skipif_unsupported_db
     @pytest.mark.django_db
     @defer.inlineCallbacks
     def runTest(self):

--- a/go/testsettings.py
+++ b/go/testsettings.py
@@ -10,24 +10,42 @@ VUMI_API_CONFIG['redis_manager'] = {
     'FAKE_REDIS': 'sure',
 }
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'go',
-        'USER': 'go',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
-    }
-}
+# Setup test database
 
-if os.environ.get('VUMIGO_FAST_TESTS'):
+VUMIGO_TEST_DB = os.environ.get('VUMIGO_TEST_DB', 'sqlite')
+
+if VUMIGO_TEST_DB == "sqlite":
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'go.db',
+        }
+    }
+
+elif VUMIGO_TEST_DB == "postgres":
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'go',
+            'USER': 'go',
+            'PASSWORD': 'go',
+            'HOST': 'localhost',
+        }
+    }
+
+elif VUMIGO_TEST_DB == "memory":
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': ':memory:',
         }
     }
+
+else:
+    raise ValueError("Invalid value %r for VUMIGO_TEST_DB"
+                     % VUMIGO_TEST_DB)
+
+del VUMIGO_TEST_DB
 
 # celery likes to eagerly close and restart database connections
 # which combines badly with tests run inside transactions. If this


### PR DESCRIPTION
It would be nice to be able to run tests against of a variety of databases without having to edit `go.testsettings`. This will allow us to run tests against SQLite on local machines and against PostGreSQL on Travis.
