### PR TITLE
Allow sandbox apps to configure their dashboards from their config

### DIFF
--- a/go/apps/jsbox/tests/test_views.py
+++ b/go/apps/jsbox/tests/test_views.py
@@ -3,6 +3,8 @@ import logging
 
 from go.apps.tests.base import DjangoGoApplicationTestCase
 from go.apps.jsbox.log import LogManager
+from go.apps.jsbox.view_definition import (
+    JSBoxReportsView, ConversationReportsView)
 
 
 class JsBoxTestCase(DjangoGoApplicationTestCase):
@@ -96,3 +98,45 @@ class JsBoxTestCase(DjangoGoApplicationTestCase):
         self.setup_conversation()
         response = self.client.get(self.get_action_view_url('view_logs'))
         self.assertRedirects(response, self.get_view_url('jsbox_logs'))
+
+    def test_jsbox_report_layout_building(self):
+        self.setup_conversation()
+        self.conversation.config['jsbox_app_config'] = {
+            'reports': {
+                'key': 'reports',
+                'value': {
+                    'layout': [{
+                        'type': 'diamondash.widgets.lvalue.LValueWidget',
+                        'time_range': '1d',
+                        'name': 'Messages Received (24h)',
+                        'target': {
+                            'metric_type': 'conversation',
+                            'name': 'messages_received',
+                        }
+                    }]
+                }
+            }
+        }
+
+        view = JSBoxReportsView()
+        layout = view.build_layout(self.conversation)
+
+        self.assertEqual(layout.get_config(), [{
+            'type': 'diamondash.widgets.lvalue.LValueWidget',
+            'name': 'Messages Received (24h)',
+            'time_range': '1d',
+            'target': (
+                "go.campaigns.%s.conversations.%s.messages_received.avg" %
+                (self.conversation.user_account.key, self.conversation.key))
+        }])
+
+    def test_jsbox_report_layout_building_for_no_report_config(self):
+        self.setup_conversation()
+
+        default_reports_view = ConversationReportsView()
+        default_layout = default_reports_view.build_layout(self.conversation)
+
+        view = JSBoxReportsView()
+        layout = view.build_layout(self.conversation)
+
+        self.assertEqual(layout.get_config(), default_layout.get_config())

--- a/go/apps/jsbox/view_definition.py
+++ b/go/apps/jsbox/view_definition.py
@@ -1,9 +1,31 @@
+from go.dashboard.dashboard import ConversationReportsLayout
 from go.conversation.view_definition import (
-    ConversationViewDefinitionBase, ConversationTemplateView,
-    EditConversationView)
+    ConversationViewDefinitionBase, ConversationReportsView,
+    ConversationTemplateView, EditConversationView)
 
 from go.apps.jsbox.forms import JsboxForm, JsboxAppConfigFormset
 from go.apps.jsbox.log import LogManager
+
+
+class JSBoxReportsView(ConversationReportsView):
+    def _get_reports_config(self, conversation):
+        app_config = conversation.config.get('jsbox_app_config', {})
+        return app_config.get('reports', {}).get('value', {})
+
+    def build_layout(self, conversation):
+        """
+        Returns a conversation's dashboard widget data.
+        Override to specialise dashboard building.
+        """
+        reports_config = self._get_reports_config(conversation)
+        layout_config = reports_config.get('layout')
+
+        if layout_config is None:
+            layout = super(JSBoxReportsView, self).build_layout(conversation)
+        else:
+            layout = ConversationReportsLayout(conversation, layout_config)
+
+        return layout
 
 
 class JSBoxLogsView(ConversationTemplateView):

--- a/go/apps/jsbox/view_definition.py
+++ b/go/apps/jsbox/view_definition.py
@@ -68,4 +68,5 @@ class ConversationViewDefinition(ConversationViewDefinitionBase):
 
     extra_views = (
         JSBoxLogsView,
+        JSBoxReportsView,
     )


### PR DESCRIPTION
Since each sandbox app chooses the metrics it fires, allowing the app's conversation dashboard to be configured using the sandbox config will allow each app to choose which metrics to display and how to display them.
