### PR TITLE
Clarify exceptional cases in ResponseTimeMiddleware

### DIFF
--- a/go/testsettings.py
+++ b/go/testsettings.py
@@ -65,3 +65,11 @@ STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 # disable console logging to avoid log messages messing up test output
 LOGGING['loggers']['go']['handlers'].remove('console')
 LOGGING['root']['handlers'].remove('mail_admins')
+
+# disable response-time middleware during tests
+DISALLOWED_MIDDLEWARE = set([
+    'go.base.middleware.ResponseTimeMiddleware'
+])
+MIDDLEWARE_CLASSES = tuple([x for x in MIDDLEWARE_CLASSES
+                            if x not in DISALLOWED_MIDDLEWARE])
+del DISALLOWED_MIDDLEWARE


### PR DESCRIPTION
ResponseTimeMiddleware currently logs errors when `process_response` sees a request that hasn't been processed by `process_request`. However, according to the Django docs, this is a common situation caused by other middleware returning a response from `process_request` (e.g. a redirect).

See https://docs.djangoproject.com/en/dev/topics/http/middleware/#process-response.
