### PR TITLE
Cache conversation object in helper metadata

### DIFF
--- a/go/apps/http_api/vumi_app.py
+++ b/go/apps/http_api/vumi_app.py
@@ -130,9 +130,7 @@ class StreamingHTTPWorker(GoApplicationWorker):
     @inlineCallbacks
     def consume_user_message(self, message):
         msg_mdh = self.get_metadata_helper(message)
-        user_api = msg_mdh.get_user_api()
-        conv_key = msg_mdh.get_conversation_key()
-        conversation = yield user_api.get_wrapped_conversation(conv_key)
+        conversation = yield msg_mdh.get_conversation()
         if conversation is None:
             log.warning("Cannot find conversation for message: %r" % (
                 message,))

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -1,5 +1,7 @@
 # -*- test-case-name: go.vumitools.tests.test_utils -*-
 
+from twisted.internet.defer import succeed
+
 from vumi.middleware.tagger import TaggingMiddleware
 from go.vumitools.middleware import OptOutMiddleware
 
@@ -72,8 +74,15 @@ class MessageMetadataHelper(object):
         return self._go_metadata['conversation_key']
 
     def get_conversation(self):
+        if 'conversation' in self._store_objects:
+            return succeed(self._store_objects['conversation'])
+
+        def stash_and_return_conv(conv):
+            self._store_objects['conversation'] = conv
+            return conv
+
         return self.get_user_api().get_wrapped_conversation(
-            self.get_conversation_key())
+            self.get_conversation_key()).addCallback(stash_and_return_conv)
 
     def get_conversation_info(self):
         conversation_info = {}


### PR DESCRIPTION
We currently load the conversation at least twice for each message processed (since we're using the message storing middleware) and we only ever read it there.
