### PR TITLE
Fix migration of contact dynamic fields.

### DIFF
--- a/go/vumitools/contact/migrations.py
+++ b/go/vumitools/contact/migrations.py
@@ -9,7 +9,9 @@ class ContactMigrator(ModelMigrator):
         mdata.copy_values(
             'name', 'surname', 'email_address', 'msisdn',
             'dob', 'twitter_handle', 'facebook_id', 'bbm_pin',
-            'gtalk_id', 'created_at', 'extra', 'subscription')
+            'gtalk_id', 'created_at')
+        mdata.copy_dynamic_values(
+            'extras-', 'subscription-')
         mdata.copy_indexes('user_account_bin', 'groups_bin')
 
         # Add stuff that's new in this version

--- a/go/vumitools/contact/old_models.py
+++ b/go/vumitools/contact/old_models.py
@@ -9,6 +9,7 @@ from vumi.persist.fields import (Unicode, ManyToMany, ForeignKey, Timestamp,
 
 from go.vumitools.account.old_models import UserAccountV4
 from go.vumitools.account import PerAccountStore
+from go.vumitools.contact.migrations import ContactMigrator
 
 
 class ContactGroupVNone(Model):
@@ -342,6 +343,9 @@ class ContactStoreVNone(PerAccountStore):
 
 
 class ContactV1(ContactVNone):
+
+    VERSION = 1
+    MIGRATOR = ContactMigrator
 
     bucket = "contact"
 

--- a/go/vumitools/contact/tests/test_migrations.py
+++ b/go/vumitools/contact/tests/test_migrations.py
@@ -35,12 +35,19 @@ class TestContact(VumiTestCase):
     def test_contact_vnone_to_v1(self):
         contact_vnone = yield self.contacts_store_vnone.new_contact(
             name=u'name', msisdn=u'msisdn')
+        contact_vnone.extra["thing"] = u"extra-thing"
+        contact_vnone.subscription["app"] = u"1"
+        yield contact_vnone.save()
+        self.assertEqual(contact_vnone.VERSION, None)
         contact_v1 = yield self.contacts_store_v1.get_contact_by_key(
             contact_vnone.key)
         self.assertEqual(contact_v1.name, 'name')
         self.assertEqual(contact_v1.msisdn, 'msisdn')
         self.assertEqual(contact_v1.mxit_id, None)
         self.assertEqual(contact_v1.wechat_id, None)
+        self.assertEqual(contact_v1.extra["thing"], u"extra-thing")
+        self.assertEqual(contact_v1.subscription["app"], u"1")
+        self.assertEqual(contact_v1.VERSION, 1)
 
     @inlineCallbacks
     def test_contact_v1(self):


### PR DESCRIPTION
The migration from version None to version 1 attempts to copy dynamic fields as ordinary fields and fails spectacularly.

praekelt/vumi#751 adds a helper for migrating dynamic fields.
