### PR TITLE
Fix acquiring source hop in routing table dispatcher when billing in the source

### DIFF
--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -466,7 +466,12 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
             src_conn = str(GoConnector.for_opt_out())
 
         elif connector_type == self.BILLING:
-            src_conn = str(GoConnector.for_billing(direction))
+            # when the source is a billing router, outbound messages
+            # are always received from the inbound billing connector
+            # and inbound messages are always received from the outbound
+            # billing connector.
+            src_conn = str(
+                GoConnector.for_billing(self.router_direction(direction)))
 
         else:
             raise UnroutableMessageError(

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -680,7 +680,7 @@ class TestRoutingTableDispatcherWithBilling(RoutingTableDispatcherTestCase):
             'billing_dispatcher_ro.inbound', 'app1.inbound')
 
         self.with_md(msg, conv=('app1', 'conv1'), hops=[
-            ['BILLING:INBOUND', 'default'],
+            ['BILLING:OUTBOUND', 'default'],
             ['CONVERSATION:app1:conv1', 'default'],
         ])
         self.assertEqual(
@@ -714,7 +714,7 @@ class TestRoutingTableDispatcherWithBilling(RoutingTableDispatcherTestCase):
             'billing_dispatcher_ro.inbound', 'optout.inbound')
 
         hops = [
-            ['BILLING:INBOUND', 'default'],
+            ['BILLING:OUTBOUND', 'default'],
             ['OPT_OUT', 'default'],
         ]
         self.with_md(msg, user_account=self.user_account_key, hops=hops)
@@ -784,7 +784,7 @@ class TestRoutingTableDispatcherWithBilling(RoutingTableDispatcherTestCase):
             'billing_dispatcher_ri.outbound', 'sphex.outbound')
 
         hops = [
-            ['BILLING:OUTBOUND', 'default'],
+            ['BILLING:INBOUND', 'default'],
             ['TRANSPORT_TAG:pool1:1234', 'default']
         ]
         self.with_md(msg, hops=hops)
@@ -819,7 +819,7 @@ class TestRoutingTableDispatcherWithBilling(RoutingTableDispatcherTestCase):
             'billing_dispatcher_ri.outbound', 'sphex.outbound')
 
         hops = [
-            ['BILLING:OUTBOUND', 'default'],
+            ['BILLING:INBOUND', 'default'],
             ['TRANSPORT_TAG:pool1:1234', 'default'],
         ]
         self.with_md(msg, hops=hops)


### PR DESCRIPTION
This issue was discovered because events weren't being routed correctly during a load test. Example traceback:

``` python
2014-02-18 14:39:28+0200 [VumiRedis,client] 'Error routing message for billing_dispatcher_ro'
2014-02-18 14:39:28+0200 [VumiRedis,client] Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 304, in addCallback
            callbackKeywords=kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 293, in addCallbacks
            self._runCallbacks()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 575, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1213, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1070, in _inlineCallbacks
            result = g.send(result)
          File "/var/praekelt/vumi-go/go/vumitools/routing.py", line 769, in process_event
            "Could not find next hop for event.", event)
        go.vumitools.routing.UnroutableMessageError: ('Could not find next hop for event.', <Message payload="{'transport_name': u'go_loadtesting_transport', 'event_type': u'ack', 'event_id': u'46f9205a41f944dc8d5c6a590558337f', 'sent_message_id': u'bb6439a5eaa04f7c9a8eeacb0e51232f', 'helper_metadata': {u'go': {u'user_account': u'feab35c9260c46aca9c523ca7c6a3b29'}, u'tag': {u'tag': [u'go_loadtest', u'go-loadtest-01']}}, 'routing_metadata': {u'go_outbound_hops': [[[u'CONVERSATION:static_reply:43abd859b5014c4dbdf424ca712870cb', u'default'], [u'BILLING:OUTBOUND', u'default']], [[u'BILLING:OUTBOUND', u'default'], [u'TRANSPORT_TAG:go_loadtest:go-loadtest-01', u'default']]], u'go_hops': [[[u'TRANSPORT_TAG:go_loadtest:go-loadtest-01', u'default'], [u'BILLING:OUTBOUND', u'default']], [['BILLING:INBOUND', u'default'], None]], u'endpoint_name': u'default'}, 'message_version': u'20110921', 'timestamp': datetime.datetime(2014, 2, 18, 12, 39, 28, 465233), 'transport_metadata': {}, 'user_message_id': u'bb6439a5eaa04f7c9a8eeacb0e51232f', 'message_type': u'event'}">)
```

Note the discrepancy between the `go_outbound_hops`:

```
[[['CONVERSATION:static_reply:43abd859b5014c4dbdf424ca712870cb', 'default'],
  ['BILLING:OUTBOUND', 'default']],
 [['BILLING:OUTBOUND', 'default'],
  ['TRANSPORT_TAG:go_loadtest:go-loadtest-01', 'default']]]
```

and the `go_hops` being built up for the event:

```
[[['TRANSPORT_TAG:go_loadtest:go-loadtest-01', 'default'],
  ['BILLING:OUTBOUND', 'default']],
 [['BILLING:INBOUND', 'default'], None]]
```
