### PR TITLE
Styling overrides for the diamondash dashboards

### DIFF
--- a/go/base/static/css/dashboards.less
+++ b/go/base/static/css/dashboards.less
@@ -1,0 +1,16 @@
+.diamondash.dashboard {
+  background: transparent;
+  
+  .widget {
+    .widget-head {
+      color: #2f3436;
+      background: #d2d0c7;
+      .border-radius(5px);
+
+      h4 {
+        padding: 6px;
+        font-size: 16px;
+      }
+    }
+  }
+}

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -795,3 +795,20 @@ table tbody.loading td {
   font-size: 2.5em;
   color: #f2f1ed;
 }
+.diamondash.dashboard {
+  background: transparent;
+}
+.diamondash.dashboard .widget .widget-head {
+  color: #2f3436;
+  background: #d2d0c7;
+  -webkit-border-radius: 5px;
+  -webkit-background-clip: padding-box;
+  -moz-border-radius: 5px;
+  -moz-background-clip: padding;
+  border-radius: 5px;
+  background-clip: padding-box;
+}
+.diamondash.dashboard .widget .widget-head h4 {
+  padding: 6px;
+  font-size: 16px;
+}

--- a/go/base/static/css/vumigo.less
+++ b/go/base/static/css/vumigo.less
@@ -373,3 +373,4 @@ a:link, button {
 @import "account.less";
 @import "tables.less";
 @import "error.less";
+@import "dashboards.less";


### PR DESCRIPTION
Once #766 lands, we will have diamondash dashboards inside Go. These dashboards will be using diamondash's styles, which clearly don't fit with Go's styling. We need to make these dashboards' styles more consistent with the rest of Go.
