### PR TITLE
Ability to migrate conversations and smartgroups from 1 account to another

### DIFF
--- a/go/base/management/commands/go_manage_conversation.py
+++ b/go/base/management/commands/go_manage_conversation.py
@@ -24,6 +24,8 @@ class Command(BaseGoAccountCommand):
         make_option('--conversation-key',
                     dest='conversation_key',
                     help='The conversation key'),
+        make_option(
+            '--file', dest='file', help='The file to import')
     )
 
     def get_conversation(self, options):
@@ -87,4 +89,24 @@ class Command(BaseGoAccountCommand):
 
     def handle_command_export(self, *apps, **options):
         conversation = self.get_conversation(options)
+        self.stdout.write(json.dumps(conversation.get_data()))
+
+    def load_file(self, options):
+        if 'file' not in options:
+            raise CommandError('Please specify a file to load.')
+        file_name = options['file']
+        return open(file_name, 'r')
+
+    def handle_command_import(self, *apps, **options):
+        raw_conv_data = json.load(self.load_file(options))
+        allowed_keys = [
+            'conversation_type',
+            'description',
+            'name',
+            'config',
+            ]
+
+        new_conv_data = dict([(key, raw_conv_data[key]) for key in
+                              allowed_keys])
+        conversation = self.user_api.new_conversation(**new_conv_data)
         self.stdout.write(json.dumps(conversation.get_data()))

--- a/go/base/management/commands/go_manage_conversation.py
+++ b/go/base/management/commands/go_manage_conversation.py
@@ -1,3 +1,4 @@
+import json
 from optparse import make_option
 from pprint import pformat
 
@@ -18,7 +19,8 @@ class Command(BaseGoAccountCommand):
         make_command_option('start', help='Start a conversation'),
         make_command_option('stop', help='Stop a conversation'),
         make_command_option('archive', help='Archive a conversation'),
-
+        make_command_option('export', help='Export a conversation definition'),
+        make_command_option('import', help='Import a conversation definition'),
         make_option('--conversation-key',
                     dest='conversation_key',
                     help='The conversation key'),
@@ -82,3 +84,7 @@ class Command(BaseGoAccountCommand):
         self.stdout.write("Archiving conversation...\n")
         conversation.archive_conversation()
         self.stdout.write("Conversation archived\n")
+
+    def handle_command_export(self, *apps, **options):
+        conversation = self.get_conversation(options)
+        self.stdout.write(json.dumps(conversation.get_data()))

--- a/go/base/management/commands/go_manage_conversation.py
+++ b/go/base/management/commands/go_manage_conversation.py
@@ -5,6 +5,7 @@ from pprint import pformat
 from django.core.management.base import CommandError
 
 from go.base.command_utils import BaseGoAccountCommand, make_command_option
+from go import config
 
 
 class Command(BaseGoAccountCommand):
@@ -104,9 +105,13 @@ class Command(BaseGoAccountCommand):
             'description',
             'name',
             'config',
-            ]
+        ]
 
         new_conv_data = dict([(key, raw_conv_data[key]) for key in
                               allowed_keys])
+        conversation_type = new_conv_data['conversation_type']
+        if conversation_type not in config.configured_conversation_types():
+            raise CommandError('Invalid conversation_type: %s' % (
+                conversation_type,))
         conversation = self.user_api.new_conversation(**new_conv_data)
         self.stdout.write(json.dumps(conversation.get_data()))

--- a/go/base/tests/test_go_manage_conversation.py
+++ b/go/base/tests/test_go_manage_conversation.py
@@ -1,3 +1,4 @@
+import json
 from pprint import pformat
 
 from mock import patch
@@ -89,3 +90,8 @@ class TestGoManageConversation(GoAccountCommandTestCase):
 
         conv = self.user_api.get_wrapped_conversation(conv.key)
         self.assertEqual(conv.archive_status, 'archived')
+
+    def test_export(self):
+        conv = self.create_conversation()
+        self.assert_command_output(json.dumps(
+            conv.get_data()), 'export', conversation_key=conv.key)


### PR DESCRIPTION
For MAMA, we have a need migrate conversations and smartgroups from a QA account to the live one, to avoid having to recreate all conversations manually.
