### PR TITLE
Add dropdown w/ transport names to add tag pools

### DIFF
--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -8,12 +8,15 @@ from django.contrib import admin
 from django.contrib import messages
 
 from go.billing.models import TagPool, Account, MessageCost, Transaction
-from go.billing.forms import CreditLoadForm, BaseCreditLoadFormSet
+from go.billing.forms import (CreditLoadForm,
+                              BaseCreditLoadFormSet,
+                              TagPoolForm)
 
 
 class TagPoolAdmin(admin.ModelAdmin):
     list_display = ('name', 'description')
     search_fields = ('name', 'description')
+    form = TagPoolForm
 
 
 class AccountAdmin(admin.ModelAdmin):

--- a/go/billing/forms.py
+++ b/go/billing/forms.py
@@ -1,10 +1,13 @@
 from decimal import Decimal
 
+from django.conf import settings
 from django import forms
 from django.forms import ModelForm
 from django.forms.models import BaseModelFormSet
 
-from go.billing.models import Account, Transaction
+from go.vumitools.api import VumiApi
+
+from go.billing.models import Account, Transaction, TagPool
 
 
 class BaseCreditLoadFormSet(BaseModelFormSet):
@@ -44,3 +47,17 @@ class CreditLoadForm(ModelForm):
 
     class Meta:
         model = Account
+
+
+class TagPoolForm(ModelForm):
+
+    class Meta:
+        model = TagPool
+
+    def __init__(self, *args, **kwargs):
+        super(TagPoolForm, self).__init__(*args, **kwargs)
+        name_choices = [('', '---------')]
+        api = VumiApi.from_config_sync(settings.VUMI_API_CONFIG)
+        for pool_name in api.tpm.list_pools():
+            name_choices.append((pool_name, pool_name))
+        self.fields['name'] = forms.ChoiceField(choices=name_choices)


### PR DESCRIPTION
When adding a tag pool to admin: http://qa-vumi.za.prk-host.net/admin/billing/tagpool/add/

Instead of presenting a text field to the user where anything can be inputted, replace the text field with a dropdown populated with the transport names (transport_name) from tagpools.yaml: https://github.com/praekelt/puppet/blob/develop/modules/vumigo/files/tagpools.yaml

![screen shot 2013-11-18 at 12 00 12 pm](https://f.cloud.github.com/assets/1521387/1561708/e3fbbbc4-5038-11e3-9d90-9abcad8f4bfe.png)
