### PR TITLE
HTTP API transport should not accept messages where the to_addr or from_addr are not unicode strings.

### DIFF
--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -261,6 +261,10 @@ class MessageStream(StreamResource):
         conversation = yield self.get_conversation(user_account)
 
         msg_options = SendToOptions(payload)
+        if msg_options.error:
+            self.client_error_response(request, msg_options.error)
+            return
+
         helper_metadata = conversation.set_go_helper_metadata()
 
         msg = yield self.worker.send_to(

--- a/go/apps/http_api/resource.py
+++ b/go/apps/http_api/resource.py
@@ -57,6 +57,16 @@ class BaseResource(resource.Resource):
         })
         self.finish_response(request, msg, code=code, status=reason)
 
+    def success_response(self, request, reason, code=http.OK):
+        msg = json.dumps({
+            "success": True,
+            "reason": reason,
+        })
+        self.finish_response(request, msg, code=code, status=reason)
+
+    def successful_send_response(self, request, msg, code=http.OK):
+        self.finish_response(request, msg.to_json(), code=code)
+
 
 class StreamResource(BaseResource):
 
@@ -204,9 +214,7 @@ class MessageStream(StreamResource):
             reply_to, content, continue_session,
             helper_metadata=helper_metadata)
 
-        request.setResponseCode(http.OK)
-        request.write(msg.to_json())
-        request.finish()
+        self.successful_send_response(request, msg)
 
     @inlineCallbacks
     def handle_PUT_send_to(self, request, payload):
@@ -221,9 +229,7 @@ class MessageStream(StreamResource):
         msg = yield self.worker.send_to(
             to_addr, content, endpoint='default', **msg_options)
 
-        request.setResponseCode(http.OK)
-        request.write(msg.to_json())
-        request.finish()
+        self.successful_send_response(request, msg)
 
 
 class MetricResource(BaseResource):
@@ -268,7 +274,7 @@ class MetricResource(BaseResource):
             self.worker.publish_account_metric(user_account, store, name,
                                                value, agg_class)
 
-        request.finish()
+        self.success_response(request, 'Metrics published')
 
 
 class ConversationResource(resource.Resource):

--- a/go/apps/http_api/tests/test_resource.py
+++ b/go/apps/http_api/tests/test_resource.py
@@ -1,0 +1,58 @@
+from twisted.trial.unittest import TestCase
+
+from go.apps.http_api.resource import MsgOptions
+
+
+class ToyMsgOptions(MsgOptions):
+    WHITELIST = {
+        "even": (lambda v: v is None or bool((v % 2) == 0)),
+        "odd": (lambda v: v is None or bool((v % 2) == 1)),
+    }
+
+
+class TestMsgOptions(TestCase):
+
+    def assert_no_attribute(self, obj, attr):
+        self.assertRaises(AttributeError, getattr, obj, attr)
+
+    def test_no_errors(self):
+        opts = ToyMsgOptions({"even": 4, "odd": 5})
+        self.assertTrue(opts.is_valid)
+        self.assertEqual(opts.errors, [])
+        self.assertEqual(opts.error_msg, None)
+        self.assertEqual(opts.even, 4)
+        self.assertEqual(opts.odd, 5)
+
+    def test_white_listing(self):
+        opts = ToyMsgOptions({"bad": 5})
+        self.assertTrue(opts.is_valid)
+        self.assert_no_attribute(opts, "bad")
+
+    def test_single_error(self):
+        opts = ToyMsgOptions({"even": 5, "odd": 7})
+        self.assertFalse(opts.is_valid)
+        self.assertEqual(opts.errors, [
+            "Invalid or missing value for payload key 'even'",
+        ])
+        self.assertEqual(
+            opts.error_msg,
+            "Invalid or missing value for payload key 'even'"
+        )
+        self.assert_no_attribute(opts, "even")
+        self.assertEqual(opts.odd, 7)
+
+    def test_many_errors(self):
+        opts = ToyMsgOptions({"even": 3, "odd": 4})
+        self.assertFalse(opts.is_valid)
+        self.assertEqual(opts.errors, [
+            "Invalid or missing value for payload key 'even'",
+            "Invalid or missing value for payload key 'odd'",
+        ])
+        self.assertEqual(
+            opts.error_msg,
+            "Errors:"
+            "\n* Invalid or missing value for payload key 'even'"
+            "\n* Invalid or missing value for payload key 'odd'"
+        )
+        self.assert_no_attribute(opts, "even")
+        self.assert_no_attribute(opts, "odd")


### PR DESCRIPTION
Example traceback:

``` python
2013-11-13 15:02:43+0000 [VumiRedis,client] Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 421, in errback
            self._startRunCallbacks(fail)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 488, in _startRun
Callbacks
            self._runCallbacks()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 575, in _runCallb
acks
            current.result = callback(current.result, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1126, in gotResul
t
            _inlineCallbacks(r, g, deferred)
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1068, in _inlineC
allbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/var/praekelt/vumi-go/go/apps/http_api/resource.py", line 161, in handle_PUT
            yield self.handle_PUT_send_to(request, payload)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1068, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/var/praekelt/vumi-go/go/apps/http_api/resource.py", line 215, in handle_PUT_send_to
            to_addr, content, endpoint='default', **msg_options)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1068, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 121, in _handle
            message = yield handler(message, connector_name)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1068, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/var/praekelt/vumi-go/go/vumitools/middleware.py", line 337, in handle_outbound
            yield self.store.add_outbound_message(message, batch_id=batch_id)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1068, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/components/message_store.py", line 215, in add_outbound_message
            yield self.cache.add_outbound_message(batch_id, msg)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1070, in _inlineCallbacks
            result = g.send(result)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/components/message_store_cache.py", line 141, in add_outbound_message
            yield self.add_to_addr(batch_id, msg['to_addr'], timestamp)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/components/message_store_cache.py", line 238, in add_to_addr
            to_addr.encode('utf-8'): timestamp,
        exceptions.AttributeError: 'int' object has no attribute 'encode'
```
