### PR TITLE
Loading of cached messages loses order (was Message Store cache pagination display is broken)

### DIFF
--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -114,6 +114,18 @@ class TestConversationWrapper(VumiTestCase):
             len((yield self.conv.received_messages_in_cache(5, 10))), 0)
 
     @inlineCallbacks
+    def test_received_messages_preserve_ordering(self):
+        yield self.conv.start()
+        stored_messages = yield self.msg_helper.add_inbound_to_conv(
+            self.conv, 5, start_date=datetime.now())
+        sorted_stored_messages = sorted(
+            stored_messages, key=lambda msg: msg['timestamp'], reverse=True)
+        cached_messages = yield self.conv.received_messages_in_cache()
+        self.assertEqual(
+            [msg['message_id'] for msg in sorted_stored_messages],
+            [msg['message_id'] for msg in cached_messages])
+
+    @inlineCallbacks
     def test_received_messages_include_sensitive(self):
         yield self.conv.start()
         yield self.msg_helper.make_stored_inbound(
@@ -161,6 +173,18 @@ class TestConversationWrapper(VumiTestCase):
             len((yield self.conv.sent_messages_in_cache(2, 4))), 2)
         self.assertEqual(
             len((yield self.conv.sent_messages_in_cache(5, 10))), 0)
+
+    @inlineCallbacks
+    def test_sent_messages_preserve_ordering(self):
+        yield self.conv.start()
+        stored_messages = yield self.msg_helper.add_outbound_to_conv(
+            self.conv, 5, start_date=datetime.now())
+        sorted_stored_messages = sorted(
+            stored_messages, key=lambda msg: msg['timestamp'], reverse=True)
+        cached_messages = yield self.conv.sent_messages_in_cache()
+        self.assertEqual(
+            [msg['message_id'] for msg in sorted_stored_messages],
+            [msg['message_id'] for msg in cached_messages])
 
     @inlineCallbacks
     def test_sent_messages_include_sensitive(self):

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -309,10 +309,13 @@ class ConversationWrapper(object):
         keys = yield self.mdb.cache.get_inbound_message_keys(
             self.batch.key, start, limit - 1)
 
-        replies = yield self.collect_messages(keys,
-            self.mdb.inbound_messages, include_sensitive, scrubber)
+        replies = yield self.collect_messages(
+            keys, self.mdb.inbound_messages, include_sensitive, scrubber)
 
-        returnValue(replies)
+        # Preserve order
+        returnValue(
+            sorted(replies, key=lambda msg: msg['timestamp'],
+                   reverse=True))
 
     def sent_messages(self, start=0, limit=100, include_sensitive=False,
                       scrubber=None):
@@ -348,10 +351,13 @@ class ConversationWrapper(object):
         keys = yield self.mdb.cache.get_outbound_message_keys(
             self.batch.key, start, limit - 1)
 
-        sent_messages = yield self.collect_messages(keys,
-            self.mdb.outbound_messages, include_sensitive, scrubber)
+        sent_messages = yield self.collect_messages(
+            keys, self.mdb.outbound_messages, include_sensitive, scrubber)
 
-        returnValue(sent_messages)
+        # Preserve order
+        returnValue(
+            sorted(sent_messages, key=lambda msg: msg['timestamp'],
+                   reverse=True))
 
     def find_inbound_messages_matching(self, pattern, flags="i",
                                        key="msg.content", ttl=None,


### PR DESCRIPTION
Once the cache is full no new messages are displayed, what should happen is that new messages are inserted in the front & the oldest ones popped off.
