### PR TITLE
Keyword router form assumed DELETE key exists.

### DIFF
--- a/go/routers/app_multiplexer/tests/test_views.py
+++ b/go/routers/app_multiplexer/tests/test_views.py
@@ -121,3 +121,31 @@ class ApplicationMultiplexerViewTests(GoDjangoTestCase):
                     u'label': u'Mama',
                     u'endpoint': u'mama',
                 }]})
+
+    def test_user_input_good_with_delete(self):
+        rtr_helper = self.router_helper.create_router_helper(started=True)
+        router = rtr_helper.get_router()
+        self.assertEqual(router.config, {})
+        response = self.client.post(rtr_helper.get_view_url('edit'), {
+            'menu_title-content': ['Please select an application'],
+            'entries-TOTAL_FORMS': ['2'],
+            'entries-INITIAL_FORMS': ['0'],
+            'entries-MAX_NUM_FORMS': [''],
+            'entries-0-application_label': ['Flappy Bird'],
+            'entries-0-endpoint_name': ['flappy-bird'],
+            'entries-0-DELETE': ['on'],
+            'entries-0-ORDER': ['0'],
+            'entries-1-application_label': ['Mama'],
+            'entries-1-endpoint_name': ['mama'],
+            'entries-1-DELETE': [''],
+            'entries-1-ORDER': ['1'],
+        })
+        self.assertRedirects(response, rtr_helper.get_view_url('show'))
+        router = rtr_helper.get_router()
+        self.assertEqual(router.config, {
+            u'menu_title': {u'content': u'Please select an application'},
+            u'entries': [
+                {
+                    u'label': u'Mama',
+                    u'endpoint': u'mama',
+                }]})

--- a/go/routers/keyword/tests/test_views.py
+++ b/go/routers/keyword/tests/test_views.py
@@ -108,3 +108,27 @@ class KeywordViewTests(GoDjangoTestCase):
         self.assertEqual(set(router.extra_inbound_endpoints), set())
         self.assertEqual(
             set(router.extra_outbound_endpoints), set(['bar', 'quux']))
+
+    def test_edit_router_keyword_config_with_delete(self):
+        rtr_helper = self.router_helper.create_router_helper(started=True)
+        router = rtr_helper.get_router()
+        self.assertEqual(router.config, {})
+        response = self.client.post(rtr_helper.get_view_url('edit'), {
+            'keyword_endpoint_mapping-TOTAL_FORMS': ['2'],
+            'keyword_endpoint_mapping-INITIAL_FORMS': ['0'],
+            'keyword_endpoint_mapping-MAX_NUM_FORMS': [''],
+            'keyword_endpoint_mapping-0-keyword': ['foo'],
+            'keyword_endpoint_mapping-0-target_endpoint': ['bar'],
+            'keyword_endpoint_mapping-0-DELETE': ['on'],
+            'keyword_endpoint_mapping-1-keyword': ['baz'],
+            'keyword_endpoint_mapping-1-target_endpoint': ['quux'],
+            'keyword_endpoint_mapping-1-DELETE': [''],
+        })
+        self.assertRedirects(response, rtr_helper.get_view_url('show'))
+        router = rtr_helper.get_router()
+        self.assertEqual(router.config, {u'keyword_endpoint_mapping': {
+            'baz': 'quux',
+        }})
+        self.assertEqual(set(router.extra_inbound_endpoints), set())
+        self.assertEqual(
+            set(router.extra_outbound_endpoints), set(['quux']))

--- a/go/routers/keyword/view_definition.py
+++ b/go/routers/keyword/view_definition.py
@@ -17,7 +17,7 @@ class BaseKeywordFormSet(forms.formsets.BaseFormSet):
     def to_config(self):
         keyword_endpoint_mapping = {}
         for form in self:
-            if not form.is_valid():
+            if not form.is_valid() or form in self.deleted_forms:
                 continue
             keyword = form.cleaned_data['keyword']
             target_endpoint = form.cleaned_data['target_endpoint']

--- a/go/routers/keyword/view_definition.py
+++ b/go/routers/keyword/view_definition.py
@@ -17,7 +17,7 @@ class BaseKeywordFormSet(forms.formsets.BaseFormSet):
     def to_config(self):
         keyword_endpoint_mapping = {}
         for form in self:
-            if (not form.is_valid()) or form.cleaned_data['DELETE']:
+            if not form.is_valid():
                 continue
             keyword = form.cleaned_data['keyword']
             target_endpoint = form.cleaned_data['target_endpoint']


### PR DESCRIPTION
```
  File "django/views/generic/base.py", line 86, in dispatch
    return handler(request, *args, **kwargs)
  File "go/router/view_definition.py", line 146, in post
    response = self.process_forms(request, router)
  File "go/router/view_definition.py", line 180, in process_forms
    config[key]
  = self.process_form(edit_form)
  File "go/router/view_definition.py", line 166, in process_form
    return form.to_config()
  File "go/routers/keyword/view_definition.py", line 20, in to_config
    if (not form.is_valid()) or form.cleaned_data['DELETE']:
```

We saw this error in the app multiplexer too -- we just need to copy the fix from there.
