### PR TITLE
Pass DiamondashApiErrors on to the client and log them rather than throwing an raw exception up to Django.

### DIFF
--- a/go/dashboard/client.py
+++ b/go/dashboard/client.py
@@ -9,6 +9,10 @@ class DiamondashApiError(Exception):
     Raised when we something goes wrong while trying to interact with
     diamondash api.
     """
+    def __init__(self, code, content, message):
+        super(DiamondashApiError, self).__init__(message)
+        self.code = code
+        self.content = content
 
 
 class DiamondashApiClient(object):
@@ -39,6 +43,7 @@ class DiamondashApiClient(object):
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
             raise DiamondashApiError(
+                resp.status_code, resp.content,
                 "%s: %s" % (e, resp.content))
 
         return {

--- a/go/dashboard/client.py
+++ b/go/dashboard/client.py
@@ -9,8 +9,8 @@ class DiamondashApiError(Exception):
     Raised when we something goes wrong while trying to interact with
     diamondash api.
     """
-    def __init__(self, code, content, message):
-        super(DiamondashApiError, self).__init__(message)
+    def __init__(self, code, content):
+        super(DiamondashApiError, self).__init__("%s: %s" % (code, content))
         self.code = code
         self.content = content
 
@@ -41,10 +41,9 @@ class DiamondashApiClient(object):
 
         try:
             resp.raise_for_status()
-        except requests.exceptions.HTTPError as e:
+        except requests.exceptions.HTTPError:
             raise DiamondashApiError(
-                resp.status_code, resp.content,
-                "%s: %s" % (e, resp.content))
+                resp.status_code, resp.content)
 
         return {
             'code': resp.status_code,

--- a/go/dashboard/tests/test_client.py
+++ b/go/dashboard/tests/test_client.py
@@ -17,7 +17,8 @@ class FakeResponse(object):
 
 
 class FakeErrorResponse(object):
-    def __init__(self, content):
+    def __init__(self, content, status_code=500):
+        self.status_code = status_code
         self.content = content
 
     def raise_for_status(self):

--- a/go/dashboard/tests/test_views.py
+++ b/go/dashboard/tests/test_views.py
@@ -27,3 +27,19 @@ class DashboardViewsTestCase(GoDjangoTestCase):
 
         self.assertEqual(resp.content, json.dumps({'bar': 'baz'}))
         self.assertEqual(resp.status_code, 201)
+
+    def test_api_proxy_error(self):
+        self.diamondash_api.set_error_response(404, "Bad horse")
+        resp = self.client.get('/diamondash/api/foo')
+
+        self.assertEqual(self.diamondash_api.get_requests(), [{
+            'url': '/foo',
+            'content': '',
+            'method': 'GET',
+        }])
+
+        self.assertEqual(resp.content, json.dumps({
+            "message": "Bad horse",
+            "success": False,
+        }))
+        self.assertEqual(resp.status_code, 404)

--- a/go/dashboard/tests/utils.py
+++ b/go/dashboard/tests/utils.py
@@ -21,8 +21,7 @@ class FakeDiamondashApiClient(DiamondashApiClient):
             'message': message
         })
 
-        self._response = DiamondashApiError(
-            code, data, "(%s) %s" % (code, data))
+        self._response = DiamondashApiError(code, data)
 
     def set_raw_response(self, content="", code=200):
         self._response = {

--- a/go/dashboard/tests/utils.py
+++ b/go/dashboard/tests/utils.py
@@ -21,7 +21,8 @@ class FakeDiamondashApiClient(DiamondashApiClient):
             'message': message
         })
 
-        self._response = DiamondashApiError("(%s) %s" % (code, data))
+        self._response = DiamondashApiError(
+            code, data, "(%s) %s" % (code, data))
 
     def set_raw_response(self, content="", code=200):
         self._response = {


### PR DESCRIPTION
Currently if Diamondash responds with an error, Vumi Go let's the exception bubble all the way up to Django's handlers rather than logging it and passing the error on to the client.

This is an issue when Diamondash is restarted and clients need to detect a need to refresh the page they're on.

A long term solution is probably to teach Diamondash about remote sources of dashboard config.
