### PR TITLE
Tests for conversation object caching in helper metadata

### DIFF
--- a/go/vumitools/tests/test_utils.py
+++ b/go/vumitools/tests/test_utils.py
@@ -87,11 +87,20 @@ class MessageMetadataHelperTestCase(GoTestCase):
         self.assertEqual(md_conv.key, conversation.key)
 
     @inlineCallbacks
+    def test_clear_object_cache(self):
+        conversation = yield self.create_conversation()
+        md = self.mk_md(go_metadata={
+            'user_account': self.user_api.user_account_key,
+            'conversation_key': conversation.key,
+        })
+        self.assertEqual(md._store_objects, {})
+        md_conv = yield md.get_conversation()
+        self.assertEqual(md._store_objects, {'conversation': md_conv})
+        md.clear_object_cache()
+        self.assertEqual(md._store_objects, {})
+
+    @inlineCallbacks
     def test_conversation_caching(self):
-        """
-        Conversation objects are cached across calls to get_conversation() and
-        clear_object_cache() clears this cache.
-        """
         md = self.mk_md()
         self.assertRaises(KeyError, md.get_conversation)
         md = self.mk_md(go_metadata={'user_account': 'user-1'})
@@ -101,28 +110,25 @@ class MessageMetadataHelperTestCase(GoTestCase):
             'user_account': self.user_api.user_account_key,
             'conversation_key': conversation.key,
         })
-        self.assertEqual(md._store_objects, {})
         md_conv = yield md.get_conversation()
         self.assertEqual(md_conv.key, conversation.key)
         self.assertEqual(md_conv.status, conversation.status)
-        self.assertNotEqual(md._store_objects, {})
 
         # Modify the conversation and get it from md again, making sure we
         # still have cached data.
         conversation.set_status_starting()
         yield conversation.save()
-        md_conv = yield md.get_conversation()
-        self.assertEqual(md_conv.key, conversation.key)
-        self.assertNotEqual(md_conv.status, conversation.status)
+        md_conv2 = yield md.get_conversation()
+        self.assertIdentical(md_conv, md_conv2)
+        self.assertNotEqual(md_conv2.status, conversation.status)
 
         # Clear the stored object cache and get the conversation from md again,
         # making sure we have new data now.
-        self.assertNotEqual(md._store_objects, {})
         md.clear_object_cache()
-        self.assertEqual(md._store_objects, {})
-        md_conv = yield md.get_conversation()
-        self.assertEqual(md_conv.key, conversation.key)
-        self.assertEqual(md_conv.status, conversation.status)
+        md_conv3 = yield md.get_conversation()
+        self.assertEqual(md_conv3.key, conversation.key)
+        self.assertEqual(md_conv3.status, conversation.status)
+        self.assertNotIdentical(md_conv, md_conv3)
 
     def test_get_conversation_info(self):
         md = self.mk_md()

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -43,6 +43,14 @@ class MessageMetadataHelper(object):
         # If we don't have a tag, we want to blow up early in some places.
         self.tag = TaggingMiddleware.map_msg_to_tag(message)
 
+    def clear_object_cache(self):
+        """Clear any cached objects we might have.
+
+        This forces the next get call to fetch the object from the datastore
+        again.
+        """
+        self._store_objects.clear()
+
     def is_sensitive(self):
         """
         Returns True if the contents of the message have been marked as


### PR DESCRIPTION
I've tested #803 manually and we need to get it out to mitigate a production issue. We still need to write automated tests for it.
