### PR TITLE
Change credit definition and credit factor

### DIFF
--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -5,9 +5,9 @@ from django.contrib.auth import get_user_model
 
 from go.config import billing_quantization_exponent
 
-
+# 10 credits = 1 US cent
 CREDIT_CONVERSION_FACTOR = getattr(
-    settings, 'BILLING_CREDIT_CONVERSION_FACTOR', Decimal('0.25'))
+    settings, 'BILLING_CREDIT_CONVERSION_FACTOR', Decimal('10.00'))
 
 # This is currently pulled in from `go.config` to avoid pulling a pile of
 # Django stuff into `go.vumitools.billing_worker` through `go.billing.utils`.


### PR DESCRIPTION
Currently a credit is defined as 4 (Note: in Vumi, billing costs are represented in US cents. So 4 cents is represented as 4, not .04)

Please change the credit definition to .1 (i.e. one tenth of one cent)

We'll also need to change the credit factor from 0.25 to 10 (i.e. such that a cost of 2.6 cents is reflected as 26 credits)
