### PR TITLE
MetricsMiddleware doesn't expire keys.

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -193,6 +193,9 @@ class MetricsMiddleware(BaseMiddleware):
         received its `message_id` is stored and when a reply for the given
         `message_id` is sent out, the timestamps are compared and a averaged
         metric is published.
+    :param int max_lifetime:
+        How long to keep a timestamp for. Anything older than this is trashed.
+        Defaults to 60 seconds.
     :param dict redis_manager:
         Connection configuration details for Redis.
     :param str op_mode:
@@ -215,6 +218,7 @@ class MetricsMiddleware(BaseMiddleware):
         self.count_suffix = self.config.get('count_suffix', 'count')
         self.response_time_suffix = self.config.get('response_time_suffix',
             'response_time')
+        self.max_lifetime = int(self.config.get('max_lifetime', 60))
         self.op_mode = self.config.get('op_mode', 'passive')
         if self.op_mode not in self.KNOWN_MODES:
             raise ConfigError('Unknown op_mode: %s' % (
@@ -263,7 +267,9 @@ class MetricsMiddleware(BaseMiddleware):
 
     def set_inbound_timestamp(self, transport_name, message):
         key = self.key(transport_name, message['message_id'])
-        return self.redis.set(key, repr(time.time()))
+        d = self.redis.set(key, repr(time.time()))
+        d.addCallback(lambda _: self.redis.expire(key, self.max_lifetime))
+        return d
 
     @inlineCallbacks
     def get_outbound_timestamp(self, transport_name, message):

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -267,9 +267,8 @@ class MetricsMiddleware(BaseMiddleware):
 
     def set_inbound_timestamp(self, transport_name, message):
         key = self.key(transport_name, message['message_id'])
-        d = self.redis.set(key, repr(time.time()))
-        d.addCallback(lambda _: self.redis.expire(key, self.max_lifetime))
-        return d
+        return self.redis.setex(
+            key, self.max_lifetime, repr(time.time()))
 
     @inlineCallbacks
     def get_outbound_timestamp(self, transport_name, message):

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -313,7 +313,8 @@ class MetricsMiddlewareTestCase(MiddlewareTestCase):
         yield mw.handle_inbound(msg1, 'dummy_endpoint')
         key = mw.key('dummy_endpoint', msg1['message_id'])
         ttl = yield mw.redis.ttl(key)
-        self.assertTrue(0 < ttl < 10)
+        self.assertTrue(
+            0 < ttl <= 10, "Expected 0 < ttl <= 10, found: %r" % (ttl,))
 
 
 class ConversationStoringMiddlewareTestCase(MiddlewareTestCase):

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -309,7 +309,7 @@ class MetricsMiddlewareTestCase(MiddlewareTestCase):
     @inlineCallbacks
     def test_expiry(self):
         mw = yield self.get_middleware({'max_lifetime': 10})
-        msg1 = self.mk_msg(transport_name='endpoint_0')
+        msg1 = self.msg_helper.make_inbound('foo', transport_name='endpoint_0')
         yield mw.handle_inbound(msg1, 'dummy_endpoint')
         key = mw.key('dummy_endpoint', msg1['message_id'])
         ttl = yield mw.redis.ttl(key)

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -306,6 +306,15 @@ class MetricsMiddlewareTestCase(MiddlewareTestCase):
         self.assertEqual(temporary[1], 1)
         self.assertEqual(unspecified[1], 1)
 
+    @inlineCallbacks
+    def test_expiry(self):
+        mw = yield self.get_middleware({'max_lifetime': 10})
+        msg1 = self.mk_msg(transport_name='endpoint_0')
+        yield mw.handle_inbound(msg1, 'dummy_endpoint')
+        key = mw.key('dummy_endpoint', msg1['message_id'])
+        ttl = yield mw.redis.ttl(key)
+        self.assertTrue(0 < ttl < 60)
+
 
 class ConversationStoringMiddlewareTestCase(MiddlewareTestCase):
     @inlineCallbacks

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -313,7 +313,7 @@ class MetricsMiddlewareTestCase(MiddlewareTestCase):
         yield mw.handle_inbound(msg1, 'dummy_endpoint')
         key = mw.key('dummy_endpoint', msg1['message_id'])
         ttl = yield mw.redis.ttl(key)
-        self.assertTrue(0 < ttl < 60)
+        self.assertTrue(0 < ttl < 10)
 
 
 class ConversationStoringMiddlewareTestCase(MiddlewareTestCase):


### PR DESCRIPTION
Leaves _lots_ of keys lying around.
