### PR TITLE
Properly display errors when posting new channel forms

### DIFF
--- a/go/channel/templates/channel/new.html
+++ b/go/channel/templates/channel/new.html
@@ -17,6 +17,9 @@
         <div class="col-md-4">
             <form id="form-channels" class="indent" method="post" action="">
                 {% csrf_token %}
+                {% if new_channel_form.errors %}
+                    {{ new_channel_form.errors }}
+                {% endif %}
 
                 <div class="form-group">
                     <label class="control-label" for="id_{{ new_channel_form.country.name }}">

--- a/go/channel/tests.py
+++ b/go/channel/tests.py
@@ -59,6 +59,22 @@ class TestChannelViews(GoDjangoTestCase):
         self.assertRedirects(response, self.get_view_url('show', channel_key))
         self.assert_active_channel_tags([tag])
 
+    def test_post_new_channel_no_country(self):
+        self.assert_active_channel_tags([])
+        response = self.client.post(reverse('channels:new_channel'), {
+            'channel': 'longcode:'})
+        self.assertContains(response, '<li>country<ul class="errorlist">'
+                            '<li>This field is required.</li></ul></li>')
+        self.assert_active_channel_tags([])
+
+    def test_post_new_channel_no_channel(self):
+        self.assert_active_channel_tags([])
+        response = self.client.post(reverse('channels:new_channel'), {
+            'country': 'International'})
+        self.assertContains(response, '<li>channel<ul class="errorlist">'
+                            '<li>This field is required.</li></ul></li>')
+        self.assert_active_channel_tags([])
+
     def test_show_channel_missing(self):
         response = self.client.get(self.get_view_url('show', u'foo:bar'))
         self.assertEqual(response.status_code, 404)

--- a/go/channel/views.py
+++ b/go/channel/views.py
@@ -85,12 +85,11 @@ def new_channel(request):
                 request.user_api.get_channel((pool, tag)))
             return redirect(
                 view_def.get_view_url('show', channel_key=channel_key))
-        else:
-            raise ValueError(repr('Error: %s' % (form.errors,)))
+    else:
+        form = NewChannelForm(request.user_api)
 
-    new_channel_form = NewChannelForm(request.user_api)
     return render(request, 'channel/new.html', {
-        'new_channel_form': new_channel_form,
+        'new_channel_form': form,
     })
 
 


### PR DESCRIPTION
Currently we raise a `ValueError` and return a 500 response:

``` python
Traceback (most recent call last):

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 115, in get_response
    response = callback(request, *callback_args, **callback_kwargs)

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 25, in _wrapped_view
    return view_func(request, *args, **kwargs)

  File "/var/praekelt/vumi-go/go/channel/views.py", line 89, in new_channel
    raise ValueError(repr('Error: %s' % (form.errors,)))

ValueError: 'Error: <ul class="errorlist"><li>country<ul class="errorlist"><li>This field is required.</li></ul></li><li>channel<ul class="errorlist"><li>This field is required.</li></ul></li></ul>'
```
