### PR TITLE
Allow for updating existing contacts on import.

### DIFF
--- a/go/base/fixtures/sample-contacts-with-uuid-headers.csv
+++ b/go/base/fixtures/sample-contacts-with-uuid-headers.csv
@@ -1,0 +1,4 @@
+key,name,surname,msisdn
+uuid1,Name 1,Surname 1,+27761234561
+uuid2,Name 2,Surname 2,+27761234562
+uuid3,Name 3,Surname 3,+27761234563

--- a/go/contacts/import_handlers.py
+++ b/go/contacts/import_handlers.py
@@ -2,7 +2,7 @@ from go.contacts import tasks, utils
 from go.contacts.parsers import ContactFileParser
 
 
-def handle_import_new_contacts(request, group):
+def dispatch_import_task(import_task, request, group):
     file_name, file_path = utils.get_file_hints_from_session(request)
     file_type, parser = ContactFileParser.get_parser(file_name)
     has_header, _, sample_row = parser.guess_headers_and_row(file_path)
@@ -15,17 +15,23 @@ def handle_import_new_contacts(request, group):
     normalizers = [request.POST.get('normalize-%s' % i, '')
                    for i in range(len(sample_row))]
     fields = zip(field_names, normalizers)
-
-    tasks.import_new_contacts_file.delay(
+    import_task.delay(
         request.user_api.user_account_key, group.key, file_name,
         file_path, fields, has_header)
 
     utils.clear_file_hints_from_session(request)
 
 
+def handle_import_new_contacts(request, group):
+    return dispatch_import_task(
+        tasks.import_new_contacts_file, request, group)
+
+
 def handle_import_upload_is_truth(request, group):
-    pass
+    return dispatch_import_task(
+        tasks.import_upload_is_truth_contacts_file, request, group)
 
 
 def handle_import_existing_is_truth(request, group):
-    pass
+    return dispatch_import_task(
+        tasks.import_existing_is_truth_contacts_file, request, group)

--- a/go/contacts/import_handlers.py
+++ b/go/contacts/import_handlers.py
@@ -1,0 +1,31 @@
+from go.contacts import tasks, utils
+from go.contacts.parsers import ContactFileParser
+
+
+def handle_import_new_contacts(request, group):
+    file_name, file_path = utils.get_file_hints_from_session(request)
+    file_type, parser = ContactFileParser.get_parser(file_name)
+    has_header, _, sample_row = parser.guess_headers_and_row(file_path)
+
+    # Grab the selected field names from the submitted form
+    # by looping over the expect n number of `column-n` keys being
+    # posted
+    field_names = [request.POST.get('column-%s' % i) for i in
+                   range(len(sample_row))]
+    normalizers = [request.POST.get('normalize-%s' % i, '')
+                   for i in range(len(sample_row))]
+    fields = zip(field_names, normalizers)
+
+    tasks.import_new_contacts_file.delay(
+        request.user_api.user_account_key, group.key, file_name,
+        file_path, fields, has_header)
+
+    utils.clear_file_hints_from_session(request)
+
+
+def handle_import_upload_is_truth(request, group):
+    pass
+
+
+def handle_import_existing_is_truth(request, group):
+    pass

--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -134,6 +134,7 @@ class FieldNormalizer(object):
 class ContactFileParser(object):
 
     DEFAULT_HEADERS = {
+        'key': 'UUID',
         'name': 'Name',
         'surname': 'Surname',
         'bbm_pin': 'BBM Pin',

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -230,8 +230,8 @@ def export_many_group_contacts(account_key, group_keys, include_extra=True):
 
 
 @task(ignore_result=True)
-def import_contacts_file(account_key, group_key, file_name, file_path,
-                         fields, has_header):
+def import_new_contacts_file(account_key, group_key, file_name, file_path,
+                             fields, has_header):
     api = VumiUserApi.from_config_sync(account_key, settings.VUMI_API_CONFIG)
     contact_store = api.contact_store
     group = contact_store.get_group(group_key)
@@ -263,7 +263,7 @@ def import_contacts_file(account_key, group_key, file_name, file_path,
             }), settings.DEFAULT_FROM_EMAIL, [user_profile.user.email],
             fail_silently=False)
 
-    except:
+    except Exception:
         # Clean up if something went wrong, either everything is written
         # or nothing is written
         for contact in written_contacts:

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -92,8 +92,11 @@ def contacts_to_csv(contacts, include_extra=True):
             extra_fields.update(contact.extra.keys())
     extra_fields = sorted(extra_fields)
 
-    # write the CSV header
-    writer.writerow(_contact_fields + ['extras-%s' % f for f in extra_fields])
+    # write the CSV header, prepend extras with `extra-` if it happens to
+    # overlap with any of the existing contact's fields.
+    writer.writerow(_contact_fields + [
+        ('extras-%s' % (f,) if f in _contact_fields else f)
+        for f in extra_fields])
 
     # loop over the contacts and create the row populated with
     # the values of the selected fields.

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -308,9 +308,7 @@ def import_and_update_contacts(contact_mangler, account_key, group_key,
 
     for contact_dictionary in contact_dictionaries:
         try:
-            group_keys = contact_dictionary.setdefault('groups', [])
-            if group.key not in group_keys:
-                contact_dictionary['groups'].append(group.key)
+            contact_dictionary['groups'] = [group.key]
             key = contact_dictionary.pop('key')
             contact = contact_store.get_contact_by_key(key)
             contact_dictionary = contact_mangler(contact, contact_dictionary)

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -385,7 +385,9 @@ def import_existing_is_truth_contacts_file(account_key, group_key, file_name,
         cloned_contact_dictionary['subscription'] = new_subscription
 
         for key, value in contact_dictionary.items():
-            if value:
+            # If the contact already has any kind of value that resolves
+            # to `True` then skip it.
+            if getattr(contact, key, None):
                 cloned_contact_dictionary.pop(key)
 
         return cloned_contact_dictionary

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -308,7 +308,9 @@ def import_and_update_contacts(contact_mangler, account_key, group_key,
 
     for contact_dictionary in contact_dictionaries:
         try:
-            contact_dictionary['groups'] = [group.key]
+            group_keys = contact_dictionary.setdefault('groups', [])
+            if group.key not in group_keys:
+                contact_dictionary['groups'].append(group.key)
             key = contact_dictionary.pop('key')
             contact = contact_store.get_contact_by_key(key)
             contact_dictionary = contact_mangler(contact, contact_dictionary)

--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -384,10 +384,13 @@ def import_existing_is_truth_contacts_file(account_key, group_key, file_name,
         new_subscription.update(dict(contact.subscription))
         cloned_contact_dictionary['subscription'] = new_subscription
 
-        for key, value in contact_dictionary.items():
-            # If the contact already has any kind of value that resolves
-            # to `True` then skip it.
-            if getattr(contact, key, None):
+        for key in contact_dictionary.keys():
+            # NOTE: If the contact already has any kind of value that
+            #       resolves to `True` then skip it.
+            #       The current implementation also means that we'll
+            #       replace attributes that are empty strings.
+            value = getattr(contact, key, None)
+            if value:
                 cloned_contact_dictionary.pop(key)
 
         return cloned_contact_dictionary

--- a/go/contacts/templates/contacts/import_upload_is_truth_completed_mail.txt
+++ b/go/contacts/templates/contacts/import_upload_is_truth_completed_mail.txt
@@ -1,0 +1,17 @@
+Hi {{user.get_full_name|safe}}!
+{% if count > 0 %}
+We've successfully imported {{count}} of your contact(s).
+They're all stored in the group {{group.name|safe}}
+
+{% if errors %}Unfortunately there were also {{errors|length}} errors. These are listed below:{% endif %}{% else %}
+We were not able to import any of your contacts unfortunately.
+
+{% if errors %}The errors are listed below:{% endif %}{% endif %}
+
+{% for key, error in errors %}{{key|safe}}: {{error|safe}}
+{% endfor %}
+Please visit http://go.vumi.org.
+
+thanks!
+
+Vumi Go.

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -155,11 +155,11 @@
                                         <p>
                                             Please specify what you would like to do:
                                         </p>
-                                        <input type="radio" name="action" value="create" checked="checked">
+                                        <input type="radio" name="import_rule" value="create" checked="checked">
                                             Do not update, create new contacts for every entry in the uploaded file. <br/>
-                                        <input type="radio" name="action" value="existing_is_truth">
+                                        <input type="radio" name="import_rule" value="existing_is_truth">
                                             Treat existing contacts as the Truth and augment with the uploaded file's contact data. <br/>
-                                        <input type="radio" name="action" value="new_is_truth">
+                                        <input type="radio" name="import_rule" value="upload_is_truth">
                                             Treat the uploaded file's contacts as the Truth and augment with existing contacts. <br/>
                                     {% else %}
                                         <h4>The file does not include contact UUIDs.</h4>

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -155,9 +155,7 @@
                                         <p>
                                             Please specify what you would like to do:
                                         </p>
-                                        <input type="radio" name="import_rule" value="create" checked="checked">
-                                            Do not update, create new contacts for every entry in the uploaded file. <br/>
-                                        <input type="radio" name="import_rule" value="existing_is_truth">
+                                        <input type="radio" name="import_rule" value="existing_is_truth" checked="checked">
                                             Treat existing contacts as the Truth and augment with the uploaded file's contact data. <br/>
                                         <input type="radio" name="import_rule" value="upload_is_truth">
                                             Treat the uploaded file's contacts as the Truth and augment with existing contacts. <br/>

--- a/go/contacts/templates/contacts/includes/tools.html
+++ b/go/contacts/templates/contacts/includes/tools.html
@@ -99,8 +99,8 @@
                 {% csrf_token %}
                 <div class="modal-body">
                     <p><span class="help-block">
-                      The file is potentially quite large and as a result the export 
-                      will be done in the background. When completed the results will 
+                      The file is potentially quite large and as a result the export
+                      will be done in the background. When completed the results will
                       be sent to you as a CSV file attached to an email.
                     </span><br/></p>
                 </div>
@@ -147,6 +147,30 @@
                               </tr>
                             {% endfor %}
                         </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="3">
+                                    {% if can_update_contacts %}
+                                        <h4>The file includes contact UUIDs.</h4>
+                                        <p>
+                                            Please specify what you would like to do:
+                                        </p>
+                                        <input type="radio" name="action" value="create" checked="checked">
+                                            Do not update, create new contacts for every entry in the uploaded file. <br/>
+                                        <input type="radio" name="action" value="existing_is_truth">
+                                            Treat existing contacts as the Truth and augment with the uploaded file's contact data. <br/>
+                                        <input type="radio" name="action" value="new_is_truth">
+                                            Treat the uploaded file's contacts as the Truth and augment with existing contacts. <br/>
+                                    {% else %}
+                                        <h4>The file does not include contact UUIDs.</h4>
+                                        <p>
+                                            New contacts will be created during import, duplicates may happen if a contact
+                                            defined in the uploaded file already exists in the contact database.
+                                        </p>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </tfoot>
                       </table>
                     </fieldset>
                 </div>

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -315,6 +315,36 @@ class TestContacts(BaseContactsTestCase):
         self.assertTrue('successfully' in mail.outbox[0].subject)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
+    def test_upload_with_contact_uuid(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
+                                  'fixtures',
+                                  'sample-contacts-with-uuid-headers.csv'))
+
+        response = self.client.post(reverse('contacts:people'), {
+            'contact_group': group.key,
+            'file': csv_file,
+        })
+        self.assertRedirects(response, group_url(group.key))
+        preview_response = self.client.get(group_url(group.key))
+        self.assertContains(
+            preview_response, 'The file includes contact UUIDs.')
+
+    def test_upload_without_contact_uuid(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+        csv_file = open(path.join(settings.PROJECT_ROOT, 'base',
+                                  'fixtures',
+                                  'sample-contacts-with-headers.csv'))
+
+        response = self.client.post(reverse('contacts:people'), {
+            'contact_group': group.key,
+            'file': csv_file,
+        })
+        self.assertRedirects(response, group_url(group.key))
+        preview_response = self.client.get(group_url(group.key))
+        self.assertContains(
+            preview_response, 'The file does not include contact UUIDs.')
+
     def test_uploading_unicode_chars_in_csv_into_new_group(self):
         new_group_name = u'Testing a ünicode grøüp'
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -374,6 +374,7 @@ class TestContacts(BaseContactsTestCase):
             # Litmus to ensure we don't butcher stuff
             contact.extra['litmus_stay'] = u'red'
             contact.extra['litmus_overwrite'] = u'blue'
+            contact.subscription['sub'] = u'the-subscription'
             contact.dob = datetime(2014, 1, 2)
             contact.save()
             # what we're going to update
@@ -404,12 +405,7 @@ class TestContacts(BaseContactsTestCase):
             'column-3': 'msisdn',
             'column-4': 'litmus_overwrite',
             'column-5': 'litmus_new',
-            'normalize-0': '',
-            'normalize-1': '',
-            'normalize-2': '',
             'normalize-3': 'msisdn_za',
-            'normalize-4': '',
-            'normalize-5': '',
         }, import_rule='upload_is_truth')
 
         group = self.contact_store.get_group(group.key)
@@ -450,6 +446,10 @@ class TestContacts(BaseContactsTestCase):
         self.assertEqual(
             set([contact.dob for contact in updated_contacts]),
             set([datetime(2014, 1, 2)]))
+        self.assertEqual(
+            set([contact.subscription['sub']
+                 for contact in updated_contacts]),
+            set(['the-subscription']))
 
         os.unlink(csv.name)
 
@@ -461,9 +461,11 @@ class TestContacts(BaseContactsTestCase):
         contact_data = []
         for i in range(3):
             # the original contact
-            contact = self.mkcontact(name='', surname='', msisdn='270000000')
+            contact = self.mkcontact(
+                name='foo', surname='bar', msisdn='270000000')
             # Litmus to ensure we don't butcher stuff
             contact.extra['litmus_stay'] = u'red'
+            contact.subscription['sub'] = u'the-subscription'
             contact.dob = datetime(2014, 1, 2)
             contact.add_to_group(group2)
             contact.save()
@@ -495,12 +497,7 @@ class TestContacts(BaseContactsTestCase):
             'column-3': 'msisdn',
             'column-4': 'litmus_stay',
             'column-5': 'litmus_new',
-            'normalize-0': '',
-            'normalize-1': '',
-            'normalize-2': '',
             'normalize-3': 'msisdn_za',
-            'normalize-4': '',
-            'normalize-5': '',
         }, import_rule='existing_is_truth')
 
         group = self.contact_store.get_group(group1.key)
@@ -517,14 +514,14 @@ class TestContacts(BaseContactsTestCase):
             for contact in contact_data]
         self.assertEqual(
             set([contact.name for contact in updated_contacts]),
-            set(['name 0', 'name 1', 'name 2']))
+            set(['foo']))
         self.assertEqual(
             set([contact.surname for contact in updated_contacts]),
-            set(['surname 0', 'surname 1', 'surname 2']))
+            set(['bar']))
         # these are normalized for ZA
         self.assertEqual(
             set([contact.msisdn for contact in updated_contacts]),
-            set(['+2711111110', '+2711111111', '+2711111112']))
+            set(['270000000']))
         # check the litmus
         self.assertEqual(
             set([contact.extra['litmus_stay']
@@ -540,6 +537,10 @@ class TestContacts(BaseContactsTestCase):
         self.assertEqual(
             set([contact.dob for contact in updated_contacts]),
             set([datetime(2014, 1, 2)]))
+        self.assertEqual(
+            set([contact.subscription['sub']
+                 for contact in updated_contacts]),
+            set(['the-subscription']))
 
         groups = []
         for contact in updated_contacts:

--- a/go/contacts/utils.py
+++ b/go/contacts/utils.py
@@ -8,11 +8,11 @@ from django.core.files.storage import default_storage
 
 def store_temporarily(django_file_object):
     django_content_file = File(file=django_file_object,
-        name=django_file_object.name)
+                               name=django_file_object.name)
     temp_file_name = 'tmp-%s-%s.upload' % (date.today().isoformat(),
-        uuid.uuid4().hex,)
+                                           uuid.uuid4().hex,)
     temp_file_path = default_storage.save(os.path.join('tmp', temp_file_name),
-        django_content_file)
+                                          django_content_file)
     return django_file_object.name, temp_file_path
 
 

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -240,6 +240,10 @@ def _static_group(request, contact_store, group):
                 'contact_data_headers': headers,
                 'field_normalizer': FieldNormalizer(),
                 'contact_data_row': row,
+                # NOTE: Only if we have a key (contact UUID) value in the
+                #       row we can look at updating contacts instead of
+                #       only writing new ones.
+                'can_update_contacts': 'key' in row,
             })
         except (ValueError, ContactParserException):
             messages.error(request, 'Something is wrong with the file')

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -16,6 +16,9 @@ from go.contacts.forms import (
     ContactForm, ContactGroupForm, UploadContactsForm, SmartGroupForm,
     SelectContactGroupForm)
 from go.contacts import tasks, utils
+from go.contacts.import_handlers import (
+    handle_import_new_contacts, handle_import_existing_is_truth,
+    handle_import_upload_is_truth)
 from go.contacts.parsers import ContactFileParser, ContactParserException
 from go.contacts.parsers.base import FieldNormalizer
 from go.vumitools.contact import ContactError
@@ -177,35 +180,24 @@ def _static_group(request, contact_store, group):
             return redirect(reverse('contacts:index'))
         elif '_complete_contact_upload' in request.POST:
             try:
-                file_name, file_path = utils.get_file_hints_from_session(
-                    request)
-                file_type, parser = ContactFileParser.get_parser(file_name)
-                has_header, _, sample_row = parser.guess_headers_and_row(
-                    file_path)
+                import_action = request.POST.get('import_action')
+                import_handler = {
+                    'existing_is_truth': handle_import_existing_is_truth,
+                    'upload_is_truth': handle_import_upload_is_truth,
+                }.get(import_action, handle_import_new_contacts)
 
-                # Grab the selected field names from the submitted form
-                # by looping over the expect n number of `column-n` keys being
-                # posted
-                field_names = [request.POST.get('column-%s' % i) for i in
-                               range(len(sample_row))]
-                normalizers = [request.POST.get('normalize-%s' % i, '')
-                               for i in range(len(sample_row))]
-                fields = zip(field_names, normalizers)
-
-                tasks.import_contacts_file.delay(
-                    request.user_api.user_account_key, group.key, file_name,
-                    file_path, fields, has_header)
-
+                import_handler(request, group)
                 messages.info(
-                    request, 'The contacts are being imported. '
-                             'We will notify you via email when the import '
-                             'has been completed')
+                    request,
+                    'The contacts are being imported. '
+                    'We will notify you via email when the import '
+                    'has been completed')
 
-                utils.clear_file_hints_from_session(request)
                 return redirect(_group_url(group.key))
 
             except (ContactParserException,):
                 messages.error(request, 'Something is wrong with the file')
+                _, file_path = utils.get_file_hints_from_session(request)
                 default_storage.delete(file_path)
 
         else:

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -180,11 +180,11 @@ def _static_group(request, contact_store, group):
             return redirect(reverse('contacts:index'))
         elif '_complete_contact_upload' in request.POST:
             try:
-                import_action = request.POST.get('import_action')
+                import_rule = request.POST.get('import_rule')
                 import_handler = {
                     'existing_is_truth': handle_import_existing_is_truth,
                     'upload_is_truth': handle_import_upload_is_truth,
-                }.get(import_action, handle_import_new_contacts)
+                }.get(import_rule, handle_import_new_contacts)
 
                 import_handler(request, group)
                 messages.info(


### PR DESCRIPTION
Currently we're only inserting new contacts on import, not allowing updating of existing ones. #918 adds support for exporting the UUID, if we find that exists we can give the option of allowing an update, the UI would need to show what needs to be treated as the  "Truth" though.
