### PR TITLE
http_api_nostream has mandatory config params with no defaults

### DIFF
--- a/go/apps/http_api_nostream/tests/test_views.py
+++ b/go/apps/http_api_nostream/tests/test_views.py
@@ -40,3 +40,14 @@ class HttpApiNoStreamTestCase(DjangoGoApplicationTestCase):
                 'api_tokens': ['token'],
             }
         })
+        self.assertEqual(self.conversation.config, {})
+        response = self.client.get(self.get_view_url('edit'))
+        self.assertContains(response, 'http://events/')
+        self.assertContains(response, 'http://messages/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_edit_view_no_config(self):
+        self.setup_conversation(started=True)
+        self.assertEqual(self.conversation.config, {})
+        response = self.client.get(self.get_view_url('edit'))
+        self.assertEqual(response.status_code, 200)

--- a/go/apps/http_api_nostream/view_definition.py
+++ b/go/apps/http_api_nostream/view_definition.py
@@ -21,8 +21,8 @@ class TokenForm(forms.Form):
         return {
             'api_tokens': (data['api_tokens'][0]
                             if data['api_tokens'] else None),
-            'push_message_url': data['push_message_url'],
-            'push_event_url': data['push_event_url'],
+            'push_message_url': data.get('push_message_url', None),
+            'push_event_url': data.get('push_event_url', None),
         }
 
     def to_config(self):


### PR DESCRIPTION
We need to do something about that.
