### PR TITLE
User profile inline admin form clashes with post-save hook

### DIFF
--- a/go/base/admin.py
+++ b/go/base/admin.py
@@ -14,6 +14,11 @@ class UserProfileInline(admin.StackedInline):
 
 
 class GoUserAdmin(UserAdmin):
+    def get_inline_instances(self, request, obj=None):
+        if obj is None:
+            return []
+        return super(GoUserAdmin, self).get_inline_instances(request, obj=obj)
+
     # The forms to add and change user instances
     inlines = (UserProfileInline,)
 


### PR DESCRIPTION
Currently the inline user profile save box in the admin interface clashes with the post-save hook that automatically creates a user profile. If one sets a user profile value in the inline form on the user creation page, then on save the new user is saved and then Django attempts to create a second user profile, resulting in a uniqueness constraint error.
