### PR TITLE
Run jsbox tests on Travis

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -6,8 +6,8 @@ import pkg_resources
 import os
 
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.trial.unittest import SkipTest
 
+from vumi.application.tests.helpers import find_nodejs_or_skip_test
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 
@@ -20,8 +20,7 @@ class TestDialogueApplication(VumiTestCase):
 
     @inlineCallbacks
     def setUp(self):
-        if DialogueApplication.find_nodejs() is None:
-            raise SkipTest("No node.js executable found.")
+        nodejs_executable = find_nodejs_or_skip_test(DialogueApplication)
 
         self.app_helper = self.add_helper(AppWorkerHelper(DialogueApplication))
 
@@ -31,6 +30,7 @@ class TestDialogueApplication(VumiTestCase):
         redis = yield self.app_helper.vumi_helper.get_redis_manager()
         self.kv_redis = redis.sub_manager('kv')
         self.app = yield self.app_helper.get_app_worker({
+            'executable': nodejs_executable,
             'args': [sandboxer_js],
             'timeout': 10,
             'app_context': (

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -5,9 +5,9 @@ import pkg_resources
 import mock
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import SkipTest
 
 from vumi.application.sandbox import JsSandbox, SandboxCommand
+from vumi.application.tests.helpers import find_nodejs_or_skip_test
 from vumi.middleware.tagger import TaggingMiddleware
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
@@ -39,13 +39,12 @@ class TestJsBoxApplication(VumiTestCase):
 
     @inlineCallbacks
     def setUp(self):
-        if JsSandbox.find_nodejs() is None:
-            raise SkipTest("No node.js executable found.")
-
+        nodejs_executable = find_nodejs_or_skip_test(JsSandbox)
         sandboxer_js = pkg_resources.resource_filename('vumi.application',
                                                        'sandboxer.js')
         self.app_helper = self.add_helper(AppWorkerHelper(JsBoxApplication))
         self.app = yield self.app_helper.get_app_worker({
+            'executable': nodejs_executable,
             'args': [sandboxer_js],
             'timeout': 10,
         })

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,6 +8,7 @@ find go/ -name '__pycache__' -delete
 echo "=== Erasing previous coverage data..."
 coverage erase
 echo "=== Running tests..."
+export VUMI_TEST_NODE_PATH="$(which node)"
 # This is necessary so that we import test modules from the working dir instead
 # of the installed package.
 export PYTHONPATH=.


### PR DESCRIPTION
Travis has its `node` executable in a strange place, so tests that need it are skipped.
