### PR TITLE
Conversation and campaign metrics

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -413,3 +413,5 @@ PIPELINE_JS = {
 }
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
+
+GO_METRICS_PREFIX = 'go.'

--- a/go/vumitools/metrics.py
+++ b/go/vumitools/metrics.py
@@ -1,0 +1,65 @@
+from django.conf import settings
+from twisted.internet.defer import inlineCallbacks
+
+from vumi.blinkenlights.metrics import Metric
+
+
+class GoMetric(object):
+    AGGREGATORS = None
+
+    def __init__(self, name, aggregators=None):
+        if aggregators is None:
+            aggregators = self.AGGREGATORS
+        self.metric = Metric(name, aggregators)
+
+    def get_full_name(self):
+        """
+        This is for constructing the full, prefixed metric name in django land
+        if a manager is not available.
+        """
+        return settings.GO_METRICS_PREFIX + self.metric.name
+
+    def get_value(self):
+        raise NotImplementedError(
+            "ConversationMetric.value() needs to be overriden")
+
+    @inlineCallbacks
+    def oneshot(self, manager, value=None):
+        if value is None:
+            value = self.get_value()
+        manager.oneshot(self.metric, (yield value))
+
+
+class ConversationMetric(GoMetric):
+    METRIC_NAME = None
+
+    def __init__(self, conv):
+        super(ConversationMetric, self).__init__(self.make_name(conv))
+        self.conv = conv
+
+    @classmethod
+    def make_name(cls, conv):
+        return "campaigns.%s.conversations.%s.%s" % (
+            conv.user_account.key, conv.key, cls.METRIC_NAME)
+
+
+class AccountMetric(GoMetric):
+    def __init__(self, account, store_name, metric_name, aggregators=None):
+        name = self.make_name(account, store_name, metric_name)
+        super(AccountMetric, self).__init__(name, aggregators)
+        self.account = account
+
+    @classmethod
+    def make_name(self, account, store_name, metric_name):
+        return "campaigns.%s.stores.%s.%s" % (
+            account.key, store_name, metric_name)
+
+
+class DjangoMetric(GoMetric):
+    def __init__(self, metric_name, aggregators=None):
+        name = self.make_name(metric_name)
+        super(DjangoMetric, self).__init__(name, aggregators)
+
+    @classmethod
+    def make_name(self, metric_name):
+        return "django.%s" % (metric_name,)

--- a/go/vumitools/metrics.py
+++ b/go/vumitools/metrics.py
@@ -55,7 +55,7 @@ class DjangoMetric(GoMetric):
     def make_name(self, metric_name):
         return "django.%s" % (metric_name,)
 
-    def oneshot(self, connection=None, value=None):
+    def oneshot(self, value=None, connection=None):
         """
         Does a once-off publish for the metric using an `AmqpConnection`.
         """

--- a/go/vumitools/metrics.py
+++ b/go/vumitools/metrics.py
@@ -101,13 +101,11 @@ class ConversationMetric(TxMetric):
 
 
 class AccountMetric(TxMetric):
-    def __init__(self, account, store_name, metric_name, aggregators=None):
-        name = self.make_name(account,
-            store_name, metric_name)
+    def __init__(self, account_key, store_name, metric_name, aggregators=None):
+        name = self.make_name(account_key, store_name, metric_name)
         super(AccountMetric, self).__init__(name, aggregators)
-        self.account = account
 
     @classmethod
-    def make_name(self, account, store_name, metric_name):
+    def make_name(self, account_key, store_name, metric_name):
         return "campaigns.%s.stores.%s.%s" % (
-            account.key, store_name, metric_name)
+            account_key, store_name, metric_name)

--- a/go/vumitools/tests/test_metrics.py
+++ b/go/vumitools/tests/test_metrics.py
@@ -232,7 +232,7 @@ class TestAccountMetric(TxMetricTestBase):
     @inlineCallbacks
     def setUp(self):
         yield super(TestAccountMetric, self).setUp()
-        self.metric = AccountMetric(self.user, 'store-1', 'susan')
+        self.metric = AccountMetric(self.user.key, 'store-1', 'susan')
 
     def test_name_construction(self):
         self.assertEqual(

--- a/go/vumitools/tests/test_metrics.py
+++ b/go/vumitools/tests/test_metrics.py
@@ -123,7 +123,7 @@ class TestDjangoMetric(VumiGoDjangoTestCase):
     def test_oneshot_with_explicitly_given_connection(self):
         self.metric.set_value(23)
         self.assertEqual(self.msgs, [])
-        self.metric.oneshot(self.make_connection())
+        self.metric.oneshot(connection=self.make_connection())
 
         [msg] = self.msgs
         self.assertEqual(

--- a/go/vumitools/tests/test_metrics.py
+++ b/go/vumitools/tests/test_metrics.py
@@ -1,21 +1,41 @@
 import time
 
+from mock import patch
 from twisted.internet.defer import succeed, inlineCallbacks
 
 from vumi.worker import BaseWorker
 from vumi.blinkenlights.metrics import LAST
 
 from go.vumitools.metrics import (
-    GoMetric, ConversationMetric, AccountMetric, DjangoMetric)
-from go.vumitools.tests.utils import GoWorkerTestCase
+    GoMetric, DjangoMetric, TxMetric, ConversationMetric, AccountMetric)
 from go.vumitools.app_worker import GoWorkerMixin, GoWorkerConfigMixin
+from go.vumitools.tests.utils import GoWorkerTestCase, GoTestCase
+from go.base.tests.utils import VumiGoDjangoTestCase
 
 
 class ToyGoMetric(GoMetric):
+    pass
+
+
+class ToyTxMetric(TxMetric):
     AGGREGATORS = [LAST]
 
     def __init__(self, *a, **kw):
-        super(ToyGoMetric, self).__init__(*a, **kw)
+        super(ToyTxMetric, self).__init__(*a, **kw)
+        self.value = None
+
+    def set_value(self, value):
+        self.value = value
+
+    def get_value(self):
+        return self.value
+
+
+class ToyDjangoMetric(DjangoMetric):
+    AGGREGATORS = [LAST]
+
+    def __init__(self, *a, **kw):
+        super(ToyDjangoMetric, self).__init__(*a, **kw)
         self.value = None
 
     def set_value(self, value):
@@ -46,38 +66,84 @@ class ToyWorker(BaseWorker, GoWorkerMixin):
         pass
 
 
-class TestGoMetricBase(GoWorkerTestCase):
+class TestGoMetric(GoTestCase):
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestGoMetric, self).setUp()
+        self.metric = ToyGoMetric('some.random.metric')
+
+    def test_full_name_retrieval(self):
+        self.assertEqual(self.metric.get_full_name(), 'go.some.random.metric')
+
+
+class TestDjangoMetric(VumiGoDjangoTestCase):
+    def setUp(self):
+        super(TestDjangoMetric, self).setUp()
+        self.metric = ToyDjangoMetric('luke')
+
+        self.time_patcher = patch('time.time')
+        mock_time = self.time_patcher.start()
+        mock_time.side_effect = lambda: 1985
+
+        self.msgs = []
+        self.publish_patcher = patch(
+            'go.base.amqp.connection.publish_metric_message')
+        mock_publish = self.publish_patcher.start()
+        mock_publish.side_effect = lambda msg: self.msgs.append(msg)
+
+    def tearDown(self):
+        super(TestDjangoMetric, self).tearDown()
+        self.time_patcher.stop()
+        self.publish_patcher.stop()
+
+    def test_name_construction(self):
+        self.assertEqual(
+            self.metric.get_full_name(),
+            u'go.django.luke')
+
+    def test_oneshot(self):
+        self.metric.set_value(23)
+        self.assertEqual(self.msgs, [])
+        self.metric.oneshot()
+
+        [msg] = self.msgs
+        self.assertEqual(
+            msg['datapoints'],
+            [('go.django.luke', ('last',), [(1985, 23)])])
+
+
+class TxMetricTestBase(GoWorkerTestCase):
     worker_class = ToyWorker
 
     @inlineCallbacks
     def setUp(self):
-        super(TestGoMetricBase, self).setUp()
+        super(TxMetricTestBase, self).setUp()
         worker_config = self.mk_config({'metrics_prefix': 'go.'})
 
         self.worker = yield self.get_worker(worker_config, start=True)
+        self.metrics_manager = self.worker.metrics
         self.vumi_api = self.worker.vumi_api
 
         self.user = yield self.mk_user(self.vumi_api, u'testuser')
         self.user_api = self.vumi_api.get_user_api(self.user.key)
-
-
-class TestGoMetric(TestGoMetricBase):
-    @inlineCallbacks
-    def setUp(self):
-        yield super(TestGoMetric, self).setUp()
-
-        self.metrics_manager = self.worker.metrics
-        self.metric = ToyGoMetric('some.random.metric')
 
         self.patch(time, 'time', lambda: 1985)
 
         self.msgs = []
         self.patch(
             self.metrics_manager,
-            'publish_message', lambda msg: self.msgs.append(msg))
+            'publish_message',
+            lambda msg: self.msgs.append(msg))
 
     def publish_metrics(self):
         self.metrics_manager._publish_metrics()
+
+
+class TestTxMetric(TxMetricTestBase):
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestTxMetric, self).setUp()
+        self.metric = ToyTxMetric('some.random.metric')
 
     def test_oneshot(self):
         self.metric.set_value(23)
@@ -117,11 +183,8 @@ class TestGoMetric(TestGoMetricBase):
             msg['datapoints'],
             [('go.some.random.metric', ('last',), [(1985, 9)])])
 
-    def test_full_name_retrieval(self):
-        self.assertEqual(self.metric.get_full_name(), 'go.some.random.metric')
 
-
-class TestConversationMetric(TestGoMetricBase):
+class TestConversationMetric(TxMetricTestBase):
     @inlineCallbacks
     def setUp(self):
         yield super(TestConversationMetric, self).setUp()
@@ -137,7 +200,7 @@ class TestConversationMetric(TestGoMetricBase):
             'go.campaigns.test-0-user.conversations.%s.dave' % self.conv.key)
 
 
-class TestAccountMetric(TestGoMetricBase):
+class TestAccountMetric(TxMetricTestBase):
     @inlineCallbacks
     def setUp(self):
         yield super(TestAccountMetric, self).setUp()
@@ -147,15 +210,3 @@ class TestAccountMetric(TestGoMetricBase):
         self.assertEqual(
             self.metric.get_full_name(),
             u'go.campaigns.test-0-user.stores.store-1.susan')
-
-
-class TestDjangoMetric(TestGoMetricBase):
-    @inlineCallbacks
-    def setUp(self):
-        yield super(TestDjangoMetric, self).setUp()
-        self.metric = DjangoMetric('luke')
-
-    def test_name_construction(self):
-        self.assertEqual(
-            self.metric.get_full_name(),
-            u'go.django.luke')

--- a/go/vumitools/tests/test_metrics.py
+++ b/go/vumitools/tests/test_metrics.py
@@ -131,9 +131,8 @@ class TestDjangoMetric(VumiGoDjangoTestCase):
             [('go.django.luke', ('last',), [(1985, 23)])])
 
     def test_oneshot_with_explicitly_given_value(self):
-        self.metric.set_value(22)
         self.assertEqual(self.msgs, [])
-        self.metric.oneshot()
+        self.metric.oneshot(22)
 
         [msg] = self.msgs
         self.assertEqual(

--- a/go/vumitools/tests/test_metrics.py
+++ b/go/vumitools/tests/test_metrics.py
@@ -1,0 +1,161 @@
+import time
+
+from twisted.internet.defer import succeed, inlineCallbacks
+
+from vumi.worker import BaseWorker
+from vumi.blinkenlights.metrics import LAST
+
+from go.vumitools.metrics import (
+    GoMetric, ConversationMetric, AccountMetric, DjangoMetric)
+from go.vumitools.tests.utils import GoWorkerTestCase
+from go.vumitools.app_worker import GoWorkerMixin, GoWorkerConfigMixin
+
+
+class ToyGoMetric(GoMetric):
+    AGGREGATORS = [LAST]
+
+    def __init__(self, *a, **kw):
+        super(ToyGoMetric, self).__init__(*a, **kw)
+        self.value = None
+
+    def set_value(self, value):
+        self.value = value
+
+    def get_value(self):
+        return self.value
+
+
+class ToyWorkerConfig(BaseWorker.CONFIG_CLASS, GoWorkerConfigMixin):
+    pass
+
+
+class ToyConversationMetric(ConversationMetric):
+    METRIC_NAME = 'dave'
+
+
+class ToyWorker(BaseWorker, GoWorkerMixin):
+    CONFIG_CLASS = ToyWorkerConfig
+
+    def setup_worker(self):
+        return self._go_setup_worker()
+
+    def teardown_worker(self):
+        return self._go_teardown_worker()
+
+    def setup_connectors(self):
+        pass
+
+
+class TestGoMetricBase(GoWorkerTestCase):
+    worker_class = ToyWorker
+
+    @inlineCallbacks
+    def setUp(self):
+        super(TestGoMetricBase, self).setUp()
+        worker_config = self.mk_config({'metrics_prefix': 'go.'})
+
+        self.worker = yield self.get_worker(worker_config, start=True)
+        self.vumi_api = self.worker.vumi_api
+
+        self.user = yield self.mk_user(self.vumi_api, u'testuser')
+        self.user_api = self.vumi_api.get_user_api(self.user.key)
+
+
+class TestGoMetric(TestGoMetricBase):
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestGoMetric, self).setUp()
+
+        self.metrics_manager = self.worker.metrics
+        self.metric = ToyGoMetric('some.random.metric')
+
+        self.patch(time, 'time', lambda: 1985)
+
+        self.msgs = []
+        self.patch(
+            self.metrics_manager,
+            'publish_message', lambda msg: self.msgs.append(msg))
+
+    def publish_metrics(self):
+        self.metrics_manager._publish_metrics()
+
+    def test_oneshot(self):
+        self.metric.set_value(23)
+        self.metric.oneshot(self.metrics_manager)
+        self.assertEqual(self.msgs, [])
+
+        self.publish_metrics()
+
+        [msg] = self.msgs
+        self.assertEqual(
+            msg['datapoints'],
+            [('go.some.random.metric', ('last',), [(1985, 23)])])
+
+    @inlineCallbacks
+    def test_oneshot_for_deferred_values(self):
+        self.metric.set_value(succeed(42))
+        yield self.metric.oneshot(self.metrics_manager)
+
+        self.assertEqual(self.msgs, [])
+
+        self.publish_metrics()
+
+        [msg] = self.msgs
+        self.assertEqual(
+            msg['datapoints'],
+            [('go.some.random.metric', ('last',), [(1985, 42)])])
+
+    def test_oneshot_for_explicitly_given_values(self):
+        self.metric.oneshot(self.metrics_manager, 9)
+
+        self.assertEqual(self.msgs, [])
+
+        self.publish_metrics()
+
+        [msg] = self.msgs
+        self.assertEqual(
+            msg['datapoints'],
+            [('go.some.random.metric', ('last',), [(1985, 9)])])
+
+    def test_full_name_retrieval(self):
+        self.assertEqual(self.metric.get_full_name(), 'go.some.random.metric')
+
+
+class TestConversationMetric(TestGoMetricBase):
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestConversationMetric, self).setUp()
+
+        self.conv = yield self.create_conversation(
+            conversation_type=u'some_conversation')
+
+        self.metric = ToyConversationMetric(self.conv)
+
+    def test_name_construction(self):
+        self.assertEqual(
+            self.metric.get_full_name(),
+            'go.campaigns.test-0-user.conversations.%s.dave' % self.conv.key)
+
+
+class TestAccountMetric(TestGoMetricBase):
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestAccountMetric, self).setUp()
+        self.metric = AccountMetric(self.user, 'store-1', 'susan')
+
+    def test_name_construction(self):
+        self.assertEqual(
+            self.metric.get_full_name(),
+            u'go.campaigns.test-0-user.stores.store-1.susan')
+
+
+class TestDjangoMetric(TestGoMetricBase):
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestDjangoMetric, self).setUp()
+        self.metric = DjangoMetric('luke')
+
+    def test_name_construction(self):
+        self.assertEqual(
+            self.metric.get_full_name(),
+            u'go.django.luke')


### PR DESCRIPTION
The aim of this ticket is to flesh out the metric infrastructure we need for #750. Once a PR is attached to this ticket and landed, #750 will use the added infrastructure as the new way of collecting and publishing metrics.
