### PR TITLE
Use wheels instead of source packages for builds where possible.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ install:
   # We easy_install a binary riak_pb package because pip install needs `protoc'.
   - "easy_install 'riak_pb<1.3.0'"
   # For some reason we need these two as well.
-  - "pip install https://github.com/praekelt/vumi/tarball/develop#egg=vumi-dev --use-mirrors"
-  - "pip install https://github.com/praekelt/vumi-wikipedia/tarball/develop#egg=vumi-wikipedia-dev --use-mirrors"
-  - "pip install -r requirements.pip --use-mirrors"
-  - "pip install -r requirements-pytest.pip --use-mirrors"
+  - "pip install https://github.com/praekelt/vumi/tarball/develop#egg=vumi-dev --use-wheel"
+  - "pip install https://github.com/praekelt/vumi-wikipedia/tarball/develop#egg=vumi-wikipedia-dev --use-wheel"
+  - "pip install -r requirements.pip --use-wheel"
+  - "pip install -r requirements-pytest.pip --use-wheel"
   - "pip install overalls"
   - "npm install"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install:
   # We easy_install a binary riak_pb package because pip install needs `protoc'.
   - "easy_install 'riak_pb<1.3.0'"
   # For some reason we need these two as well.
-  - "pip install https://github.com/praekelt/vumi/tarball/develop#egg=vumi-dev --use-wheel"
-  - "pip install https://github.com/praekelt/vumi-wikipedia/tarball/develop#egg=vumi-wikipedia-dev --use-wheel"
+  - "pip install https://github.com/praekelt/vumi/tarball/develop#egg=vumi-dev"
+  - "pip install https://github.com/praekelt/vumi-wikipedia/tarball/develop#egg=vumi-wikipedia-dev"
   - "pip install -r requirements.pip --use-wheel"
   - "pip install -r requirements-pytest.pip --use-wheel"
   - "pip install overalls"


### PR DESCRIPTION
This PR removes `--use-mirrors` from our Travis `pip install` commands (because it provides no real benefit and just makes the installs take longer) and adds `--use-wheel` which will install from a newer packaging format (see http://wheel.readthedocs.org/ for details) which is rather faster for the packages that have wheels available (which sadly isn't very many of them yet).

My test build ( https://travis-ci.org/praekelt/vumi-go/builds/15100414 ) took just over 21 minutes to run compared to the develop build before it ( https://travis-ci.org/praekelt/vumi-go/builds/15045486 ) which took nearly 32 minutes. There's a lot of variance in our build times in general, but this is the quickest successful build in the last few weeks.
