### PR TITLE
Split conversation and router config classes.

### DIFF
--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -208,7 +208,6 @@ class TestNoStreamingHTTPWorker(VumiTestCase):
         response = yield http_request_full(url, json.dumps(msg),
                                            self.auth_headers, method='PUT')
 
-        print repr(response.delivered_body)
         put_msg = json.loads(response.delivered_body)
         self.assertEqual(response.code, http.OK)
 

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -106,7 +106,7 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
                 event['user_message_id'], event['event_id']))
 
         config = yield self.get_message_config(event)
-        conversation = config.get_conversation()
+        conversation = config.conversation
         push_url = self.get_api_config(conversation, 'push_event_url')
         yield self.send_event_to_client(event, conversation, push_url)
 

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -9,7 +9,8 @@ from vumi.config import ConfigDict
 from vumi.application.sandbox import JsSandbox, SandboxResource
 from vumi import log
 
-from go.vumitools.app_worker import GoApplicationMixin, GoWorkerConfigMixin
+from go.vumitools.app_worker import (
+    GoApplicationMixin, GoApplicationConfigMixin)
 
 
 class ConversationConfigResource(SandboxResource):
@@ -26,7 +27,7 @@ class ConversationConfigResource(SandboxResource):
         return self.reply(command, value=value, success=True)
 
 
-class JsBoxConfig(JsSandbox.CONFIG_CLASS, GoWorkerConfigMixin):
+class JsBoxConfig(JsSandbox.CONFIG_CLASS, GoApplicationConfigMixin):
     jsbox_app_config = ConfigDict(
         "Custom configuration passed to the javascript code.", default={})
     jsbox = ConfigDict(
@@ -40,7 +41,7 @@ class JsBoxConfig(JsSandbox.CONFIG_CLASS, GoWorkerConfigMixin):
 
     @property
     def sandbox_id(self):
-        return self.get_conversation().user_account.key
+        return self.conversation.user_account.key
 
 
 class JsBoxApplication(GoApplicationMixin, JsSandbox):
@@ -76,7 +77,7 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
         yield self._go_teardown_worker()
 
     def conversation_for_api(self, api):
-        return api.config.get_conversation()
+        return api.config.conversation
 
     def user_api_for_api(self, api):
         conv = self.conversation_for_api(api)
@@ -103,7 +104,7 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
         config = yield self.get_config(msg)
         if not config.javascript:
             log.warning("No JS for conversation: %s" % (
-                config.get_conversation().key,))
+                config.conversation.key,))
             return
         yield super(JsBoxApplication, self).process_message_in_sandbox(msg)
 

--- a/go/apps/wikipedia/vumi_app.py
+++ b/go/apps/wikipedia/vumi_app.py
@@ -3,11 +3,12 @@ from twisted.internet.defer import inlineCallbacks
 
 from vumi_wikipedia.wikipedia import WikipediaWorker, TimerWrapper
 
-from go.vumitools.app_worker import GoApplicationMixin, GoWorkerConfigMixin
+from go.vumitools.app_worker import (
+    GoApplicationMixin, GoApplicationConfigMixin)
 from go.vumitools.metrics import ConversationMetric
 
 
-class WikipediaConfig(WikipediaWorker.CONFIG_CLASS, GoWorkerConfigMixin):
+class WikipediaConfig(WikipediaWorker.CONFIG_CLASS, GoApplicationConfigMixin):
     pass
 
 
@@ -37,7 +38,7 @@ class WikipediaApplication(WikipediaWorker, GoApplicationMixin):
         pass
 
     def get_timer_metric(self, config, metric_name):
-        metric = ConversationMetric(config.get_conversation(), metric_name)
+        metric = ConversationMetric(config.conversation, metric_name)
         # TODO: Make this less horrible.
         metric.set = lambda value: metric.oneshot(self.metrics, value)
         return TimerWrapper(metric)
@@ -47,7 +48,7 @@ class WikipediaApplication(WikipediaWorker, GoApplicationMixin):
 
     def send_sms_non_reply(self, msg, config, sms_content):
         helper_metadata = {}
-        config.get_conversation().set_go_helper_metadata(helper_metadata)
+        config.conversation.set_go_helper_metadata(helper_metadata)
         return self.send_to(
             msg['from_addr'], sms_content, transport_type='sms',
             endpoint='sms_content', helper_metadata=helper_metadata)


### PR DESCRIPTION
Currently conversation and router config classes share too much infrastructure (and the infrastructure is rather hacky). This splits things up more and cleans things up a big. A further goal is to allow applications more control over how conversation config is translated into application config.
