### PR TITLE
Expose Wikipedia config options in the UI.

### DIFF
--- a/go/apps/wikipedia/tests/test_views.py
+++ b/go/apps/wikipedia/tests/test_views.py
@@ -46,26 +46,33 @@ class TestWikipediaViews(GoDjangoTestCase):
         response = self.client.get(conv_helper.get_view_url('show'))
         self.assertContains(response, u"<h1>myconv</h1>")
 
-    def test_edit_set_api_url(self):
+    def test_edit_set_all_fields(self):
         conv_helper = self.app_helper.create_conversation_helper()
         conversation = conv_helper.get_conversation()
         self.assertEqual(conversation.config, {})
         response = self.client.post(conv_helper.get_view_url('edit'), {
             'api_url': 'http://wikipedia/api.php',
+            'include_url_in_sms': True,
+            'mobi_url_host': 'http://mobi/',
         }, follow=True)
         self.assertRedirects(response, conv_helper.get_view_url('show'))
         reloaded_conv = conv_helper.get_conversation()
         self.assertEqual(reloaded_conv.config, {
             'api_url': 'http://wikipedia/api.php',
+            'include_url_in_sms': True,
+            'mobi_url_host': 'http://mobi/',
         })
 
-    def test_edit_no_api_url(self):
+    def test_edit_set_no_fields(self):
         conv_helper = self.app_helper.create_conversation_helper()
         conversation = conv_helper.get_conversation()
         self.assertEqual(conversation.config, {})
         response = self.client.post(conv_helper.get_view_url('edit'), {
-            'wikipedia-api_url': '',
+            'api_url': '',
+            'mobi_url_host': '',
         }, follow=True)
         self.assertRedirects(response, conv_helper.get_view_url('show'))
         reloaded_conv = conv_helper.get_conversation()
-        self.assertEqual(reloaded_conv.config, {})
+        self.assertEqual(reloaded_conv.config, {
+            'include_url_in_sms': False,
+        })

--- a/go/apps/wikipedia/tests/test_views.py
+++ b/go/apps/wikipedia/tests/test_views.py
@@ -32,7 +32,7 @@ class TestWikipediaViews(GoDjangoTestCase):
         self.assertEqual(conversation.description, '')
         self.assertEqual(conversation.config, {})
         self.assertEqual(list(conversation.extra_endpoints), [u'sms_content'])
-        self.assertRedirects(response, conv_helper.get_view_url('show'))
+        self.assertRedirects(response, conv_helper.get_view_url('edit'))
 
     def test_show_stopped(self):
         conv_helper = self.app_helper.create_conversation_helper(
@@ -45,3 +45,27 @@ class TestWikipediaViews(GoDjangoTestCase):
             name=u"myconv", started=True)
         response = self.client.get(conv_helper.get_view_url('show'))
         self.assertContains(response, u"<h1>myconv</h1>")
+
+    def test_edit_set_api_url(self):
+        conv_helper = self.app_helper.create_conversation_helper()
+        conversation = conv_helper.get_conversation()
+        self.assertEqual(conversation.config, {})
+        response = self.client.post(conv_helper.get_view_url('edit'), {
+            'api_url': 'http://wikipedia/api.php',
+        }, follow=True)
+        self.assertRedirects(response, conv_helper.get_view_url('show'))
+        reloaded_conv = conv_helper.get_conversation()
+        self.assertEqual(reloaded_conv.config, {
+            'api_url': 'http://wikipedia/api.php',
+        })
+
+    def test_edit_no_api_url(self):
+        conv_helper = self.app_helper.create_conversation_helper()
+        conversation = conv_helper.get_conversation()
+        self.assertEqual(conversation.config, {})
+        response = self.client.post(conv_helper.get_view_url('edit'), {
+            'wikipedia-api_url': '',
+        }, follow=True)
+        self.assertRedirects(response, conv_helper.get_view_url('show'))
+        reloaded_conv = conv_helper.get_conversation()
+        self.assertEqual(reloaded_conv.config, {})

--- a/go/apps/wikipedia/tests/test_vumi_app.py
+++ b/go/apps/wikipedia/tests/test_vumi_app.py
@@ -63,3 +63,10 @@ class TestWikipediaApplication(VumiTestCase, FakeHTTPTestCaseMixin):
             ConversationMetric.make_name(self.conv, name) for name in [
                 'wikipedia_search_call', 'wikipedia_extract_call',
                 'wikipedia_extract_call']])
+
+    @inlineCallbacks
+    def test_api_url_config(self):
+        yield self.setup_conv({'api_url': 'http://wikipedia/api.php'})
+        msg = self.app_helper.make_inbound(None, conv=self.conv)
+        config = yield self.app.get_config(msg)
+        self.assertEqual(config.api_url.geturl(), 'http://wikipedia/api.php')

--- a/go/apps/wikipedia/tests/test_vumi_app.py
+++ b/go/apps/wikipedia/tests/test_vumi_app.py
@@ -65,8 +65,14 @@ class TestWikipediaApplication(VumiTestCase, FakeHTTPTestCaseMixin):
                 'wikipedia_extract_call']])
 
     @inlineCallbacks
-    def test_api_url_config(self):
-        yield self.setup_conv({'api_url': 'http://wikipedia/api.php'})
+    def test_conversation_config(self):
+        yield self.setup_conv({
+            'api_url': 'http://wikipedia/api.php',
+            'include_url_in_sms': True,
+            'mobi_url_host': 'http://mobi/',
+        })
         msg = self.app_helper.make_inbound(None, conv=self.conv)
         config = yield self.app.get_config(msg)
         self.assertEqual(config.api_url.geturl(), 'http://wikipedia/api.php')
+        self.assertEqual(config.include_url_in_sms, True)
+        self.assertEqual(config.mobi_url_host, 'http://mobi/')

--- a/go/apps/wikipedia/view_definition.py
+++ b/go/apps/wikipedia/view_definition.py
@@ -1,5 +1,32 @@
-from go.conversation.view_definition import ConversationViewDefinitionBase
+from django import forms
+
+from go.conversation.view_definition import (
+    ConversationViewDefinitionBase, EditConversationView)
+
+
+class ConfigForm(forms.Form):
+    api_url = forms.CharField(
+        help_text='The mediawiki API URL to use.', required=False)
+
+    @staticmethod
+    def initial_from_config(data):
+        return {
+            'api_url': data.get('api_url', None),
+        }
+
+    def to_config(self):
+        data = self.cleaned_data
+        config_dict = {}
+        if data['api_url']:
+            config_dict['api_url'] = data['api_url']
+        return config_dict
+
+
+class EditWikipediaView(EditConversationView):
+    edit_forms = (
+        (None, ConfigForm),
+    )
 
 
 class ConversationViewDefinition(ConversationViewDefinitionBase):
-    pass
+    edit_view = EditWikipediaView

--- a/go/apps/wikipedia/view_definition.py
+++ b/go/apps/wikipedia/view_definition.py
@@ -6,19 +6,30 @@ from go.conversation.view_definition import (
 
 class ConfigForm(forms.Form):
     api_url = forms.CharField(
-        help_text='The mediawiki API URL to use.', required=False)
+        help_text="The mediawiki API URL to use.", required=False)
+    include_url_in_sms = forms.BooleanField(
+        help_text="Include URL in the first SMS.", required=False)
+    mobi_url_host = forms.CharField(
+        help_text="The replacement URL base to use in the first SMS.",
+        required=False)
 
     @staticmethod
     def initial_from_config(data):
         return {
             'api_url': data.get('api_url', None),
+            'include_url_in_sms': data.get('include_url_in_sms', False),
+            'mobi_url_host': data.get('mobi_url_host', None),
         }
 
     def to_config(self):
         data = self.cleaned_data
-        config_dict = {}
+        config_dict = {
+            'include_url_in_sms': data['include_url_in_sms'],
+        }
         if data['api_url']:
             config_dict['api_url'] = data['api_url']
+        if data['mobi_url_host']:
+            config_dict['mobi_url_host'] = data['mobi_url_host']
         return config_dict
 
 

--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -173,7 +173,7 @@ class TestWizardViews(GoDjangoTestCase):
         self.assertEqual(1, len(self.user_helper.user_api.active_channels()))
         self.assertRedirects(
             response, reverse('conversations:conversation', kwargs={
-                'conversation_key': conv.key, 'path_suffix': '',
+                'conversation_key': conv.key, 'path_suffix': 'edit/',
             }))
 
     def test_post_create_view_invalid_conversation_type(self):


### PR DESCRIPTION
The Wikipedia app has a number of config options, some of those need to be exposed in the Go UI, especially `include_url_in_sms` and `mobi_url_host`.
