### PR TITLE
Test methods missing @inlineCallbacks decorator

### DIFF
--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -718,6 +718,7 @@ class TestGroupsResource(ResourceTestCaseBase):
         self.assertEqual(gr_data['name'], 'new name')
         self.assertEqual(gr_data['query'], 'some query')
 
+    @inlineCallbacks
     def test_handle_count_members(self):
         group = yield self.new_group(u'foo group')
         contact = yield self.new_contact(

--- a/go/routers/app_multiplexer/tests/test_vumi_app.py
+++ b/go/routers/app_multiplexer/tests/test_vumi_app.py
@@ -440,25 +440,26 @@ class TestApplicationMultiplexerRouter(VumiTestCase):
         choice = self.router_worker.get_menu_choice(msg, (1, 2))
         self.assertEqual(choice, None)
 
+    @inlineCallbacks
     def test_create_menu(self):
         """
         Create a menu prompt to choose between linked endpoints
         """
-        router_worker = yield self.router_helper.get_router_worker({
-            'menu_title': {'content': 'Please select a choice'},
-            'entries': [
-                {
-                    'label': 'Flappy Bird',
-                    'endpoint': 'flappy-bird',
-                },
-                {
-                    'label': 'Mama',
-                    'endpoint': 'mama',
-                }
-            ]
-        })
-        text = router_worker.create_menu(self.router_worker.config)
+        router = yield self.router_helper.create_router(
+            started=True, config={
+                'menu_title': {'content': 'Please select a choice'},
+                'entries': [
+                    {
+                        'label': 'Flappy Bird',
+                        'endpoint': 'flappy-bird',
+                    },
+                    {
+                        'label': 'Mama',
+                        'endpoint': 'mama',
+                    }
+                ]
+            })
+        config = yield self.dynamic_config_with_router(router)
+        text = self.router_worker.create_menu(config)
         self.assertEqual(
-            text,
-            'Please select a choice\n1) Flappy Bird\n2) Mama'
-        )
+            text, 'Please select a choice\n1) Flappy Bird\n2) Mama')

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -382,6 +382,7 @@ class TestTxVumiRouterApi(VumiTestCase):
         returnValue(
             self.user_api.get_router_api(router.router_type, router.key))
 
+    @inlineCallbacks
     def test_get_router(self):
         router = yield self.create_router()
         router_api = yield self.get_router_api(router)


### PR DESCRIPTION
Based on praekelt/vumi#741 I found the following test methods that `yield` but aren't decorated with `@inlineCallbacks`:

TestGroupsResource.test_handle_count_members
TestApplicationMultiplexerRouter.test_create_menu
TestTxVumiRouterApi.test_get_router
TestVumiRouterApi.test_get_router
