### PR TITLE
Add name config field for dialogue apps

### DIFF
--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -18,8 +18,7 @@ class PollConfigResource(SandboxResource):
             JSON string containg the configuration dictionary.
         """
         config = {
-            "metric_store": "poll-%s" % conversation.key,
-            "user_store": "poll-%s" % conversation.key,
+            "name": "poll-%s" % conversation.key
         }
         return json.dumps(config)
 


### PR DESCRIPTION
We need to include a name config field for dialogue apps, since this is compulsory in v2.
