### PR TITLE
Fix poll loading that broke after migration to sandbox toolkit v2.

### DIFF
--- a/go/apps/dialogue/tests/dummy_polls.py
+++ b/go/apps/dialogue/tests/dummy_polls.py
@@ -41,10 +41,6 @@ simple_poll = {
             # end specific
             "text": "Thank you for taking our survey",
         },
-        {
-            "uuid": "unknown-1",
-            "type": "unknown-or-garbled",
-        },
     ],
     "connections": [
         {

--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -13,24 +13,26 @@ describe("app", function() {
     describe("DialogueApp", function() {
         var poll;
         var tester;
-        
+
         beforeEach(function() {
             poll = _.cloneDeep(dummy_polls.simple_poll);
 
             tester = new AppTester(new DialogueApp())
                 .setup.config.app({name: 'dialogue_app'})
-                .setup.config({poll: poll})
+                .setup.config({poll: poll}, {json: false})
                 .setup.user.addr('+27123');
         });
 
+        function extend_poll(poll_extend) {
+            return tester.setup.config({
+                poll: _.extend(poll, poll_extend)
+            },
+            {json: false});
+        }
+
         it("should throw an error if an unknown state type is encountered",
         function() {
-            return tester
-                .setup.config({
-                    poll: _.extend(poll, {
-                        states: [{type: 'unknown'}]
-                    })
-                })
+            return extend_poll({states: [{type: 'unknown'}]})
                 .run()
                 .catch(function(e) {
                     assert(e instanceof Error);
@@ -42,10 +44,7 @@ describe("app", function() {
 
         it("should stay on the same state if a state has no next state",
         function() {
-            return tester
-                .setup.config({
-                    poll: _.extend(poll, {connections: []})
-                })
+            return extend_poll({connections: []})
                 .setup.user.state('choice-1')
                 .input('1')
                 .check.user.state('choice-1')
@@ -97,10 +96,7 @@ describe("app", function() {
             });
 
             it("should only accept number based answers if asked", function() {
-                return tester
-                    .setup.config({
-                        poll: _.extend(poll, {accept_labels: false})
-                    })
+                return extend_poll({accept_labels: false})
                     .setup.user.state('choice-1')
                     .input('Red')
                     .check.user.state('choice-1')
@@ -109,10 +105,7 @@ describe("app", function() {
 
             it("should accept label and number based answers if asked",
             function() {
-                return tester
-                    .setup.config({
-                        poll: _.extend(poll, {accept_labels: true})
-                    })
+                return extend_poll({accept_labels: true})
                     .setup.user.state('choice-1')
                     .input('Red')
                     .check.user.state('freetext-1')
@@ -166,10 +159,7 @@ describe("app", function() {
 
             it("should move to the start state next session if asked",
             function() {
-                return tester
-                    .setup.config({
-                        poll: _.extend(poll, {repeatable: true})
-                    })
+                return extend_poll({repeatable: true})
                     .setup.user.state('end-1')
                     .start()
                     .check.user.state('choice-1')
@@ -178,10 +168,7 @@ describe("app", function() {
 
             it("should not move to the start state next session if asked",
             function() {
-                return tester
-                    .setup.config({
-                        poll: _.extend(poll, {repeatable: false})
-                    })
+                return extend_poll({repeatable: false})
                     .setup.user.state('end-1')
                     .start()
                     .check.user.state('end-1')

--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -34,8 +34,11 @@ class TestDialogueApplication(VumiTestCase):
             'args': [sandboxer_js],
             'timeout': 10,
             'app_context': (
-                "{require: function(m) { if (m == 'jed' || m == 'vumigo_v01')"
-                " return require(m); return null; }, Buffer: Buffer}"
+                "{require: function(m) {"
+                " if (['moment', 'url', 'querystring', 'crypto', 'lodash',"
+                " 'q', 'jed', 'libxmljs', 'zlib', 'vumigo_v01', 'vumigo_v02'"
+                "].indexOf(m) >= 0) return require(m); return null;"
+                " }, Buffer: Buffer}"
             ),
             'env': {
                 'NODE_PATH': node_path,

--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -100,7 +100,11 @@ class TestDialogueApplication(VumiTestCase):
     def test_user_message(self):
         conversation = yield self.setup_conversation()
         yield self.app_helper.start_conversation(conversation)
-        yield self.app_helper.make_dispatch_inbound("hello", conv=conversation)
+        with LogCatcher(message='Switched to state:') as lc:
+            yield self.app_helper.make_dispatch_inbound(
+                "hello", conv=conversation)
+            self.assertEqual(lc.messages(),
+                             ['Switched to state: choice-1'])
         [reply] = self.app_helper.get_dispatched_outbound()
         self.assertEqual(reply["content"],
                          "What is your favourite colour?\n1. Red\n2. Blue")

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -20,6 +20,15 @@ var DialogueApp = App.extend(function(self) {
         start_state: {uuid: null}
     };
 
+    self.events = {
+        'im inbound_event': function (event) {
+            var ev = event.event;
+            return event.im.log.info(
+                "Saw " + ev.event_type + " for message " +
+                ev.sent_message_id + ".");
+        }
+    };
+
     self.init = function() {
         return Q
             .all([self.get_poll(), self.im.contacts.for_user()])

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -32,10 +32,10 @@ var DialogueApp = App.extend(function(self) {
 
     self.get_poll = function() {
         return self
-            .im.sandbox_config.get('poll', {json: true})
+            .im.sandbox_config.get('poll', {json: false})
             .then(function(poll) {
                 return _.defaults(poll, self.poll_defaults);
-           });
+            });
     };
 
     self.add_state = function(desc) {


### PR DESCRIPTION
The change needed is:

``` diff
diff --git a/go/apps/dialogue/vumi_app.js b/go/apps/dialogue/vumi_app.js
index 63c6ad3..f6c1295 100644
--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -32,10 +32,10 @@ var DialogueApp = App.extend(function(self) {

     self.get_poll = function() {
         return self
-            .im.sandbox_config.get('poll', {json: true})
+            .im.sandbox_config.get('poll', {json: false})
             .then(function(poll) {
                 return _.defaults(poll, self.poll_defaults);
-           });
+            });
     };

     self.add_state = function(desc) {
```

but we also need to fix tests.
