### PR TITLE
Use new metric infrastructure for metric publishing

### DIFF
--- a/go/apps/bulk_message/tests/test_vumi_app.py
+++ b/go/apps/bulk_message/tests/test_vumi_app.py
@@ -224,12 +224,13 @@ class TestBulkMessageApplication(AppWorkerTestCase):
         yield self.dispatch_command(
             'collect_metrics', conversation_key=conv.key,
             user_account_key=self.user_account.key)
-        metrics = self.poll_metrics(
-            '%s.conversations.%s' % (self.user_account.key, conv.key))
-        self.assertEqual({
-                u'messages_sent': [2],
-                u'messages_received': [1],
-                }, metrics)
+
+        prefix = "campaigns.test-0-user.conversations.%s" % conv.key
+
+        self.assertEqual(
+            self.get_published_metrics(self.app),
+            [("%s.messages_sent" % prefix, 2),
+             ("%s.messages_received" % prefix, 1)])
 
     @inlineCallbacks
     def test_reconcile_cache(self):

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -330,11 +330,12 @@ class StreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
         self.assertEqual(response.code, http.OK)
 
-        [metric1, metric2] = self.app.metrics._metrics
+        prefix = "campaigns.test-0-user.stores.metrics_store"
+
         self.assertEqual(
-            metric1.name,
-            '%s.stores.%s.vumi.test.v1' % (self.account.key, 'metrics_store'))
-        self.assertEqual(metric1.aggs, ('sum',))
+            self.get_published_metrics(self.app),
+            [("%s.vumi.test.v1" % prefix, 1234),
+             ("%s.vumi.test.v2" % prefix, 3456)])
 
     @inlineCallbacks
     def test_concurrency_limits(self):

--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -291,9 +291,10 @@ class TestSequentialSendApplication(AppWorkerTestCase):
         yield self.dispatch_command(
             'collect_metrics', conversation_key=conv.key,
             user_account_key=self.user_account.key)
-        metrics = self.poll_metrics(
-            '%s.conversations.%s' % (self.user_account.key, conv.key))
-        self.assertEqual({
-                u'messages_sent': [0],
-                u'messages_received': [0],
-                }, metrics)
+
+        prefix = "campaigns.test-0-user.conversations.%s" % conv.key
+
+        self.assertEqual(
+            self.get_published_metrics(self.app),
+            [("%s.messages_sent" % prefix, 0),
+             ("%s.messages_received" % prefix, 0)])

--- a/go/apps/subscription/tests/test_vumi_app.py
+++ b/go/apps/subscription/tests/test_vumi_app.py
@@ -117,13 +117,14 @@ class TestSubscriptionApplication(AppWorkerTestCase):
         yield self.dispatch_command(
             'collect_metrics', conversation_key=self.conv.key,
             user_account_key=self.user_account.key)
-        metrics = self.poll_metrics(
-            '%s.conversations.%s' % (self.user_account.key, self.conv.key))
-        self.assertEqual({
-                u'foo.subscribed': [2],
-                u'foo.unsubscribed': [0],
-                u'bar.subscribed': [1],
-                u'bar.unsubscribed': [2],
-                u'messages_sent': [0],
-                u'messages_received': [0],
-                }, metrics)
+
+        prefix = "campaigns.test-0-user.conversations.%s" % self.conv.key
+
+        self.assertEqual(
+            self.get_published_metrics(self.app),
+            [("%s.foo.subscribed" % prefix, 2),
+             ("%s.foo.unsubscribed" % prefix, 0),
+             ("%s.bar.subscribed" % prefix, 1),
+             ("%s.bar.unsubscribed" % prefix, 2),
+             ("%s.messages_sent" % prefix, 0),
+             ("%s.messages_received" % prefix, 0)])

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -49,6 +49,8 @@ class ResponseTimeMiddleware(object):
             metric = self.metric_from_request(request)
             metric.oneshot(response_time)
         except AttributeError, e:
+            # For cases where our request object was not processed and given a
+            # `start_time` attribute
             logger.exception(e)
         except Resolver404:
             # Ignoring the Resolver404 as that just means we've not found a

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -42,10 +42,10 @@ class ResponseTimeMiddleware(object):
         request.start_time = time.time()
 
     def process_response(self, request, response):
-        response_time = request.start_time - time.time()
-        response['X-Response-Time'] = response_time
-
         try:
+            response_time = request.start_time - time.time()
+            response['X-Response-Time'] = response_time
+
             metric = self.metric_from_request(request)
             metric.oneshot(response_time)
         except AttributeError, e:

--- a/go/base/middleware.py
+++ b/go/base/middleware.py
@@ -2,13 +2,10 @@ import time
 import logging
 
 from django.core.urlresolvers import resolve, Resolver404
-from django.conf import settings
 
 from go.base.utils import vumi_api_for_user
-from go.base.amqp import connection
+from go.vumitools.metrics import DjangoMetric
 from go.api.go_api.session_manager import SessionManager
-
-from vumi.blinkenlights.metrics import AVG
 
 logger = logging.getLogger(__name__)
 
@@ -34,21 +31,23 @@ class ResponseTimeMiddleware(object):
     It sets an X-Response-Time HTTP header which can be useful for debugging
     or logging slow resources upstream.
     """
-    def __init__(self):
-        self.metrics_prefix = getattr(settings, 'METRICS_PREFIX', 'go.django.')
+    @classmethod
+    def metric_from_request(cls, request):
+        func = resolve(request.path)[0]
+        metric_name = '%s.%s.%s' % (
+            func.__module__, func.__name__, request.method)
+        return DjangoMetric(metric_name.lower())
 
     def process_request(self, request):
         request.start_time = time.time()
 
     def process_response(self, request, response):
+        response_time = request.start_time - time.time()
+        response['X-Response-Time'] = response_time
+
         try:
-            stop_time = time.time()
-            func = resolve(request.path)[0]
-            metric_name = '%s.%s.%s' % (func.__module__, func.__name__,
-                                        request.method)
-            response_time = stop_time - request.start_time
-            self.publish_metric(metric_name.lower(), response_time)
-            response['X-Response-Time'] = response_time
+            metric = self.metric_from_request(request)
+            metric.oneshot(response_time)
         except AttributeError, e:
             logger.exception(e)
         except Resolver404:
@@ -58,10 +57,3 @@ class ResponseTimeMiddleware(object):
             pass
         if response:
             return response
-
-    def publish_metric(self, metric_name, value, timestamp=None,
-                        aggregators=None):
-        aggregators = aggregators or [AVG]
-        prefixed_metric_name = '%s%s' % (self.metrics_prefix, metric_name)
-        connection.publish_metric(prefixed_metric_name, aggregators,
-            value, timestamp)

--- a/go/base/tests/test_middleware.py
+++ b/go/base/tests/test_middleware.py
@@ -3,7 +3,6 @@ import json
 
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.test.utils import override_settings
 from django.http import HttpResponse
 
 from go.api.go_api.session_manager import SessionManager
@@ -42,7 +41,6 @@ class VumiUserApiMiddlewareTestCase(VumiGoDjangoTestCase):
 
 class ResponseTimeMiddlewareTestcase(TestCase):
 
-    @override_settings(METRICS_PREFIX='test.prefix.')
     def setUp(self):
         self.factory = RequestFactory()
         self.mw = ResponseTimeMiddleware()
@@ -73,7 +71,7 @@ class ResponseTimeMiddlewareTestcase(TestCase):
         command = json.loads(args[0])
         [datapoint] = command['datapoints']
         self.assertEqual(datapoint[0],
-            'test.prefix.django.contrib.auth.views.login.get')
+            'go.django.django.contrib.auth.views.login.get')
         self.assertEqual(datapoint[1], ['avg'])
         self.assertTrue(datapoint[2])
         self.assertEqual(kwargs['routing_key'], 'vumi.metrics')
@@ -97,4 +95,4 @@ class ResponseTimeMiddlewareTestcase(TestCase):
         command = json.loads(args[0])
         [datapoint] = command['datapoints']
         self.assertEqual(datapoint[0],
-            'test.prefix.django.contrib.auth.views.login.post')
+            'go.django.django.contrib.auth.views.login.post')

--- a/go/vumitools/tests/test_app_worker.py
+++ b/go/vumitools/tests/test_app_worker.py
@@ -100,10 +100,9 @@ class TestGoApplicationWorker(AppWorkerTestCase):
             conversation_key=self.conv.key,
             user_account_key=self.user_account.key)
 
-        metrics = self.poll_metrics(
-            '%s.conversations.%s' % (self.user_account.key, self.conv.key))
+        prefix = "campaigns.test-0-user.conversations.%s" % self.conv.key
 
-        self.assertEqual({
-            u'messages_sent': [0],
-            u'messages_received': [0],
-        }, metrics)
+        self.assertEqual(
+            self.get_published_metrics(self.app),
+            [("%s.messages_sent" % prefix, 0),
+             ("%s.messages_received" % prefix, 0)])


### PR DESCRIPTION
The plan is to use the metric infrastructure added in #753 to replace the current way of metric publishing in Go.
