### PR TITLE
Fix setup_env again

### DIFF
--- a/go/api/go_api/utils.py
+++ b/go/api/go_api/utils.py
@@ -16,6 +16,9 @@ class GoApiSubHandler(BaseSubhandler, object):
 
     def __init__(self, user_account_key, vumi_api):
         super(GoApiSubHandler, self).__init__()
+        # We could get either bytes or unicode here. Decode if necessary.
+        if not isinstance(user_account_key, unicode):
+            user_account_key = user_account_key.decode('utf8')
         self.user_account_key = user_account_key
         self.vumi_api = vumi_api
 

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -83,6 +83,9 @@ class VumiUserApi(object):
     conversation_wrapper = ConversationWrapper
 
     def __init__(self, api, user_account_key):
+        # We could get either bytes or unicode here. Decode if necessary.
+        if not isinstance(user_account_key, unicode):
+            user_account_key = user_account_key.decode('utf8')
         self.api = api
         self.manager = self.api.manager
         self.user_account_key = user_account_key

--- a/go/vumitools/tests/helpers.py
+++ b/go/vumitools/tests/helpers.py
@@ -351,7 +351,9 @@ class VumiApiHelper(object):
     @proxyable
     @maybe_async
     def make_user(self, username, enable_search=True, django_user_pk=None):
-        key = u"test-%s-user" % (len(self._user_helpers),)
+        # NOTE: We use bytes instead of unicode here because that's what the
+        #       real new_user gives us.
+        key = "test-%s-user" % (len(self._user_helpers),)
         user = self.get_vumi_api().account_store.users(key, username=username)
         yield user.save()
         user_helper = UserApiHelper(self, key, django_user_pk=django_user_pk)

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -65,6 +65,16 @@ class TestTxVumiUserApi(VumiTestCase):
         self.account_store_vnone = AccountStoreVNone(self.vumi_api.manager)
         self.account_store_v1 = AccountStoreV1(self.vumi_api.manager)
 
+    def test_create_converts_key_to_unicode(self):
+        """
+        The user_account_key attr should be unicode even if a bytestring was
+        provided.
+        """
+        user_api_from_unicode = VumiUserApi(self.vumi_api, u'foo')
+        self.assertIsInstance(user_api_from_unicode.user_account_key, unicode)
+        user_api_from_bytes = VumiUserApi(self.vumi_api, 'foo')
+        self.assertIsInstance(user_api_from_bytes.user_account_key, unicode)
+
     @inlineCallbacks
     def test_optout_filtering(self):
         group = yield self.user_api.contact_store.new_group(u'test-group')


### PR DESCRIPTION
It's somehow managed to get broken:

```
Wrote setup_env/build/go_subscription_application.yaml.
Wrote setup_env/build/go_subscription_application.conf.
Account user1@example.org created
ValidationError: Value 'b68a5428cf3046a9a660aa2cb0aa452c' is not a unicode string.
```
