### PR TITLE
Make jsbox event handling optional

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -114,11 +114,11 @@ class TestDialogueApplication(VumiTestCase):
         yield self.app_helper.start_conversation(conversation)
         msg = yield self.app_helper.make_stored_outbound(
             conversation, "foo")
-        with LogCatcher(message="Saw") as lc:
+        with LogCatcher(message="Ignoring") as lc:
             yield self.app_helper.make_dispatch_ack(msg, conv=conversation)
-            self.assertEqual(
-                lc.messages(),
-                ['Saw ack for message %s.' % (msg['message_id'],)])
+        self.assertEqual(
+            lc.messages(),
+            ["Ignoring event for conversation: %s" % (conversation.key,)])
 
     @inlineCallbacks
     def test_delivery_report(self):
@@ -126,12 +126,12 @@ class TestDialogueApplication(VumiTestCase):
         yield self.app_helper.start_conversation(conversation)
         msg = yield self.app_helper.make_stored_outbound(
             conversation, "foo")
-        with LogCatcher(message="Saw") as lc:
+        with LogCatcher(message="Ignoring") as lc:
             yield self.app_helper.make_dispatch_delivery_report(
                 msg, conv=conversation)
-            self.assertEqual(
-                lc.messages(),
-                ['Saw delivery_report for message %s.' % (msg['message_id'],)])
+        self.assertEqual(
+            lc.messages(),
+            ["Ignoring event for conversation: %s" % (conversation.key,)])
 
     @inlineCallbacks
     def test_send_message_command(self):

--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -65,17 +65,3 @@ class DialogueApplication(JsBoxApplication):
     CONFIG_CLASS = DialogueConfig
 
     worker_name = 'dialogue_application'
-
-    @inlineCallbacks
-    def process_event_in_sandbox(self, event):
-        """
-        We don't want to process events in the sandbox, just log them.
-
-        We use the sandbox logging resource to pretend this happened in the
-        sandbox, however.
-        """
-        config = yield self.get_config(event)
-        api = self.create_sandbox_api(self.resources, config)
-        log_msg = "Saw %s for message %s." % (
-            event['event_type'], event['user_message_id'])
-        yield api.log(log_msg, logging.INFO)

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -119,8 +119,10 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
         We only want to process events in the sandbox if configured to do so.
         """
         config = yield self.get_config(event)
-        app_config = jsbox_js_config(config.conversation.config)
-        if app_config.get('process_events'):
+        js_config = self.get_jsbox_js_config(config.conversation)
+        if js_config is None:
+            return
+        if js_config.get('process_events'):
             yield super(JsBoxApplication, self).process_event_in_sandbox(event)
         else:
             api = self.create_sandbox_api(self.resources, config)
@@ -139,19 +141,23 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
         msg = mk_inbound_push_trigger(to_addr, conversation)
         return self.consume_user_message(msg)
 
-    @inlineCallbacks
-    def process_command_send_jsbox(self, user_account_key, conversation_key,
-                                   batch_id):
-        conv = yield self.get_conversation(user_account_key, conversation_key)
-
+    def get_jsbox_js_config(self, conv):
         try:
-            js_config = jsbox_js_config(conv.config)
-            delivery_class = js_config.get('delivery_class')
+            return jsbox_js_config(conv.config)
         except Exception:
             log.err(
                 "Bad jsbox js config: %s"
                 % (jsbox_config_value(conv.config, 'config'),))
             return
+
+    @inlineCallbacks
+    def process_command_send_jsbox(self, user_account_key, conversation_key,
+                                   batch_id):
+        conv = yield self.get_conversation(user_account_key, conversation_key)
+        js_config = self.get_jsbox_js_config(conv)
+        if js_config is None:
+            return
+        delivery_class = js_config.get('delivery_class')
 
         if conv is None:
             log.warning("Cannot find conversation '%s' for user '%s'." % (

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -119,8 +119,7 @@ class JsBoxApplication(GoApplicationMixin, JsSandbox):
         We only want to process events in the sandbox if configured to do so.
         """
         config = yield self.get_config(event)
-        app_config = config.jsbox_app_config.get('config', {}).get('value')
-        app_config = json.loads(app_config or '{}')
+        app_config = jsbox_js_config(config.conversation.config)
         if app_config.get('process_events'):
             yield super(JsBoxApplication, self).process_event_in_sandbox(event)
         else:


### PR DESCRIPTION
Most (all?) jsbox apps don't actually need to process events, but we're currently spinning up the sandbox for them anyway. This should be optional and default to disabled.
