### PR TITLE
Accessing the help page while not logged in returns a 500 response

### DIFF
--- a/go/templates/app.html
+++ b/go/templates/app.html
@@ -10,8 +10,10 @@
                 <img src="{{ STATIC_URL }}img/logo-lrg.png" alt="Vumi Go" class="logo" width="63">
             </a>
         </li>
+        {% if request.user.is_authenticated %}
         <li><a href="{% url 'conversations:index' %}">Dashboard</a></li>
         <li><a href="{% url 'contacts:people' %}">Contacts</a></li>
+        {% endif %}
     </ul>
 
     <ul class="nav navbar-nav pull-right">
@@ -29,6 +31,7 @@
         {% endcomment %}
 
         <li><a href="{% url 'help' %}">Help</a></li>
+        {% if request.user.is_authenticated %}
         <li class="dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                 Account
@@ -41,6 +44,7 @@
                 <li><span class="status">{% credit_balance request.user %}</span></li>
             </ul>
         </li>
+        {% endif %}
     </ul>
 </nav>
 {% endblock %}

--- a/go/templates/flatpages/default.html
+++ b/go/templates/flatpages/default.html
@@ -1,7 +1,8 @@
 {% extends "app.html" %}
 {% load markup %}
 
-{% block page_title %}{{flatpage.title}}{% endblock %}
+{% block page_title %}Vumi Go: {{flatpage.title}}{% endblock %}
+{% block content_title %}{{flatpage.title}}{% endblock %}
 
 {% block content_main %}
 {{flatpage.content|markdown}}

--- a/go/tests/test_views.py
+++ b/go/tests/test_views.py
@@ -6,7 +6,7 @@ from django.contrib.sites.models import Site
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
 
 
-class TestChannelViews(GoDjangoTestCase):
+class TestHelpViews(GoDjangoTestCase):
 
     def setUp(self):
         self.vumi_helper = self.add_helper(DjangoVumiApiHelper())
@@ -20,6 +20,7 @@ class TestChannelViews(GoDjangoTestCase):
             page.sites.add(site)
 
     def test_help_authenticated(self):
+        """The help view should be accessible when logged in."""
         self.mk_help()
         response = self.client.get(reverse('help'))
         self.assertEqual(response.status_code, 200)
@@ -30,6 +31,7 @@ class TestChannelViews(GoDjangoTestCase):
         self.assertContains(response, 'credits')
 
     def test_help_not_authenticated(self):
+        """The help view should be accessible when not logged in."""
         self.mk_help()
         self.client.logout()
         response = self.client.get(reverse('help'))

--- a/go/tests/test_views.py
+++ b/go/tests/test_views.py
@@ -1,0 +1,41 @@
+from django.core.urlresolvers import reverse
+
+from django.contrib.flatpages.models import FlatPage
+from django.contrib.sites.models import Site
+
+from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
+
+
+class TestChannelViews(GoDjangoTestCase):
+
+    def setUp(self):
+        self.vumi_helper = self.add_helper(DjangoVumiApiHelper())
+        self.user_helper = self.vumi_helper.make_django_user()
+        self.client = self.vumi_helper.get_client()
+
+    def mk_help(self):
+        page = FlatPage(title='Help', content="Wisdom", url="/help/")
+        page.save()
+        for site in Site.objects.all():
+            page.sites.add(site)
+
+    def test_help_authenticated(self):
+        self.mk_help()
+        response = self.client.get(reverse('help'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Help')
+        self.assertContains(response, 'Dashboard')
+        self.assertContains(response, 'Contacts')
+        self.assertContains(response, 'Account')
+        self.assertContains(response, 'credits')
+
+    def test_help_not_authenticated(self):
+        self.mk_help()
+        self.client.logout()
+        response = self.client.get(reverse('help'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Help')
+        self.assertNotContains(response, 'Dashboard')
+        self.assertNotContains(response, 'Contacts')
+        self.assertNotContains(response, 'Account')
+        self.assertNotContains(response, 'credits')


### PR DESCRIPTION
That looks like:

``` python
File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/template/base.py", line 844, in render_node
    return node.render(context)

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 63, in render
    result = block.nodelist.render(context)

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/template/base.py", line 830, in render
    bit = self.render_node(node, context)

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/template/base.py", line 844, in render_node
    return node.render(context)

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/template/base.py", line 1114, in render
    return func(*resolved_args, **resolved_kwargs)

  File "/var/praekelt/vumi-go/go/billing/templatetags/billing_tags.py", line 14, in credit_balance
    account = user.account_set.all()[0]

  File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/utils/functional.py", line 205, in inner
    return func(self._wrapped, *args)

AttributeError: 'AnonymousUser' object has no attribute 'account_set'
```
