### PR TITLE
Log messages should go to Sentry, not our inbox

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -212,6 +212,10 @@ LOGGING = {
         },
     },
     'handlers': {
+        'sentry': {
+            'level': 'ERROR',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler'
@@ -230,7 +234,7 @@ LOGGING = {
         },
     },
     'root': {
-        'handlers': ['mail_admins'],
+        'handlers': ['sentry'],
         'level': 'ERROR',
     },
 }

--- a/go/settings.py
+++ b/go/settings.py
@@ -214,7 +214,7 @@ LOGGING = {
     'handlers': {
         'sentry': {
             'level': 'ERROR',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+            'class': 'raven.contrib.django.handlers.SentryHandler',
         },
         'mail_admins': {
             'level': 'ERROR',

--- a/go/testsettings.py
+++ b/go/testsettings.py
@@ -62,7 +62,7 @@ STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 
 # disable console logging to avoid log messages messing up test output
 LOGGING['loggers']['go']['handlers'].remove('console')
-LOGGING['root']['handlers'].remove('mail_admins')
+LOGGING['root']['handlers'].remove('sentry')
 
 # disable response-time middleware during tests
 DISALLOWED_MIDDLEWARE = set([


### PR DESCRIPTION
This may just be a configuration thing, but making a ticket anyways.
