### PR TITLE
Exclude exhausted tagpools from new channel form

### DIFF
--- a/go/channel/tests.py
+++ b/go/channel/tests.py
@@ -50,6 +50,19 @@ class TestChannelViews(GoDjangoTestCase):
         self.assertContains(response, 'International')
         self.assertContains(response, 'longcode:')
 
+    def test_get_new_channel_empty_or_exhausted_tagpool(self):
+        self.vumi_helper.setup_tagpool(u'empty', [])
+        self.vumi_helper.setup_tagpool(u'exhausted', [u'tag1'])
+        self.user_helper.add_tagpool_permission(u'empty')
+        self.user_helper.add_tagpool_permission(u'exhausted')
+        tag = self.user_helper.user_api.acquire_tag(u'exhausted')
+        self.assert_active_channel_tags([tag])
+        response = self.client.get(reverse('channels:new_channel'))
+        self.assertContains(response, 'International')
+        self.assertContains(response, 'longcode:')
+        self.assertNotContains(response, 'empty:')
+        self.assertNotContains(response, 'exhausted:')
+
     def test_post_new_channel(self):
         self.assert_active_channel_tags([])
         response = self.client.post(reverse('channels:new_channel'), {

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -211,17 +211,24 @@ class VumiUserApi(object):
         for tag in user_account.tags:
             tp_usage[tag[0]] += 1
 
-        allowed_set = set()
+        all_pools = yield self.api.tpm.list_pools()
+        allowed_pools = set()
         for tp_bunch in user_account.tagpools.load_all_bunches():
             for tp in (yield tp_bunch):
                 if (tp.max_keys is None
                         or tp.max_keys > tp_usage[tp.tagpool]):
-                    allowed_set.add(tp.tagpool)
+                    allowed_pools.add(tp.tagpool)
 
-        available_set = yield self.api.tpm.list_pools()
-        pool_names = list(allowed_set & available_set)
+        available_pools = []
+        for pool in all_pools:
+            if pool not in allowed_pools:
+                continue
+            free_tags = yield self.api.tpm.free_tags(pool)
+            if free_tags:
+                available_pools.append(pool)
+
         pool_data = dict([(pool, (yield self.api.tpm.get_metadata(pool)))
-                         for pool in pool_names])
+                          for pool in available_pools])
         returnValue(TagpoolSet(pool_data))
 
     @Manager.calls_manager

--- a/go/wizard/tests.py
+++ b/go/wizard/tests.py
@@ -62,6 +62,28 @@ class TestWizardViews(GoDjangoTestCase):
         # Check that we have a tagpool/tag in the response
         self.assertContains(response, 'longcode:')
 
+    def test_get_create_view_emtpy_or_exhausted_tagpool(self):
+        self.user_helper.add_app_permission(u'go.apps.bulk_message')
+        self.user_helper.add_app_permission(u'go.apps.subscription')
+        self.vumi_helper.setup_tagpool(u'longcode', [u'tag1'])
+        self.vumi_helper.setup_tagpool(u'empty', [])
+        self.vumi_helper.setup_tagpool(u'exhausted', [u'tag1'])
+        self.user_helper.add_tagpool_permission(u'longcode')
+        self.user_helper.add_tagpool_permission(u'empty')
+        self.user_helper.add_tagpool_permission(u'exhausted')
+        self.user_helper.user_api.acquire_tag(u'exhausted')
+        response = self.client.get(reverse('wizard:create'))
+        # Check that we have a few conversation types in the response
+        self.assertContains(response, 'bulk_message')
+        self.assertContains(response, 'subscription')
+        self.assertNotContains(response, 'survey')
+        # Check that we have a tagpool/tag in the response
+        self.assertContains(response, 'longcode:')
+        # Check that we don't have the empty or exhausted tagpools in the
+        # response
+        self.assertNotContains(response, 'empty:')
+        self.assertNotContains(response, 'exhausted:')
+
     def test_get_create_view_with_existing_routers(self):
         self.user_helper.add_app_permission(u'go.apps.bulk_message')
         self.user_helper.add_app_permission(u'go.apps.subscription')


### PR DESCRIPTION
Pools with no remaining tags in them are still listed in the channel creation form and cause explosions when we try to acquire the tags.
