### PR TITLE
Get delivery class from jsbox config for push triggers

### DIFF
--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -45,8 +45,7 @@ class TestDialogueViews(GoDjangoTestCase):
             'send_jsbox',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.batch.key,
-            delivery_class=conversation.delivery_class))
+            batch_id=conversation.batch.key))
 
     def test_action_send_dialogue_no_group(self):
         conv_helper = self.setup_conversation(started=True, with_group=False)

--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -74,7 +74,6 @@ class TestDialogueApplication(VumiTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key,
-            delivery_class=conversation.delivery_class,
         )
 
     @inlineCallbacks

--- a/go/apps/jsbox/definition.py
+++ b/go/apps/jsbox/definition.py
@@ -1,7 +1,6 @@
-import json
-
 from go.vumitools.conversation.definition import (
     ConversationDefinitionBase, ConversationAction)
+from go.apps.jsbox.utils import jsbox_js_config
 
 
 class SendJsboxAction(ConversationAction):
@@ -41,10 +40,8 @@ class ConversationDefinition(ConversationDefinitionBase):
     )
 
     def configured_endpoints(self, config):
-        app_config = config.get("jsbox_app_config", {})
-        raw_js_config = app_config.get("config", {}).get("value", {})
         try:
-            js_config = json.loads(raw_js_config)
+            js_config = jsbox_js_config(config)
         except Exception:
             return []
 

--- a/go/apps/jsbox/definition.py
+++ b/go/apps/jsbox/definition.py
@@ -19,9 +19,7 @@ class SendJsboxAction(ConversationAction):
                 " messages attached to this conversation.")
 
     def perform_action(self, action_data):
-        return self.send_command(
-            'send_jsbox', batch_id=self._conv.batch.key,
-            delivery_class=self._conv.delivery_class)
+        return self.send_command('send_jsbox', batch_id=self._conv.batch.key)
 
 
 class ViewLogsAction(ConversationAction):

--- a/go/apps/jsbox/tests/test_utils.py
+++ b/go/apps/jsbox/tests/test_utils.py
@@ -1,0 +1,49 @@
+import json
+
+from vumi.tests.helpers import VumiTestCase
+
+from go.apps.jsbox import utils
+
+
+class TestUtils(VumiTestCase):
+    def test_jsbox_config_value(self):
+        config = {
+            'jsbox_app_config': {
+                'foo': {
+                    'key': 'foo',
+                    'value': 'bar'
+                }
+            }
+        }
+
+        self.assertEqual(utils.jsbox_config_value(config, 'foo'), 'bar')
+
+    def test_jsbox_config_value_no_value(self):
+        config = {
+            'jsbox_app_config': {}
+        }
+
+        self.assertEqual(utils.jsbox_config_value(config, 'foo'), None)
+
+    def test_jsbox_config_value_no_config(self):
+        self.assertEqual(utils.jsbox_config_value({}, 'foo'), None)
+
+    def test_jsbox_js_config(self):
+        config = {
+            'jsbox_app_config': {
+                'config': {
+                    'key': 'config',
+                    'value': json.dumps({'foo': 'bar'})
+                }
+            }
+        }
+
+        self.assertEqual(utils.jsbox_js_config(config), {'foo': 'bar'})
+
+    def test_jsbox_js_config_no_config(self):
+        config = {
+            'jsbox_app_config': {
+            }
+        }
+
+        self.assertEqual(utils.jsbox_js_config(config), {})

--- a/go/apps/jsbox/tests/test_views.py
+++ b/go/apps/jsbox/tests/test_views.py
@@ -46,8 +46,7 @@ class TestJsBoxViews(GoDjangoTestCase):
             'send_jsbox',
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
-            batch_id=conversation.batch.key,
-            delivery_class=conversation.delivery_class))
+            batch_id=conversation.batch.key))
 
     def test_action_send_jsbox_no_group(self):
         conv_helper = self.setup_conversation(started=True, with_group=False)

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -178,10 +178,11 @@ class TestJsBoxApplication(VumiTestCase):
 
         with LogCatcher() as lc:
             yield self.send_send_jsbox_command(conv)
+            print lc.errors
 
-            self.assertEqual(
-                [e['message'][0] for e in lc.errors],
-                "Bad jsbox js config: bad")
+            self.assertTrue(any(
+                "Bad jsbox js config: bad" in
+                e['message'][0] for e in lc.errors))
 
     @inlineCallbacks
     def test_user_message(self):

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -178,7 +178,6 @@ class TestJsBoxApplication(VumiTestCase):
 
         with LogCatcher() as lc:
             yield self.send_send_jsbox_command(conv)
-            print lc.errors
 
             self.assertTrue(any(
                 "Bad jsbox js config: bad" in

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -178,7 +178,10 @@ class TestJsBoxApplication(VumiTestCase):
 
         with LogCatcher() as lc:
             yield self.send_send_jsbox_command(conv)
-            self.assertTrue("Bad jsbox js config: bad" in lc.messages())
+
+            self.assertEqual(
+                [e['message'][0] for e in lc.errors],
+                "Bad jsbox js config: bad")
 
     @inlineCallbacks
     def test_user_message(self):

--- a/go/apps/jsbox/utils.py
+++ b/go/apps/jsbox/utils.py
@@ -1,0 +1,12 @@
+import json
+
+
+def jsbox_config_value(config, key):
+    jsbox_config = config.get("jsbox_app_config", {})
+    key_config = jsbox_config.get(key, {})
+    return key_config.get('value')
+
+
+def jsbox_js_config(config):
+    app_config = jsbox_config_value(config, 'config')
+    return json.loads(app_config) if app_config is not None else {}

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -10,6 +10,7 @@ from vumi.config import ConfigDict
 from vumi import log
 
 from go.apps.jsbox.outbound import mk_inbound_push_trigger
+from go.apps.jsbox.utils import jsbox_config_value
 from go.vumitools.app_worker import (
     GoApplicationMixin, GoApplicationConfigMixin)
 
@@ -22,9 +23,7 @@ class ConversationConfigResource(SandboxResource):
         if key is None:
             return self.reply(command, success=False)
         conversation = self.app_worker.conversation_for_api(api)
-        app_config = conversation.config.get("jsbox_app_config", {})
-        key_config = app_config.get(key, {})
-        value = key_config.get('value')
+        value = jsbox_config_value(conversation.config, key)
         return self.reply(command, value=value, success=True)
 
 
@@ -126,6 +125,7 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
     def process_command_send_jsbox(self, user_account_key, conversation_key,
                                    batch_id, delivery_class):
         conv = yield self.get_conversation(user_account_key, conversation_key)
+
         if conv is None:
             log.warning("Cannot find conversation '%s' for user '%s'." % (
                 conversation_key, user_account_key))

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -10,7 +10,7 @@ from vumi.config import ConfigDict
 from vumi import log
 
 from go.apps.jsbox.outbound import mk_inbound_push_trigger
-from go.apps.jsbox.utils import jsbox_config_value
+from go.apps.jsbox.utils import jsbox_config_value, jsbox_js_config
 from go.vumitools.app_worker import (
     GoApplicationMixin, GoApplicationConfigMixin)
 
@@ -123,8 +123,17 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
 
     @inlineCallbacks
     def process_command_send_jsbox(self, user_account_key, conversation_key,
-                                   batch_id, delivery_class):
+                                   batch_id):
         conv = yield self.get_conversation(user_account_key, conversation_key)
+
+        try:
+            js_config = jsbox_js_config(conv.config)
+            delivery_class = js_config.get('delivery_class')
+        except Exception:
+            log.warning(
+                "Bad jsbox js config: %s"
+                % (jsbox_config_value(conv.config, 'config'),))
+            return
 
         if conv is None:
             log.warning("Cannot find conversation '%s' for user '%s'." % (

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -130,7 +130,7 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
             js_config = jsbox_js_config(conv.config)
             delivery_class = js_config.get('delivery_class')
         except Exception:
-            log.warning(
+            log.err(
                 "Bad jsbox js config: %s"
                 % (jsbox_config_value(conv.config, 'config'),))
             return


### PR DESCRIPTION
At the moment, we get the delivery class off the conversation model: 
https://github.com/praekelt/vumi-go/blob/develop/go/apps/jsbox/definition.py#L25

The `Conversation` model's `delivery_class` attribute is no longer set now that we have routing table dispatchers, so we need to find the delivery class a different way.

The plan is to determine the delivery class from the jsbox conversation's config, since we rely on it on the toolkit side anyways. This will be easy enough to remove once we have proper address types.
