### PR TITLE
Use MessageMetadataHelper caching more widely

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -76,9 +76,9 @@ class OptOutMiddleware(BaseMiddleware):
     @inlineCallbacks
     def handle_inbound(self, message, endpoint):
         optout_disabled = False
-        tag = TaggingMiddleware.map_msg_to_tag(message)
-        if tag is not None:
-            tagpool_metadata = yield self.vumi_api.tpm.get_metadata(tag[0])
+        msg_mdh = MessageMetadataHelper(self.vumi_api, message)
+        if msg_mdh.tag is not None:
+            tagpool_metadata = yield msg_mdh.get_tagpool_metadata()
             optout_disabled = tagpool_metadata.get(
                 'disable_global_opt_out', False)
         keyword = (message['content'] or '').strip()

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -13,7 +13,9 @@ from vumi.blinkenlights.metrics import MetricManager, Count, Metric
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.errors import ConfigError
 
+from go.vumitools.api import VumiApi
 from go.vumitools.credit import CreditManager
+from go.vumitools.utils import MessageMetadataHelper
 
 
 class NormalizeMsisdnMiddleware(TransportMiddleware):
@@ -60,7 +62,6 @@ class OptOutMiddleware(BaseMiddleware):
 
     @inlineCallbacks
     def setup_middleware(self):
-        from go.vumitools.api import VumiApi
         self.vumi_api = yield VumiApi.from_config_async(self.config)
 
         self.case_sensitive = self.config.get('case_sensitive', False)
@@ -319,7 +320,6 @@ class GoStoringMiddleware(StoringMiddleware):
     @inlineCallbacks
     def setup_middleware(self):
         yield super(GoStoringMiddleware, self).setup_middleware()
-        from go.vumitools.api import VumiApi
         self.vumi_api = yield VumiApi.from_config_async(self.config)
 
     @inlineCallbacks
@@ -346,8 +346,6 @@ class GoStoringMiddleware(StoringMiddleware):
 class ConversationStoringMiddleware(GoStoringMiddleware):
     @inlineCallbacks
     def get_batch_id(self, msg):
-        # MessageMetadataHelper is imported here to avoid a circular import
-        from go.vumitools.utils import MessageMetadataHelper
         mdh = MessageMetadataHelper(self.vumi_api, msg)
         conversation = yield mdh.get_conversation()
         returnValue(conversation.batch.key)
@@ -356,8 +354,6 @@ class ConversationStoringMiddleware(GoStoringMiddleware):
 class RouterStoringMiddleware(GoStoringMiddleware):
     @inlineCallbacks
     def get_batch_id(self, msg):
-        # MessageMetadataHelper is imported here to avoid a circular import
-        from go.vumitools.utils import MessageMetadataHelper
         mdh = MessageMetadataHelper(self.vumi_api, msg)
         router = yield mdh.get_router()
         returnValue(router.batch.key)

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -296,7 +296,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
         if msg_mdh.has_user_account():
             user_account_key = msg_mdh.get_account_key()
         elif msg_mdh.tag is not None:
-            tag_info = yield self.vumi_api.mdb.get_tag_info(tuple(msg_mdh.tag))
+            tag_info = yield msg_mdh.get_tag_info()
             user_account_key = tag_info.metadata['user_account']
             if user_account_key is None:
                 raise UnroutableMessageError(
@@ -386,8 +386,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
         elif conn.ctype == conn.TRANSPORT_TAG:
             msg_mdh.set_tag([conn.tagpool, conn.tagname])
-            tagpool_metadata = yield self.vumi_api.tpm.get_metadata(
-                conn.tagpool)
+            tagpool_metadata = yield msg_mdh.get_tagpool_metadata()
             transport_name = tagpool_metadata.get('transport_name')
             if transport_name is None:
                 raise UnroutableMessageError(
@@ -569,7 +568,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
             # but this is an error path)
             f.raiseException()
 
-        tagpool_metadata = yield self.vumi_api.tpm.get_metadata(msg_mdh.tag[0])
+        tagpool_metadata = yield msg_mdh.get_tagpool_metadata()
         if not tagpool_metadata.get('reply_to_unroutable_inbound'):
             f.raiseException()
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -119,6 +119,9 @@ class TestOptOutMiddleware(VumiTestCase):
         yield mw.handle_inbound(msg, 'dummy_endpoint')
         expected_response = dict(expected_response,
                                  tag={'tag': ['pool', 'tag1']})
+        # MessageMetadataHelper can add 'go' metadata and we want to ignore it.
+        if 'go' in msg['helper_metadata']:
+            expected_response['go'] = msg['helper_metadata']['go']
         self.assertEqual(msg['helper_metadata'], expected_response)
 
     @inlineCallbacks

--- a/go/vumitools/tests/test_utils.py
+++ b/go/vumitools/tests/test_utils.py
@@ -88,9 +88,14 @@ class TestMessageMetadataHelper(VumiTestCase):
             'user_account': conversation.user_account.key,
             'conversation_key': conversation.key,
         })
+        md.set_tag(["pool", "tag"])
         self.assertEqual(md._store_objects, {})
         md_conv = yield md.get_conversation()
-        self.assertEqual(md._store_objects, {'conversation': md_conv})
+        tag_info = yield md.get_tag_info()
+        self.assertEqual(md._store_objects, {
+            'conversation': md_conv,
+            'tag_info': tag_info,
+        })
         md.clear_object_cache()
         self.assertEqual(md._store_objects, {})
 
@@ -238,3 +243,68 @@ class TestMessageMetadataHelper(VumiTestCase):
         self.assertNotIdentical(md, other_md)
         self.assertEqual({}, other_md._store_objects)
         self.assertEqual(md._go_metadata, other_md._go_metadata)
+
+    def test_get_tag_info_no_tag(self):
+        md = self.mk_md()
+        self.assertEqual(None, md.tag)
+        self.assertRaises(ValueError, md.get_tag_info)
+
+    def test_get_tagpool_metadata_no_tag(self):
+        md = self.mk_md()
+        self.assertEqual(None, md.tag)
+        self.assertRaises(ValueError, md.get_tagpool_metadata)
+
+    @inlineCallbacks
+    def test_get_tag_info(self):
+        md = self.mk_md()
+        md.set_tag(["pool", "tagname"])
+
+        tag_info = yield md.get_tag_info()
+        self.assertEqual(("pool", "tagname"), tag_info.tag)
+
+    @inlineCallbacks
+    def test_tag_info_caching(self):
+        md = self.mk_md()
+        md.set_tag(["pool", "tagname"])
+
+        self.assertEqual({}, md._store_objects)
+        tag_info = yield md.get_tag_info()
+        self.assertEqual(("pool", "tagname"), tag_info.tag)
+        self.assertEqual({'tag_info': tag_info}, md._store_objects)
+
+        # Stash a fake thing in the cache to make sure that what we get is
+        # actually the thing in the cache.
+        md._store_objects['tag_info'] = "I am the cached tag_info"
+        cached_tag_info = yield md.get_tag_info()
+        self.assertEqual(cached_tag_info, "I am the cached tag_info")
+
+    @inlineCallbacks
+    def test_get_tagpool_metadata(self):
+        yield self.vumi_helper.setup_tagpool("pool", ["tagname"], metadata={
+            "foo": "bar",
+        })
+        md = self.mk_md()
+        md.set_tag(["pool", "tagname"])
+
+        tagpool_metadata = yield md.get_tagpool_metadata()
+        self.assertEqual({"foo": "bar"}, tagpool_metadata)
+
+    @inlineCallbacks
+    def test_tagpool_metadata_caching(self):
+        yield self.vumi_helper.setup_tagpool("pool", ["tagname"], metadata={
+            "foo": "bar",
+        })
+        md = self.mk_md()
+        md.set_tag(["pool", "tagname"])
+
+        self.assertEqual({}, md._store_objects)
+        tagpool_metadata = yield md.get_tagpool_metadata()
+        self.assertEqual({"foo": "bar"}, tagpool_metadata)
+        self.assertEqual(
+            {'tagpool_metadata': tagpool_metadata}, md._store_objects)
+
+        # Stash a fake thing in the cache to make sure that what we get is
+        # actually the thing in the cache.
+        md._store_objects['tagpool_metadata'] = "I am the cached metadata"
+        cached_tagpool_metadata = yield md.get_tagpool_metadata()
+        self.assertEqual(cached_tagpool_metadata, "I am the cached metadata")

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -3,7 +3,6 @@
 from twisted.internet.defer import succeed
 
 from vumi.middleware.tagger import TaggingMiddleware
-from go.vumitools.middleware import OptOutMiddleware
 
 
 class MessageMetadataHelper(object):
@@ -121,6 +120,8 @@ class MessageMetadataHelper(object):
         self._go_metadata.pop('is_paid', None)
 
     def is_optout_message(self):
+        # To avoid circular imports.
+        from go.vumitools.middleware import OptOutMiddleware
         return OptOutMiddleware.is_optout_message(self.message)
 
     def get_router_key(self):

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -50,6 +50,16 @@ class MessageMetadataHelper(object):
         """
         self._store_objects.clear()
 
+    def _stash_and_return_object(self, obj, key):
+        self._store_objects[key] = obj
+        return obj
+
+    def _get_if_not_stashed(self, key, func, *args, **kw):
+        if key in self._store_objects:
+            return succeed(self._store_objects[key])
+        return func(*args, **kw).addCallback(
+            self._stash_and_return_object, key)
+
     def is_sensitive(self):
         """
         Returns True if the contents of the message have been marked as
@@ -81,15 +91,9 @@ class MessageMetadataHelper(object):
         return self._go_metadata['conversation_key']
 
     def get_conversation(self):
-        if 'conversation' in self._store_objects:
-            return succeed(self._store_objects['conversation'])
-
-        def stash_and_return_conv(conv):
-            self._store_objects['conversation'] = conv
-            return conv
-
-        return self.get_user_api().get_wrapped_conversation(
-            self.get_conversation_key()).addCallback(stash_and_return_conv)
+        return self._get_if_not_stashed(
+            'conversation', self.get_user_api().get_wrapped_conversation,
+            self.get_conversation_key())
 
     def get_conversation_info(self):
         conversation_info = {}
@@ -152,3 +156,17 @@ class MessageMetadataHelper(object):
     def set_tag(self, tag):
         TaggingMiddleware.add_tag_to_msg(self.message, tag)
         self.tag = TaggingMiddleware.map_msg_to_tag(self.message)
+
+    def get_tag_info(self):
+        if self.tag is None:
+            raise ValueError("No tag to look up metadata for.")
+
+        return self._get_if_not_stashed(
+            'tag_info', self.vumi_api.mdb.get_tag_info, tuple(self.tag))
+
+    def get_tagpool_metadata(self):
+        if self.tag is None:
+            raise ValueError("No tag to look up metadata for.")
+
+        return self._get_if_not_stashed(
+            'tagpool_metadata', self.vumi_api.tpm.get_metadata, self.tag[0])


### PR DESCRIPTION
There are a bunch of redis/riak lookups we can cache in `MessageMetadataHelper` to avoid unnecessary work.

I'm going to start with middlewares and the routing table dispatcher because that's what's hurting us the most right now.
