### PR TITLE
npm post install hook exits unhappily when the symlinks already exist

### DIFF
--- a/utils/npm-post-install.sh
+++ b/utils/npm-post-install.sh
@@ -3,9 +3,13 @@
 BINS='grunt bower yuglify'
 PROJECT_ROOT=$(cd "`dirname $0`/.."; pwd)
 
-if [ -n $VIRTUAL_ENV ]; then
-  for bin in $BINS
-  do
-    ln -s $PROJECT_ROOT/node_modules/.bin/$bin $VIRTUAL_ENV/bin/$bin
-  done
-fi
+function make_links {
+    if [ -n $VIRTUAL_ENV ]; then
+        for bin in $BINS
+        do
+            ln -s $PROJECT_ROOT/node_modules/.bin/$bin $VIRTUAL_ENV/bin/$bin
+        done
+    fi
+}
+
+make_links || :

--- a/utils/npm-post-install.sh
+++ b/utils/npm-post-install.sh
@@ -3,15 +3,16 @@
 BINS='grunt bower yuglify'
 PROJECT_ROOT=$(cd "`dirname $0`/.."; pwd)
 
-function make_links {
-    if [ -n $VIRTUAL_ENV ]; then
-        for bin in $BINS
-        do
-            ln -s $PROJECT_ROOT/node_modules/.bin/$bin $VIRTUAL_ENV/bin/$bin
-        done
-    fi
-
-    return 0;
+function link {
+    src="$PROJECT_ROOT/node_modules/.bin/$bin"
+    dest="$VIRTUAL_ENV/bin/$1"
+    ln -s $src $dest  2> /dev/null || echo "Skipping $1, symlink already exists."
 }
 
-make_links
+
+if [ -n $VIRTUAL_ENV ]; then
+    for bin in $BINS
+    do
+        link $bin
+    done
+fi

--- a/utils/npm-post-install.sh
+++ b/utils/npm-post-install.sh
@@ -4,7 +4,7 @@ BINS='grunt bower yuglify'
 PROJECT_ROOT=$(cd "`dirname $0`/.."; pwd)
 
 function link {
-    src="$PROJECT_ROOT/node_modules/.bin/$bin"
+    src="$PROJECT_ROOT/node_modules/.bin/$1"
     dest="$VIRTUAL_ENV/bin/$1"
     ln -s $src $dest  2> /dev/null || echo "Skipping $1, symlink already exists."
 }

--- a/utils/npm-post-install.sh
+++ b/utils/npm-post-install.sh
@@ -10,6 +10,8 @@ function make_links {
             ln -s $PROJECT_ROOT/node_modules/.bin/$bin $VIRTUAL_ENV/bin/$bin
         done
     fi
+
+    return 0;
 }
 
-make_links || :
+make_links


### PR DESCRIPTION
This means that a `fab js_setup_env` will stop after doing its thing for the first host.
