### PR TITLE
Create billing accounts when user accounts are created

### DIFF
--- a/go/base/management/commands/go_manage_account.py
+++ b/go/base/management/commands/go_manage_account.py
@@ -58,5 +58,8 @@ class Command(BaseGoCommand):
             if created:
                 self.stdout.write(
                     "  Created billing account.\n")
+            else:
+                self.stdout.write(
+                    "  Billing account already exists.\n")
 
         self._apply_to_accounts(create_billing_account)

--- a/go/base/management/commands/go_manage_account.py
+++ b/go/base/management/commands/go_manage_account.py
@@ -1,0 +1,62 @@
+from optparse import make_option
+
+from go.base.command_utils import (
+    BaseGoCommand, CommandError, make_command_option,
+    user_details_as_string, get_user_by_account_key)
+from go.billing.models import Account
+
+
+class Command(BaseGoCommand):
+    help = "Manage Go accounts."
+
+    option_list = BaseGoCommand.option_list + (
+        make_command_option(
+            'create_billing_account',
+            help=(
+                "Create a billing account table entry for the user if"
+                "there isn't an entry already.")),
+        make_option(
+            '--email-address', dest='email_address',
+            help="Act on the given user."),
+        make_option(
+            '--all',
+            dest='all_accounts',
+            help='Act on all accounts.'),
+        make_option('--dry-run',
+            dest='dry_run',
+            action='store_true', default=False,
+            help='Just pretend to act.'),
+    )
+
+    def _get_user_apis(self):
+        if self.options.get("email_address"):
+            return [self.mk_user_api(self.options["email_address"])]
+        if self.options.get("all_accounts"):
+            return self.mk_all_user_apis()
+        raise CommandError(
+            "Please specify either --email-address or --all-users")
+
+    def _apply_to_accounts(self, func, dry_run=None):
+        if dry_run is None:
+            dry_run = self.options.get('dry_run')
+
+        for user, user_api in self._get_user_apis():
+            self.stdout.write(
+                "Performing %s on account %s ...\n" % (
+                    func.__name__, user_details_as_string(user)
+                ))
+            if not dry_run:
+                func(user_api)
+            self.stdout.write("done.\n")
+
+    def handle_command_create_billing_account(self, *args, **options):
+        def create_billing_account(user_api):
+            account_key = user_api.user_account_key
+            user = get_user_by_account_key(account_key)
+            _, created = Account.objects.get_or_create(
+                user=user, account_number=account_key)
+            if created:
+                self.stdout.write(
+                    "  Created billing account.\n")
+
+        self._apply_to_accounts(create_billing_account)

--- a/go/base/tests/test_go_manage_account.py
+++ b/go/base/tests/test_go_manage_account.py
@@ -91,6 +91,7 @@ class TestGoManageAccount(GoCommandTestCase):
         expected_output = "\n".join([
             u'Performing create_billing_account on account'
             u' Test User <user@domain.com> [test-0-user] ...',
+            u'  Billing account already exists.',
             u'done.',
             u''
         ])

--- a/go/base/tests/test_go_manage_account.py
+++ b/go/base/tests/test_go_manage_account.py
@@ -70,7 +70,8 @@ class TestGoManageAccount(GoCommandTestCase):
             'dummy')
 
     def test_billing_account_created(self):
-        self.assertEqual(self.get_billing_account(), None)
+        account = self.get_billing_account()
+        account.delete()
         expected_output = "\n".join([
             u'Performing create_billing_account on account'
             u' Test User <user@domain.com> [test-0-user] ...',
@@ -86,7 +87,7 @@ class TestGoManageAccount(GoCommandTestCase):
         self.assertEqual(account.account_number, self.user_helper.account_key)
 
     def test_billing_account_already_exists(self):
-        initial_account = self.mk_billing_account()
+        initial_account = self.get_billing_account()
         expected_output = "\n".join([
             u'Performing create_billing_account on account'
             u' Test User <user@domain.com> [test-0-user] ...',

--- a/go/base/tests/test_go_manage_account.py
+++ b/go/base/tests/test_go_manage_account.py
@@ -1,0 +1,102 @@
+from go.base.command_utils import make_command_option
+from go.base.management.commands import go_manage_account
+from go.base.tests.helpers import GoCommandTestCase
+from go.billing.models import Account
+
+
+class TestGoManageAccount(GoCommandTestCase):
+
+    def setUp(self):
+        self.setup_command(go_manage_account.Command)
+
+    def mk_billing_account(self):
+        user = self.user_helper.get_django_user()
+        return Account.objects.create(
+            user=user, account_number=user.userprofile.user_account)
+
+    def get_billing_account(self):
+        user = self.user_helper.get_django_user()
+        try:
+            return Account.objects.get(
+                account_number=user.userprofile.user_account)
+        except Account.DoesNotExist:
+            return None
+
+    def setup_dummy_command(self):
+        def handle_command_dummy(*args, **options):
+            def dummy(user_api):
+                pass
+
+            self.command._apply_to_accounts(dummy)
+
+        self.command.handle_command_dummy = handle_command_dummy
+        self.command.option_list = self.command.option_list + (
+            make_command_option("dummy"),)
+
+    def test_select_individual_account(self):
+        self.setup_dummy_command()
+        expected_output = "\n".join([
+            u'Performing dummy on account'
+            u' Test User <user@domain.com> [test-0-user] ...',
+            u'done.',
+            u''
+        ])
+        self.assert_command_output(
+            expected_output, 'dummy',
+            email_address=self.user_email)
+
+    def test_select_all_accounts(self):
+        self.setup_dummy_command()
+        self.vumi_helper.make_django_user(
+            email="user-two@domain.com",
+            first_name="Second", last_name="User")
+        expected_output = "\n".join([
+            u'Performing dummy on account'
+            u' Second User <user-two@domain.com> [test-1-user] ...',
+            u'done.',
+            u'Performing dummy on account'
+            u' Test User <user@domain.com> [test-0-user] ...',
+            u'done.',
+            u''
+        ])
+        self.assert_command_output(
+            expected_output, 'dummy',
+            all_accounts=True)
+
+    def test_no_account_selected(self):
+        self.setup_dummy_command()
+        self.assert_command_error(
+            "^Please specify either --email-address or --all-users$",
+            'dummy')
+
+    def test_billing_account_created(self):
+        self.assertEqual(self.get_billing_account(), None)
+        expected_output = "\n".join([
+            u'Performing create_billing_account on account'
+            u' Test User <user@domain.com> [test-0-user] ...',
+            u'  Created billing account.',
+            u'done.',
+            u''
+        ])
+        self.assert_command_output(
+            expected_output, 'create_billing_account',
+            email_address=self.user_email)
+        account = self.get_billing_account()
+        self.assertEqual(account.user.email, self.user_email)
+        self.assertEqual(account.account_number, self.user_helper.account_key)
+
+    def test_billing_account_already_exists(self):
+        initial_account = self.mk_billing_account()
+        expected_output = "\n".join([
+            u'Performing create_billing_account on account'
+            u' Test User <user@domain.com> [test-0-user] ...',
+            u'done.',
+            u''
+        ])
+        self.assert_command_output(
+            expected_output, 'create_billing_account',
+            email_address=self.user_email)
+        account = self.get_billing_account()
+        self.assertEqual(account.user.email, self.user_email)
+        self.assertEqual(account.account_number, self.user_helper.account_key)
+        self.assertEqual(account.id, initial_account.id)

--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -711,8 +711,8 @@ class TransactionResource(BaseResource):
         if result is None:
             raise BillingError(
                 "Unable to determine %s message cost for account %s"
-                " and tag pool %s" % (message_direction, account_number,
-                                      tag_pool_name))
+                " and tag pool %s" % (
+                    message_direction, account_number, tag_pool_name))
 
         message_cost = result.get('message_cost', 0)
         session_cost = result.get('session_cost', 0)
@@ -784,10 +784,17 @@ class TransactionResource(BaseResource):
         params = {'account_number': account_number}
         cursor = yield cursor.execute(query, params)
         result = yield cursor.fetchone()
+
+        if result is None:
+            raise BillingError(
+                "Unable to find billing account %s while checking"
+                " credit balance. Message was %s to/from tag pool %s." % (
+                    account_number, message_direction, tag_pool_name))
+
         credit_balance = result.get('credit_balance')
         alert_credit_balance = result.get('alert_credit_balance')
-        if credit_balance < alert_credit_balance and \
-                credit_balance + credit_amount > alert_credit_balance:
+        if (credit_balance < alert_credit_balance and
+                credit_balance + credit_amount > alert_credit_balance):
             pass  # TODO: Raise a Low Credits alert; somehow
 
         defer.returnValue(transaction)

--- a/go/billing/models.py
+++ b/go/billing/models.py
@@ -1,10 +1,13 @@
 from decimal import Decimal
 
 from django.db import models
+from django.db.models.signals import post_save
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
+
 import go.billing.settings as app_settings
+from go.base.models import UserProfile
 
 
 class TagPool(models.Model):
@@ -36,6 +39,16 @@ class Account(models.Model):
 
     def __unicode__(self):
         return u"{0} ({1})".format(self.account_number, self.user.email)
+
+
+def create_billing_account(sender, instance, created, **kwargs):
+    if created:
+        Account.objects.create(user=instance.user,
+                               account_number=instance.user_account)
+
+
+post_save.connect(create_billing_account, sender=UserProfile,
+    dispatch_uid='go.billing.models.create_billing_account')
 
 
 class MessageCost(models.Model):

--- a/go/billing/tests/test_forms.py
+++ b/go/billing/tests/test_forms.py
@@ -32,8 +32,7 @@ class TestMessageCostForm(GoDjangoTestCase):
         self.tag_pool = TagPool(name=u"pool", description=u"description")
         self.tag_pool.save()
 
-        self.account = Account(user=self.user, account_number="1234")
-        self.account.save()
+        self.account = Account.objects.get(user=self.user)
 
     def patch_quantization(self, quantization):
         self.monkey_patch(

--- a/go/billing/tests/test_models.py
+++ b/go/billing/tests/test_models.py
@@ -18,8 +18,7 @@ class TestAccount(GoDjangoTestCase):
 
     def test_unicode(self):
         django_user = self.user_helper.get_django_user()
-        acc = Account(
-            user=django_user, account_number=self.user_helper.account_key)
+        acc = Account.objects.get(user=django_user)
         self.assertEqual(
             unicode(acc),
             u"%s (%s)" % (self.user_helper.account_key, django_user)
@@ -33,10 +32,8 @@ class TestMessageCost(GoDjangoTestCase):
 
     def mk_msg_cost(self, account=None, tag_pool=None, **kw):
         if account is None:
-            account = Account(
-                user=self.user_helper.get_django_user(),
-                account_number=self.user_helper.account_key)
-            account.save()
+            account = Account.objects.get(
+                user=self.user_helper.get_django_user())
         if tag_pool is None:
             tag_pool = TagPool(name=u"pool", description=u"description")
             tag_pool.save()

--- a/go/billing/tests/test_models.py
+++ b/go/billing/tests/test_models.py
@@ -24,6 +24,18 @@ class TestAccount(GoDjangoTestCase):
             u"%s (%s)" % (self.user_helper.account_key, django_user)
         )
 
+    def test_post_save_hook(self):
+        user_helper = self.vumi_helper.make_django_user(
+            email="newuser@example.com")
+        django_user = user_helper.get_django_user()
+        profile = django_user.get_profile()
+        acc = Account.objects.get(user=django_user)
+        self.assertEqual(acc.user, django_user)
+        self.assertEqual(acc.account_number, profile.user_account)
+        self.assertEqual(acc.credit_balance, 0.0)
+        self.assertEqual(acc.alert_threshold, 0.0)
+        self.assertEqual(acc.alert_credit_balance, 0.0)
+
 
 class TestMessageCost(GoDjangoTestCase):
     def setUp(self):


### PR DESCRIPTION
Billing people requires that they have a billing account. Currently no one has them. We need:
- To create them automatically when accounts are created.
- To add a management commands to create them for all the accounts that currently don't have them.
