### PR TITLE
Make message export not rely on message keys being in the MessageStoreCache.

### DIFF
--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -165,9 +165,3 @@ def get_router_view_definition(router_type, router=None):
     if not hasattr(router_pkg, 'view_definition'):
         return RouterViewDefinitionBase(router_def)
     return router_pkg.view_definition.RouterViewDefinition(router_def)
-
-
-# Thanks Craz @ SO: http://stackoverflow.com/a/434411
-def grouper(iterable, n, fillvalue=None):
-    args = [iter(iterable)] * n
-    return izip_longest(*args, fillvalue=fillvalue)

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -2,7 +2,6 @@
 
 import csv
 import codecs
-from itertools import izip_longest
 from StringIO import StringIO
 
 from django import forms

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -2,6 +2,7 @@
 
 import csv
 import codecs
+from itertools import izip_longest
 from StringIO import StringIO
 
 from django import forms
@@ -164,3 +165,9 @@ def get_router_view_definition(router_type, router=None):
     if not hasattr(router_pkg, 'view_definition'):
         return RouterViewDefinitionBase(router_def)
     return router_pkg.view_definition.RouterViewDefinition(router_def)
+
+
+# Thanks Craz @ SO: http://stackoverflow.com/a/434411
+def grouper(iterable, n, fillvalue=None):
+    args = [iter(iterable)] * n
+    return izip_longest(*args, fillvalue=fillvalue)

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -1,5 +1,3 @@
-import warnings
-
 from StringIO import StringIO
 from zipfile import ZipFile, ZIP_DEFLATED
 

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -147,10 +147,12 @@ def export_conversation_messages_sorted(account_key, conversation_key):
     # limiting to 0 results in getting the full set, creating lists of tuples
     # with direction sort we can sort sent & received messages in a somewhat
     # threaded fashion further down.
-    sent_messages = [('sent', msg)
-                     for msg in conversation.sent_messages(limit=0)]
-    received_messages = [('received', msg)
-                         for msg in conversation.received_messages(limit=0)]
+    sent_messages = [
+        ('sent', msg)
+        for msg in conversation.sent_messages_in_cache(limit=0)]
+    received_messages = [
+        ('received', msg)
+        for msg in conversation.received_messages_in_cache(limit=0)]
 
     def sort_by_addr_and_timestap(entry):
         """

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -45,7 +45,8 @@ def load_messages_in_chunks(conversation, direction=None, size=20,
     :param int size:
         How big the chunks should be. Default 20.
     :param bool include_sensitive:
-        If ``true`` then all messages marked as `sensitive` are skipped.
+        If ``False`` then all messages marked as `sensitive` are skipped.
+        Defaults to ``False``.
     :param callable scrubber:
         If provided, this is called for every message allowing it to be
         modified on the fly.

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -116,14 +116,6 @@ def export_conversation_messages_unsorted(account_key, conversation_key):
 
 
 @task(ignore_result=True)
-def export_conversation_messages(account_key, conversation_key):
-    warnings.warn('export_conversation_messages() is deprecated. '
-                  'Please use export_conversation_messages_sorted() instead',
-                  category=DeprecationWarning)
-    return export_conversation_messages_sorted(account_key, conversation_key)
-
-
-@task(ignore_result=True)
 def export_conversation_messages_sorted(account_key, conversation_key):
     """
     Export the messages (threaded and sorted) in a conversation via email.

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -1,3 +1,5 @@
+import warnings
+
 from StringIO import StringIO
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -8,13 +10,94 @@ from django.core.mail import EmailMessage
 
 from go.vumitools.api import VumiUserApi
 from go.base.models import UserProfile
-from go.base.utils import UnicodeCSVWriter
+from go.base.utils import UnicodeCSVWriter, grouper
+
+
+# The field names to export
+conversation_export_field_names = [
+    'timestamp',
+    'from_addr',
+    'to_addr',
+    'content',
+    'message_id',
+    'in_reply_to',
+]
+
+
+def write_messages(writer, messages):
+    for message in messages:
+        writer.writerow([unicode(message.payload.get(fn) or '')
+                         for fn in conversation_export_field_names])
+    return messages
+
+
+def email_export(user_profile, conversation, io):
+    zipio = StringIO()
+    zf = ZipFile(zipio, "a", ZIP_DEFLATED)
+    zf.writestr("messages-export.csv", io.getvalue())
+    zf.close()
+
+    email = EmailMessage(
+        'Conversation message export: %s' % (conversation.name,),
+        'Please find the messages of the conversation %s attached.\n' % (
+            conversation.name),
+        settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
+    email.attach('messages-export.zip', zipio.getvalue(), 'application/zip')
+    email.send()
+
+
+@task(ignore_result=True)
+def export_conversation_messages_unsorted(account_key, conversation_key):
+    """
+    Export the messages from a conversation as they come from the message
+    store. Completely unsorted.
+
+    :param str account_key:
+        The account holder's account account_key
+    :param str conversation_key:
+        The key of the conversation we want to export the messages for.
+    """
+    api = VumiUserApi.from_config_sync(account_key, settings.VUMI_API_CONFIG)
+    user_profile = UserProfile.objects.get(user_account=account_key)
+    conversation = api.get_wrapped_conversation(conversation_key)
+    mdb = conversation.mdb
+    io = StringIO()
+
+    writer = UnicodeCSVWriter(io)
+    writer.writerow(conversation_export_field_names)
+
+    inbound_keys = conversation.inbound_keys()
+    outbound_keys = conversation.outbound_keys()
+
+    for keys_chunk in grouper(inbound_keys, 20):
+        messages = conversation.collect_messages(
+            message_keys, conversation.messages.inbound_messages,
+            include_sensitive=False, scrubber=None)
+        write_messages(writer, messages)
+
+    for keys_chunk in grouper(outbound_keys, 20):
+        messages = conversation.collect_messages(
+            message_keys, conversation.messages.outbound_messages,
+            include_sensitive=False, scrubber=None)
+        write_messages(writer, messages)
+
+    email_export(user_profile, conversation, io)
 
 
 @task(ignore_result=True)
 def export_conversation_messages(account_key, conversation_key):
+    warnings.warn('export_conversation_messages() is deprecated. '
+                  'Please use export_conversation_messages_sorted() instead',
+                  category=DeprecationWarning)
+    return export_conversation_messages_sorted(account_key, conversation_key)
+
+
+@task(ignore_result=True)
+def export_conversation_messages_sorted(account_key, conversation_key):
     """
-    Export the messages in a conversation via email.
+    Export the messages (threaded and sorted) in a conversation via email.
+
+    NOTE: This loads _all_ messages from the conversation into memory.
 
     :param str account_key:
         The account holder's account account_key
@@ -22,31 +105,21 @@ def export_conversation_messages(account_key, conversation_key):
         The key of the conversation we want to export the messages for.
     """
 
-    # The field names to export
-    field_names = [
-        'from_addr',
-        'to_addr',
-        'timestamp',
-        'content',
-        'message_id',
-        'in_reply_to',
-    ]
-
     api = VumiUserApi.from_config_sync(account_key, settings.VUMI_API_CONFIG)
     user_profile = UserProfile.objects.get(user_account=account_key)
     conversation = api.get_wrapped_conversation(conversation_key)
     io = StringIO()
 
     writer = UnicodeCSVWriter(io)
-    writer.writerow(field_names)
+    writer.writerow(conversation_export_field_names)
 
     # limiting to 0 results in getting the full set, creating lists of tuples
     # with direction sort we can sort sent & received messages in a somewhat
     # threaded fashion further down.
     sent_messages = [('sent', msg)
-                        for msg in conversation.sent_messages(limit=0)]
+                     for msg in conversation.sent_messages(limit=0)]
     received_messages = [('received', msg)
-                            for msg in conversation.received_messages(limit=0)]
+                         for msg in conversation.received_messages(limit=0)]
 
     def sort_by_addr_and_timestap(entry):
         """
@@ -61,22 +134,8 @@ def export_conversation_messages(account_key, conversation_key):
         return (message['from_addr'], message['timestamp'])
 
     all_messages = [msg for directon, msg in
-                        sorted(sent_messages + received_messages,
-                            key=sort_by_addr_and_timestap)]
+                    sorted(sent_messages + received_messages,
+                           key=sort_by_addr_and_timestap)]
 
-    for message in all_messages:
-        writer.writerow([unicode(message.payload.get(fn) or '')
-                            for fn in field_names])
-
-    zipio = StringIO()
-    zf = ZipFile(zipio, "a", ZIP_DEFLATED)
-    zf.writestr("messages-export.csv", io.getvalue())
-    zf.close()
-
-    email = EmailMessage(
-        'Conversation message export: %s' % (conversation.name,),
-        'Please find the messages of the conversation %s attached.\n' % (
-            conversation.name),
-        settings.DEFAULT_FROM_EMAIL, [user_profile.user.email])
-    email.attach('messages-export.zip', zipio.getvalue(), 'application/zip')
-    email.send()
+    write_messages(writer, all_messages)
+    email_export(user_profile, conversation, io)

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -51,11 +51,16 @@ def load_messages_in_chunks(conversation, direction=None, size=20,
         If provided, this is called for every message allowing it to be
         modified on the fly.
     """
-    direction = ('inbound' if direction == 'inbound' else 'outbound')
-    keys_func = getattr(conversation, '%s_keys' % (direction,))
-    proxy = getattr(conversation.mdb, '%s_messages' % (direction,))
+    if direction == 'inbound':
+        keys = conversation.inbound_keys()
+        proxy = conversation.mdb.inbound_messages
+    elif direction == 'outbound':
+        keys = conversation.outbound_keys()
+        proxy = conversation.mdb.outbound_messages
+    else:
+        raise ValueError('Invalid value received for `direction`. '
+                         'Only `inbound` and `outbound` are allowed.')
 
-    keys = keys_func()
     for chunk in grouper(keys, size):
         # grouper() pads with `None` if less than `size` available,
         # we unpad here.

--- a/go/conversation/tasks.py
+++ b/go/conversation/tasks.py
@@ -31,7 +31,7 @@ def write_messages(writer, messages):
     return messages
 
 
-def load_messages_in_chunks(conversation, direction=None, size=20,
+def load_messages_in_chunks(conversation, direction='inbound', size=20,
                             include_sensitive=False, scrubber=None):
     """
     Load the conversation's messages in chunks of `size`.
@@ -58,8 +58,9 @@ def load_messages_in_chunks(conversation, direction=None, size=20,
         keys = conversation.outbound_keys()
         proxy = conversation.mdb.outbound_messages
     else:
-        raise ValueError('Invalid value received for `direction`. '
-                         'Only `inbound` and `outbound` are allowed.')
+        raise ValueError('Invalid value (%s) received for `direction`. '
+                         'Only `inbound` and `outbound` are allowed.' %
+                         (direction,))
 
     for chunk in grouper(keys, size):
         # grouper() pads with `None` if less than `size` available,

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -874,10 +874,13 @@ class TestConversationTasks(GoDjangoTestCase):
         [(file_name, zipcontent, mime_type)] = email.attachments
         self.assertEqual(file_name, 'messages-export.zip')
         zipfile = ZipFile(StringIO(zipcontent), 'r')
-        content = zipfile.open('messages-export.csv', 'r').read()
-        # 1 header, 5 sent, 5 received, 1 trailing newline == 12
-        self.assertEqual(12, len(content.split('\n')))
-        self.assertEqual(mime_type, 'application/zip')
+        fp = zipfile.open('messages-export.csv', 'r')
+        reader = csv.reader(fp)
+        message_ids = [row[4] for row in reader]
+        self.assertEqual('message_id', message_ids.pop(0))
+        self.assertEqual(
+            set(message_ids),
+            set(conv.inbound_keys() + conv.outbound_keys()))
 
     def test_export_conversation_messages_sorted(self):
         conv = self.create_conversation(reply_count=2)

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -716,7 +716,7 @@ class TestConversationViews(BaseConversationViewTestCase):
     def test_send_one_off_reply(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
         self.msg_helper.add_inbound_to_conv(conv, 1)
-        [msg] = conv.received_messages()
+        [msg] = conv.received_messages_in_cache()
         response = self.client.post(self.get_view_url(conv, 'message_list'), {
             'in_reply_to': msg['message_id'],
             'content': 'foo',

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -847,8 +847,7 @@ class TestConversationReportsView(BaseConversationViewTestCase):
 class TestConversationTasks(GoDjangoTestCase):
     def setUp(self):
         self.vumi_helper = self.add_helper(
-            DjangoVumiApiHelper(), setup_vumi_api=False)
-        self.vumi_helper.setup_vumi_api()
+            DjangoVumiApiHelper())
         self.user_helper = self.vumi_helper.make_django_user()
         self.msg_helper = self.add_helper(
             GoMessageHelper(vumi_helper=self.vumi_helper))

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -22,7 +22,7 @@ from go.vumitools.exceptions import ConversationSendError
 from go.token.django_token_manager import DjangoTokenManager
 from go.conversation.forms import (ConfirmConversationForm, ReplyToMessageForm,
                                    ConversationDetailForm)
-from go.conversation.tasks import export_conversation_messages
+from go.conversation.tasks import export_conversation_messages_unsorted
 from go.conversation.utils import PagedMessageCache
 from go.dashboard.dashboard import Dashboard, ConversationReportsLayout
 
@@ -301,7 +301,7 @@ class MessageListView(ConversationTemplateView):
 
     def post(self, request, conversation):
         if '_export_conversation_messages' in request.POST:
-            export_conversation_messages.delay(
+            export_conversation_messages_unsorted.delay(
                 request.user_api.user_account_key, conversation.key)
             messages.info(request, 'Conversation messages CSV file export '
                                     'scheduled. CSV file should arrive in '

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -222,11 +222,11 @@ class MessageListView(ConversationTemplateView):
         # Paginator starts counting at 1 so 0 would also be invalid
         inbound_message_paginator = Paginator(
             PagedMessageCache(conversation.count_replies(),
-                lambda start, stop: conversation.received_messages(
+                lambda start, stop: conversation.received_messages_in_cache(
                     start, stop)), 20)
         outbound_message_paginator = Paginator(
             PagedMessageCache(conversation.count_sent_messages(),
-                lambda start, stop: conversation.sent_messages(
+                lambda start, stop: conversation.sent_messages_in_cache(
                     start, stop)), 20)
 
         tag_context = {

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -64,10 +64,22 @@ class TestConversationWrapper(VumiTestCase):
         self.assertEqual((yield self.conv.count_replies()), 5)
 
     @inlineCallbacks
+    def test_inbound_keys(self):
+        messages = yield self.msg_helper.add_inbound_to_conv(self.conv, 5)
+        keys = set([message['message_id'] for message in messages])
+        self.assertEqual(set((yield self.conv.inbound_keys())), keys)
+
+    @inlineCallbacks
     def test_count_sent_messages(self):
         yield self.conv.start()
         yield self.msg_helper.add_outbound_to_conv(self.conv, 5)
         self.assertEqual((yield self.conv.count_sent_messages()), 5)
+
+    @inlineCallbacks
+    def test_outbound_keys(self):
+        messages = yield self.msg_helper.add_outbound_to_conv(self.conv, 5)
+        keys = set([message['message_id'] for message in messages])
+        self.assertEqual(set((yield self.conv.outbound_keys())), keys)
 
     @inlineCallbacks
     def test_count_inbound_uniques(self):

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -105,11 +105,14 @@ class TestConversationWrapper(VumiTestCase):
     def test_received_messages(self):
         yield self.conv.start()
         yield self.msg_helper.add_inbound_to_conv(self.conv, 5)
-        received_messages = yield self.conv.received_messages()
+        received_messages = yield self.conv.received_messages_in_cache()
         self.assertEqual(len(received_messages), 5)
-        self.assertEqual(len((yield self.conv.received_messages(0, 2))), 2)
-        self.assertEqual(len((yield self.conv.received_messages(2, 4))), 2)
-        self.assertEqual(len((yield self.conv.received_messages(5, 10))), 0)
+        self.assertEqual(
+            len((yield self.conv.received_messages_in_cache(0, 2))), 2)
+        self.assertEqual(
+            len((yield self.conv.received_messages_in_cache(2, 4))), 2)
+        self.assertEqual(
+            len((yield self.conv.received_messages_in_cache(5, 10))), 0)
 
     @inlineCallbacks
     def test_received_messages_include_sensitive(self):
@@ -118,10 +121,11 @@ class TestConversationWrapper(VumiTestCase):
             self.conv, "hi", helper_metadata={
                 'go': {'sensitive': True},
             })
-        self.assertEqual([], (yield self.conv.received_messages()))
+        self.assertEqual([], (yield self.conv.received_messages_in_cache()))
         self.assertEqual(
             1,
-            len((yield self.conv.received_messages(include_sensitive=True))))
+            len((yield self.conv.received_messages_in_cache(
+                include_sensitive=True))))
 
     @inlineCallbacks
     def test_received_messages_include_sensitive_and_scrub(self):
@@ -135,7 +139,7 @@ class TestConversationWrapper(VumiTestCase):
             msg['content'] = 'scrubbed'
             return msg
 
-        [scrubbed_messages] = yield self.conv.received_messages(
+        [scrubbed_messages] = yield self.conv.received_messages_in_cache(
             include_sensitive=True, scrubber=scrubber)
         self.assertEqual(scrubbed_messages['content'], 'scrubbed')
 
@@ -143,18 +147,21 @@ class TestConversationWrapper(VumiTestCase):
     def test_received_messages_dictionary(self):
         yield self.conv.start()
         msg = yield self.msg_helper.make_stored_inbound(self.conv, "hi")
-        [reply] = yield self.conv.received_messages()
+        [reply] = yield self.conv.received_messages_in_cache()
         self.assertEqual(msg['message_id'], reply['message_id'])
 
     @inlineCallbacks
     def test_sent_messages(self):
         yield self.conv.start()
         yield self.msg_helper.add_outbound_to_conv(self.conv, 5)
-        sent_messages = yield self.conv.sent_messages()
+        sent_messages = yield self.conv.sent_messages_in_cache()
         self.assertEqual(len(sent_messages), 5)
-        self.assertEqual(len((yield self.conv.sent_messages(0, 2))), 2)
-        self.assertEqual(len((yield self.conv.sent_messages(2, 4))), 2)
-        self.assertEqual(len((yield self.conv.sent_messages(5, 10))), 0)
+        self.assertEqual(
+            len((yield self.conv.sent_messages_in_cache(0, 2))), 2)
+        self.assertEqual(
+            len((yield self.conv.sent_messages_in_cache(2, 4))), 2)
+        self.assertEqual(
+            len((yield self.conv.sent_messages_in_cache(5, 10))), 0)
 
     @inlineCallbacks
     def test_sent_messages_include_sensitive(self):
@@ -163,9 +170,11 @@ class TestConversationWrapper(VumiTestCase):
             self.conv, "hi", helper_metadata={
                 'go': {'sensitive': True},
             })
-        self.assertEqual([], (yield self.conv.sent_messages()))
+        self.assertEqual([], (yield self.conv.sent_messages_in_cache()))
         self.assertEqual(
-            1, len((yield self.conv.sent_messages(include_sensitive=True))))
+            1,
+            len((yield self.conv.sent_messages_in_cache(
+                include_sensitive=True))))
 
     @inlineCallbacks
     def test_sent_messages_include_sensitive_and_scrub(self):
@@ -179,7 +188,7 @@ class TestConversationWrapper(VumiTestCase):
             msg['content'] = 'scrubbed'
             return msg
 
-        [scrubbed_message] = yield self.conv.sent_messages(
+        [scrubbed_message] = yield self.conv.sent_messages_in_cache(
             include_sensitive=True, scrubber=scrubber)
         self.assertEqual(scrubbed_message['content'], 'scrubbed')
 
@@ -187,7 +196,7 @@ class TestConversationWrapper(VumiTestCase):
     def test_sent_messages_dictionary(self):
         yield self.conv.start()
         msg = yield self.msg_helper.make_stored_outbound(self.conv, "hi")
-        [sent_message] = yield self.conv.sent_messages()
+        [sent_message] = yield self.conv.sent_messages_in_cache()
         self.assertEqual(msg['message_id'], sent_message['message_id'])
 
     @inlineCallbacks

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -458,6 +458,20 @@ class ConversationWrapper(object):
 
         returnValue(sorted(aggregates.items()))
 
+    def inbound_keys(self):
+        """
+        Return the keys for this conversation's received messages in
+        whatever order the message store decides to give them back to us.
+        """
+        return self.mdb.batch_inbound_keys(self.batch.key)
+
+    def outbound_keys(self):
+        """
+        Return the keys for this conversation's sent messages in
+        whatever order the message store decides to give them back to us.
+        """
+        return self.mdb.batch_outbound_keys(self.batch.key)
+
     @property
     def worker_name(self):
         # TODO better way of working out worker_name

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -1,6 +1,7 @@
 # -*- test-case-name: go.vumitools.conversation.tests.test_utils -*-
 # -*- coding: utf-8 -*-
 
+import warnings
 from datetime import datetime
 from collections import defaultdict
 
@@ -258,9 +259,17 @@ class ConversationWrapper(object):
                     collection.append(scrubbed_msg)
         returnValue(collection)
 
-    @Manager.calls_manager
     def received_messages(self, start=0, limit=100, include_sensitive=False,
                           scrubber=None):
+        warnings.warn('received_messages() is deprecated. Please use '
+                      'received_messages_in_cache() instead.',
+                      category=DeprecationWarning)
+        return self.received_messages_in_cache(start, limit, include_sensitive,
+                                               scrubber)
+
+    @Manager.calls_manager
+    def received_messages_in_cache(self, start=0, limit=100,
+                                   include_sensitive=False, scrubber=None):
         """
         Get a list of replies from the message store. The keys come from
         the message store's cache.
@@ -290,9 +299,17 @@ class ConversationWrapper(object):
 
         returnValue(replies)
 
-    @Manager.calls_manager
     def sent_messages(self, start=0, limit=100, include_sensitive=False,
                       scrubber=None):
+        warnings.warn('sent_messages() is deprecated. Please use '
+                      'sent_messages_in_cache() instead.',
+                      category=DeprecationWarning)
+        return self.sent_messages_in_cache(start, limit, include_sensitive,
+                                           scrubber)
+
+    @Manager.calls_manager
+    def sent_messages_in_cache(self, start=0, limit=100,
+                               include_sensitive=False, scrubber=None):
         """
         Get a list of sent_messages from the message store. The keys come from
         the message store's cache.

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -246,6 +246,21 @@ class ConversationWrapper(object):
         for bunch in bunches:
             messages.extend((yield bunch))
 
+        returnValue(self.filter_and_scrub_messages(
+            messages, include_sensitive=include_sensitive, scrubber=scrubber))
+
+    def filter_and_scrub_messages(self, messages, include_sensitive, scrubber):
+        """
+        Filter and scrub the given messages.
+
+        :param list messages:
+            The list of messages to filter and scrub.
+        :param bool include_sensitive:
+            Whether or not to include hidden messages.
+        :param callable scrubber:
+            The scrubber to use on hidden messages. Should return a message
+            object or None.
+        """
         collection = []
         for message in messages:
             # vumi message is an attribute on the inbound message object
@@ -257,7 +272,7 @@ class ConversationWrapper(object):
                 scrubbed_msg = scrubber(msg)
                 if scrubbed_msg:
                     collection.append(scrubbed_msg)
-        returnValue(collection)
+        return collection
 
     def received_messages(self, start=0, limit=100, include_sensitive=False,
                           scrubber=None):


### PR DESCRIPTION
This assumption goes away with the work going on in praekelt/vumi#675. Currently the message store cache is being used as a convenient way of retrieving message keys and timestamps, an alternative to that needs to be found.
