### PR TITLE
normalization middleware needs to normalize outbound as well.

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -22,13 +22,16 @@ class NormalizeMsisdnMiddleware(TransportMiddleware):
 
     def handle_inbound(self, message, endpoint):
         from_addr = normalize_msisdn(message.get('from_addr'),
-                        country_code=self.country_code)
+                                     country_code=self.country_code)
         message['from_addr'] = from_addr
         return message
 
     def handle_outbound(self, message, endpoint):
+        to_addr = normalize_msisdn(message.get('to_addr'),
+                                   country_code=self.country_code)
         if self.strip_plus:
-            message['to_addr'] = message['to_addr'].lstrip('+')
+            to_addr = to_addr.lstrip('+')
+        message['to_addr'] = to_addr
         return message
 
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -80,11 +80,17 @@ class TestNormalizeMisdnMiddleware(VumiTestCase):
             'country_code': '256',
         })
 
-    def test_normalization(self):
+    def test_inbound_normalization(self):
         msg = self.mw_helper.make_inbound(
             "foo", to_addr='8007', from_addr='256123456789')
         msg = self.mw.handle_inbound(msg, 'dummy_endpoint')
         self.assertEqual(msg['from_addr'], '+256123456789')
+
+    def test_outbound_normalization(self):
+        msg = self.mw_helper.make_outbound(
+            "foo", to_addr='0123456789', from_addr='8007')
+        msg = self.mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['to_addr'], '+256123456789')
 
 
 class TestOptOutMiddleware(VumiTestCase):


### PR DESCRIPTION
Currently it doesn't.
