### PR TITLE
The NoStreamingHTTPWorker should validate conversation configuration fields.

### DIFF
--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -389,8 +389,20 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
         self.patch(vumi_app, 'http_request_full', raiser)
 
     @inlineCallbacks
+    def test_post_inbound_message_no_url(self):
+        self.conversation.config['http_api_nostream'].update({
+            'push_message_url': None,
+        })
+        yield self.conversation.save()
+
+        msg = self.msg_helper.make_inbound('in 1', message_id='1')
+        with LogCatcher(message='URL not configured') as lc:
+            yield self.dispatch_to_conv(msg, self.conversation)
+            [url_not_configured_log] = lc.messages()
+        self.assertTrue('push_message_url' in url_not_configured_log)
+
+    @inlineCallbacks
     def test_post_inbound_message_unsupported_scheme(self):
-        # Set the URL so stuff is HTTP Posted instead of streamed.
         self.conversation.config['http_api_nostream'].update({
             'push_message_url': 'example.com',
         })
@@ -405,12 +417,6 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_post_inbound_message_timeout(self):
-        # Set the URL so stuff is HTTP Posted instead of streamed.
-        self.conversation.config['http_api_nostream'].update({
-            'push_message_url': self.mock_push_server.url,
-        })
-        yield self.conversation.save()
-
         self._patch_http_request_full(HttpTimeoutError)
         msg = self.msg_helper.make_inbound('in 1', message_id='1')
         with LogCatcher(message='Timeout') as lc:
@@ -420,12 +426,6 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_post_inbound_message_dns_lookup_error(self):
-        # Set the URL so stuff is HTTP Posted instead of streamed.
-        self.conversation.config['http_api_nostream'].update({
-            'push_message_url': self.mock_push_server.url,
-        })
-        yield self.conversation.save()
-
         self._patch_http_request_full(DNSLookupError)
         msg = self.msg_helper.make_inbound('in 1', message_id='1')
         with LogCatcher(message='DNS lookup error') as lc:
@@ -435,12 +435,6 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_post_inbound_event(self):
-        # Set the URL so stuff is HTTP Posted instead of streamed.
-        self.conversation.config['http_api_nostream'].update({
-            'push_event_url': self.mock_push_server.url,
-        })
-        yield self.conversation.save()
-
         msg1 = yield self.msg_helper.make_stored_outbound(
             self.conversation, 'out 1', message_id='1')
         ack1 = self.msg_helper.make_ack(msg1)
@@ -454,13 +448,22 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
         self.assertEqual(TransportEvent.from_json(posted_json_data), ack1)
 
     @inlineCallbacks
-    def test_post_inbound_event_timeout(self):
-        # Set the URL so stuff is HTTP Posted instead of streamed.
+    def test_post_inbound_event_no_url(self):
         self.conversation.config['http_api_nostream'].update({
-            'push_event_url': self.mock_push_server.url,
+            'push_event_url': None,
         })
         yield self.conversation.save()
 
+        msg1 = yield self.msg_helper.make_stored_outbound(
+            self.conversation, 'out 1', message_id='1')
+        ack1 = self.msg_helper.make_ack(msg1)
+        with LogCatcher(message='URL not configured') as lc:
+            yield self.dispatch_event_to_conv(ack1, self.conversation)
+            [url_not_configured_log] = lc.messages()
+        self.assertTrue('push_event_url' in url_not_configured_log)
+
+    @inlineCallbacks
+    def test_post_inbound_event_timeout(self):
         msg1 = yield self.msg_helper.make_stored_outbound(
             self.conversation, 'out 1', message_id='1')
         ack1 = self.msg_helper.make_ack(msg1)
@@ -473,12 +476,6 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
 
     @inlineCallbacks
     def test_post_inbound_event_dns_lookup_error(self):
-        # Set the URL so stuff is HTTP Posted instead of streamed.
-        self.conversation.config['http_api_nostream'].update({
-            'push_event_url': self.mock_push_server.url,
-        })
-        yield self.conversation.save()
-
         msg1 = yield self.msg_helper.make_stored_outbound(
             self.conversation, 'out 1', message_id='1')
         ack1 = self.msg_helper.make_ack(msg1)

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -396,10 +396,10 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
         yield self.conversation.save()
 
         msg = self.msg_helper.make_inbound('in 1', message_id='1')
-        with LogCatcher(message='URL not configured') as lc:
+        with LogCatcher(message='push_message_url not configured') as lc:
             yield self.dispatch_to_conv(msg, self.conversation)
             [url_not_configured_log] = lc.messages()
-        self.assertTrue('push_message_url' in url_not_configured_log)
+        self.assertTrue(self.conversation.key in url_not_configured_log)
 
     @inlineCallbacks
     def test_post_inbound_message_unsupported_scheme(self):
@@ -457,10 +457,10 @@ class NoStreamingHTTPWorkerTestCase(AppWorkerTestCase):
         msg1 = yield self.msg_helper.make_stored_outbound(
             self.conversation, 'out 1', message_id='1')
         ack1 = self.msg_helper.make_ack(msg1)
-        with LogCatcher(message='URL not configured') as lc:
+        with LogCatcher(message='push_event_url not configured') as lc:
             yield self.dispatch_event_to_conv(ack1, self.conversation)
             [url_not_configured_log] = lc.messages()
-        self.assertTrue('push_event_url' in url_not_configured_log)
+        self.assertTrue(self.conversation.key in url_not_configured_log)
 
     @inlineCallbacks
     def test_post_inbound_event_timeout(self):

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -73,6 +73,9 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
 
         push_message_url = self.get_api_config(conversation,
                                                'push_message_url')
+        if push_message_url is None:
+            log.warning("URL not configured: push_message_url")
+            return
         yield self.push(push_message_url, message)
 
     @inlineCallbacks
@@ -89,6 +92,9 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
         config = yield self.get_message_config(event)
         conversation = config.get_conversation()
         push_event_url = self.get_api_config(conversation, 'push_event_url')
+        if push_event_url is None:
+            log.warning("URL not configured: push_event_url")
+            return
         yield self.push(push_event_url, event)
 
     @inlineCallbacks

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -74,7 +74,9 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
         push_message_url = self.get_api_config(conversation,
                                                'push_message_url')
         if push_message_url is None:
-            log.warning("URL not configured: push_message_url")
+            log.warning(
+                "push_message_url not configured for conversation: %s" % (
+                    conversation.key))
             return
         yield self.push(push_message_url, message)
 
@@ -93,7 +95,9 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
         conversation = config.get_conversation()
         push_event_url = self.get_api_config(conversation, 'push_event_url')
         if push_event_url is None:
-            log.warning("URL not configured: push_event_url")
+            log.warning(
+                "push_event_url not configured for conversation: %s" % (
+                    conversation.key))
             return
         yield self.push(push_event_url, event)
 


### PR DESCRIPTION
It seems the the worker choked on a conversation that had empty message_push, event_push urls. 

Here's the log of what happened:
https://gist.github.com/vgeddes/1bc8f87f2063fdb9205b

Until we fix this, we're just going to make sure that conversations are well-defined when used with this transport.
