### PR TITLE
Contact look-up for messages without a transport_type raises an exception.

### DIFF
--- a/go/base/tests/utils.py
+++ b/go/base/tests/utils.py
@@ -237,12 +237,13 @@ class VumiGoDjangoTestCase(GoPersistenceMixin, TestCase):
             messages.append((msg_in, msg_out, ack))
         return messages
 
-    def add_message_to_conv(self, conversation, reply=False, sensitive=False):
+    def add_message_to_conv(self, conversation, reply=False, sensitive=False,
+                            transport_type='sms'):
         msg = TransportUserMessage(
             to_addr='9292',
             from_addr='from-addr',
             content='hello',
-            transport_type='sms',
+            transport_type=transport_type,
             transport_name='sphex')
         if sensitive:
             msg['helper_metadata']['go'] = {'sensitive': True}

--- a/go/conversation/templates/conversation/message_list_table.html
+++ b/go/conversation/templates/conversation/message_list_table.html
@@ -15,10 +15,16 @@
             {% get_contact_for_message request.user_api message message_direction as contact %}
             <td><i class="glyphicon glyphicon-repeat"></i> {{conversation.delivery_class}}</td>
             <td>
+                {% if contact != None %}
                 <h6><a href="{% url 'contacts:person' person_key=contact.key %}">{{contact}}</a> via {{message.transport_type}} - {{message.timestamp}}</h6>
+                {% elif message_direction == 'inbound' %}
+                <h6><i>{{message.user}}</i> via {{message.transport_type}} (unsupported) - {{message.timestamp}}</h6>
+                {% else %}
+                <h6><i>{{message.to_addr}}</i> via {{message.transport_type}} (unsupported) - {{message.timestamp}}</h6>
+                {% endif %}
                 <p>{{message.content}}</p>
             </td>
-            {% if message_direction == 'inbound' and conversation.has_channel_supporting_generic_sends %}
+            {% if message_direction == 'inbound' and contact != None and conversation.has_channel_supporting_generic_sends %}
             <td>
                 <a href="#reply-{{message.message_id}}" class="btn btn-default" title="Reply" data-toggle='modal'><i class="glyphicon glyphicon-repeat"></i> Reply</a>
                 <div id="reply-{{message.message_id}}" class="modal fade" role="dialog">

--- a/go/conversation/templatetags/conversation_tags.py
+++ b/go/conversation/templatetags/conversation_tags.py
@@ -3,7 +3,6 @@ from django.core.urlresolvers import reverse
 
 from go.conversation.forms import ReplyToMessageForm
 from go.base.utils import get_conversation_view_definition
-from go.vumitools.contact.models import ContactError
 
 
 register = template.Library()

--- a/go/conversation/templatetags/conversation_tags.py
+++ b/go/conversation/templatetags/conversation_tags.py
@@ -3,6 +3,7 @@ from django.core.urlresolvers import reverse
 
 from go.conversation.forms import ReplyToMessageForm
 from go.base.utils import get_conversation_view_definition
+from go.vumitools.contact.models import ContactError
 
 
 register = template.Library()
@@ -41,6 +42,8 @@ def get_contact_for_message(user_api, message, direction='inbound'):
     # retrieving a contact return something useful for debugging (i.e.
     # the `transport_type` that failed to be looked up).
     delivery_class = user_api.delivery_class_for_msg(message)
+    if not user_api.contact_store.delivery_class_supported(delivery_class):
+        return None
     user = message.user() if direction == 'inbound' else message['to_addr']
     return user_api.contact_store.contact_for_addr(
         delivery_class, unicode(user), create=True)

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -281,6 +281,14 @@ class ContactStore(PerAccountStore):
         opt_out = yield opt_out_store.get_opt_out('msisdn', contact.msisdn)
         returnValue(opt_out)
 
+    _SUPPORTED_DELIVERY_CLASSES = set([
+        'sms', 'ussd', 'gtalk', 'twitter',
+    ])
+
+    def delivery_class_supported(self, delivery_class):
+        """Return True if the delivery class is supported."""
+        return delivery_class in self._SUPPORTED_DELIVERY_CLASSES
+
     def _contact_field_for_addr(self, delivery_class, addr):
         # TODO: change when we have proper address types in vumi
         if delivery_class in ('sms', 'ussd'):


### PR DESCRIPTION
Currently any attempt to display a message without a `transport_type` fails because the `delivery_class` look-up relies on a `transport_type` being set and contact look raises an error if the `delivery_class` is `None`.

Outbound messages are expected to not have a `transport_type` set when:
- They have yet to be dispatched towards a transport by the routing dispatcher because they are still in flight.
- Will never reach a transport because they conversation that sent them is not hooked up to one.
