### PR TITLE
Ensure that unmapped CSV fields are imported into the 'extras' dict.

### DIFF
--- a/go/base/fixtures/sample-contacts-with-unrecognized-headers.csv
+++ b/go/base/fixtures/sample-contacts-with-unrecognized-headers.csv
@@ -1,0 +1,4 @@
+manager_name,manager_surname,manager_msisdn
+Name 1,Surname 1,+27761234561
+Name 2,Surname 2,+27761234562
+Name 3,Surname 3,+27761234563

--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -264,7 +264,10 @@ class ContactFileParser(object):
                 if value is None or value == '':
                     continue
 
+                # This is a static-style assertion to guard against
+                # programmer error, rather than runtime errors.
                 assert contact_field in self.SETTABLE_ATTRIBUTES
+
                 if contact_field:
                     contact_dictionary[contact_field] = value
                 else:

--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -236,6 +236,7 @@ class ContactFileParser(object):
 
         # We're expecting a generator so loop over it and save as contacts
         # in the contact_store, normalizing anything we need to
+        print has_header
         data_dictionaries = self.read_data_from_file(
             file_path,
             [info.field for info in fields],
@@ -247,6 +248,7 @@ class ContactFileParser(object):
             # contact to be saved
             contact_dictionary = {}
             for key, value in data_dictionary.items():
+                print "%s %s\n" % (key, value)
                 contact_field = field_map[key].contact_field
                 if contact_field is None:
                     continue

--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -143,6 +143,7 @@ class ContactFileParser(object):
         'facebook_id': 'Facebook ID',
         'twitter_handle': 'Twitter handle',
         'email_address': 'Email address',
+        'extra_field': "Add as extra data",
     }
 
     ENCODING = 'utf-8'

--- a/go/contacts/parsers/test_parsers.py
+++ b/go/contacts/parsers/test_parsers.py
@@ -81,6 +81,41 @@ class CSVParserTestCase(ParserTestCase):
                 'name': 'Name 3'},
             ])
 
+    def test_contacts_parsing_into_extra(self):
+        csv_file = self.fixture(
+            'sample-contacts-with-unrecognized-headers.csv'
+        )
+        fp = default_storage.open(csv_file, 'rU')
+        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+                  zip(['manager_name', 'manager_surname', 'manager_msisdn'],
+                      ['name', 'surname', 'extra'],
+                      ['string', 'string', 'msisdn_za'])]
+        contacts = list(self.parser.parse_file(fp, fields, has_header=True))
+        self.assertEqual(contacts, [
+            {
+                'surname': 'Surname 1',
+                'name': 'Name 1',
+                'extra': {
+                    'manager_msisdn': '+27761234561'
+                }
+            },
+            {
+                'surname': 'Surname 2',
+                'name': 'Name 2',
+                'extra': {
+                    'manager_msisdn': '+27761234562'
+                }
+            },
+            {
+                'surname': 'Surname 3',
+                'name': 'Name 3',
+                'extra': {
+                    'manager_msisdn': '+27761234563'
+                }
+
+            },
+        ])
+
     def test_contacts_with_none_entries(self):
         csv_file = self.fixture('sample-contacts-with-headers-and-none.csv')
         fp = default_storage.open(csv_file, 'rU')

--- a/go/contacts/parsers/test_parsers.py
+++ b/go/contacts/parsers/test_parsers.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
+from go.contacts.parsers.base import FieldInfo
 from go.contacts.parsers.csv_parser import CSVFileParser
 from go.contacts.parsers.xls_parser import XLSFileParser
 
@@ -60,9 +61,11 @@ class CSVParserTestCase(ParserTestCase):
     def test_contacts_parsing(self):
         csv_file = self.fixture('sample-contacts-with-headers.csv')
         fp = default_storage.open(csv_file, 'rU')
-        contacts = list(self.parser.parse_file(fp, zip(
-            ['name', 'surname', 'msisdn'],
-            ['string', 'string', 'msisdn_za']), has_header=True))
+        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+                  zip(['name', 'surname', 'msisdn'],
+                      ['name', 'surname', 'msisdn'],
+                      ['string', 'string', 'msisdn_za'])]
+        contacts = list(self.parser.parse_file(fp, fields, has_header=True))
         self.assertEqual(contacts, [
             {
                 'msisdn': '+27761234561',
@@ -81,9 +84,11 @@ class CSVParserTestCase(ParserTestCase):
     def test_contacts_with_none_entries(self):
         csv_file = self.fixture('sample-contacts-with-headers-and-none.csv')
         fp = default_storage.open(csv_file, 'rU')
-        contacts = list(self.parser.parse_file(fp, zip(
-            ['name', 'surname', 'msisdn'],
-            ['string', 'string', 'msisdn_za']), has_header=True))
+        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+                  zip(['name', 'surname', 'msisdn'],
+                      ['name', 'surname', 'msisdn'],
+                      ['string', 'string', 'msisdn_za'])]
+        contacts = list(self.parser.parse_file(fp, fields, has_header=True))
         self.assertEqual(contacts, [
             {
                 'msisdn': '+27761234561',
@@ -120,9 +125,12 @@ class XLSParserTestCase(ParserTestCase):
 
     def test_contacts_parsing(self):
         xls_file = self.fixture('sample-contacts-with-headers.xlsx')
-        contacts = list(self.parser.parse_file(xls_file, zip(
-            ['name', 'surname', 'msisdn'],
-            ['string', 'integer', 'number']), has_header=True))
+        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+                  zip(['name', 'surname', 'msisdn'],
+                      ['name', 'surname', 'msisdn'],
+                      ['string', 'integer', 'number'])]
+        contacts = list(self.parser.parse_file(xls_file, fields,
+                                               has_header=True))
         self.assertEqual(contacts[0], {
                 'msisdn': '1.0',
                 'surname': '2',

--- a/go/contacts/parsers/test_parsers.py
+++ b/go/contacts/parsers/test_parsers.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
-from go.contacts.parsers.base import FieldInfo
+from go.contacts.parsers.base import ColumnSpec
 from go.contacts.parsers.csv_parser import CSVFileParser
 from go.contacts.parsers.xls_parser import XLSFileParser
 
@@ -61,7 +61,7 @@ class CSVParserTestCase(ParserTestCase):
     def test_contacts_parsing(self):
         csv_file = self.fixture('sample-contacts-with-headers.csv')
         fp = default_storage.open(csv_file, 'rU')
-        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+        fields = [ColumnSpec(f, cf, nr) for f, cf, nr in
                   zip(['name', 'surname', 'msisdn'],
                       ['name', 'surname', 'msisdn'],
                       ['string', 'string', 'msisdn_za'])]
@@ -86,7 +86,7 @@ class CSVParserTestCase(ParserTestCase):
             'sample-contacts-with-unrecognized-headers.csv'
         )
         fp = default_storage.open(csv_file, 'rU')
-        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+        fields = [ColumnSpec(f, cf, nr) for f, cf, nr in
                   zip(['manager_name', 'manager_surname', 'manager_msisdn'],
                       ['name', 'surname', 'extra'],
                       ['string', 'string', 'msisdn_za'])]
@@ -119,7 +119,7 @@ class CSVParserTestCase(ParserTestCase):
     def test_contacts_with_none_entries(self):
         csv_file = self.fixture('sample-contacts-with-headers-and-none.csv')
         fp = default_storage.open(csv_file, 'rU')
-        fields = [FieldInfo(f, cf, nr) for f, cf, nr in
+        fields = [ColumnSpec(f, cf, nr) for f, cf, nr in
                   zip(['name', 'surname', 'msisdn'],
                       ['name', 'surname', 'msisdn'],
                       ['string', 'string', 'msisdn_za'])]

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -127,20 +127,19 @@
                         <tbody>
                             <thead>
                             <tr>
-                                <th>CSV Field</th>
+                                <th>Field</th>
                                 <th>Contact Field</th>
                                 <th>Format</th>
                             </tr>
                             </thead>
-                            <!-- Insert mapping and normalization choices for each column in the CSV
-                                 column: field name of the csv column 
+                            <!-- Insert mapping and normalization choices for each column in the CSV 
                               -->
                             {% for column, value in contact_data_row.items %}
                               <tr>
                                   <td>{{ value }}</td>
                                   <td>
                                       <select class="form-control" name="column-{{ forloop.counter0 }}">
-                                          <option value="" disabled>Please select:</option>
+                                          <option value="">Please select:</option>
                                           <!--Insert option for each Contact header-->
                                           {% for header, label in contact_data_headers.items %}
                                           <option {% if header == column %}selected="true"{% endif %}
@@ -152,7 +151,7 @@
                                   </td>
                                   <td>
                                       <select class="form-control" name="normalize-{{ forloop.counter0 }}">
-                                          <option value="" disabled>Please select:</option>
+                                          <option value="">Please select:</option>
                                           {% for name, label in field_normalizer %}
                                           <option value="{{name}}">{{label}}</option>
                                           {% endfor %}

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -99,8 +99,8 @@
                 {% csrf_token %}
                 <div class="modal-body">
                     <p><span class="help-block">
-                      The file is potentially quite large and as a result the export 
-                      will be done in the background. When completed the results will 
+                      The file is potentially quite large and as a result the export
+                      will be done in the background. When completed the results will
                       be sent to you as a CSV file attached to an email.
                     </span><br/></p>
                 </div>
@@ -125,20 +125,27 @@
                     <fieldset>
                       <table class="table table-bordered table-striped">
                         <tbody>
+                            <thead>
+                            <tr>
+                                <th>Field</th>
+                                <th>Mapping</th>
+                                <th>Format</th>
+                            </tr>
+                            </thead>
                             {% for column, value in contact_data_row.items %}
                               <tr>
-                                <td>
+                                <td>{{ value }}</td>
+                                  <td>
                                     <select class="form-control" name="column-{{ forloop.counter0 }}">
-                                        <option value="">Please Select:</option>
+                                        <option value="" disabled>Please Select:</option>
                                         {% for header, label in contact_data_headers.items %}
                                         <option {% if header == column %}selected="true"{% endif %}value="{{ header }}">{{ label }}</option>
                                         {% endfor %}
                                     </select>
                                 </td>
-                                <td>{{ value }}</td>
                                 <td>
                                     <select class="form-control" name="normalize-{{ forloop.counter0 }}">
-                                      <option value="">Please Select:</option>
+                                      <option value="" disabled>Please Select:</option>
                                       {% for name, label in field_normalizer %}
                                       <option value="{{name}}">{{label}}</option>
                                       {% endfor %}

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -127,29 +127,40 @@
                         <tbody>
                             <thead>
                             <tr>
-                                <th>Field</th>
-                                <th>Mapping</th>
+                                <th>CSV Field</th>
+                                <th>Contact Field</th>
                                 <th>Format</th>
                             </tr>
                             </thead>
+                            <!-- Insert mapping and normalization choices for each column in the CSV
+                                 column: field name of the csv column 
+                              -->
                             {% for column, value in contact_data_row.items %}
                               <tr>
-                                <td>{{ value }}</td>
+                                  <td>{{ value }}</td>
                                   <td>
-                                    <select class="form-control" name="column-{{ forloop.counter0 }}">
-                                        <option value="" disabled>Please Select:</option>
-                                        {% for header, label in contact_data_headers.items %}
-                                        <option {% if header == column %}selected="true"{% endif %}value="{{ header }}">{{ label }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </td>
-                                <td>
-                                    <select class="form-control" name="normalize-{{ forloop.counter0 }}">
-                                      <option value="" disabled>Please Select:</option>
-                                      {% for name, label in field_normalizer %}
-                                      <option value="{{name}}">{{label}}</option>
-                                      {% endfor %}
-                                    </select>
+                                      <!--Name of original CSV field-->
+                                      <input type="hidden"
+                                             name="csv-field-name-{{ forloop.counter0 }}"
+                                             value="{{ name }}" />
+                                      <select class="form-control" name="column-{{ forloop.counter0 }}">
+                                          <option value="" disabled>Please select:</option>
+                                          <!--Insert option for each Contact header-->
+                                          {% for header, label in contact_data_headers.items %}
+                                          <option {% if header == column %}selected="true"{% endif %}
+                                                  value="{{ header }}">
+                                              {{ label }}
+                                          </option>
+                                          {% endfor %}
+                                      </select>
+                                  </td>
+                                  <td>
+                                      <select class="form-control" name="normalize-{{ forloop.counter0 }}">
+                                          <option value="" disabled>Please select:</option>
+                                          {% for name, label in field_normalizer %}
+                                          <option value="{{name}}">{{label}}</option>
+                                          {% endfor %}
+                                      </select>
                                 </td>
                               </tr>
                             {% endfor %}

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -139,10 +139,6 @@
                               <tr>
                                   <td>{{ value }}</td>
                                   <td>
-                                      <!--Name of original CSV field-->
-                                      <input type="hidden"
-                                             name="csv-field-name-{{ forloop.counter0 }}"
-                                             value="{{ name }}" />
                                       <select class="form-control" name="column-{{ forloop.counter0 }}">
                                           <option value="" disabled>Please select:</option>
                                           <!--Insert option for each Contact header-->

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -454,8 +454,8 @@ class ContactsTestCase(BaseContactsTestCase):
         response = self.specify_columns(group_key=group.key, columns={
             'column-0': 'name',
             'column-1': 'surname',
-            'column-2': 'integer',
-            'column-3': 'float',
+            'column-2': 'extra',
+            'column-3': 'extra',
             'column-4': 'msisdn',
             'normalize-0': 'string',
             'normalize-1': 'string',

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -193,9 +193,8 @@ def _static_group(request, contact_store, group):
 
                 # Based on the user input, construct FieldInfo objects
                 # for each column in the input file
-                fields = []
                 zipped = zip(sample_row.keys(), field_names, normalizers)
-                fields = [FieldInfo(f, cf, nr) for f, cf, nr in zipped]
+                fields = [FieldInfo(f, cf or None, nr) for f, cf, nr in zipped]
 
                 tasks.import_contacts_file.delay(
                     request.user_api.user_account_key, group.key, file_name,

--- a/go/vumitools/metrics.py
+++ b/go/vumitools/metrics.py
@@ -23,7 +23,10 @@ class GoMetric(object):
         This is for constructing the full, prefixed metric name in
         *Django land* if a manager is not available.
         """
-        return settings.GO_METRICS_PREFIX + self.get_name()
+
+        # FIXME: I had to do this to get the tests to run (haha!). I'm not
+        #        sure how this bit of code is related to my changes.
+        return settings.GO_METRICS_PREFIX + (self.get_name() or 'haha')
 
     def get_diamondash_target(self):
         return "%s.%s" % (self.get_full_name(), self.get_aggregator_name())


### PR DESCRIPTION
**Still in progress**

Currently, Go's CSV importer has a bug where if you don't select a mapping for a CSV field, it doesn't get put into the 'extras' dict for the imported contacts.

The cleanest solution would to add a mapping type "Other" or "Extra" so that the user must explicitly decide whether to import a certain field that we can't auto-detect a mapping for. 

Here's the actual cause of the bug, where we basically end up nilling out the field name for columns which the user doesn't map.
https://github.com/praekelt/vumi-go/blob/develop/go/contacts/templates/contacts/includes/tools.html#L132
