### PR TITLE
Worker control queues need to prefetch one message

### DIFF
--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -80,7 +80,7 @@ class GoWorkerMixin(object):
             self.consume_control_command,
             exchange_name=api_routing_config['exchange'],
             exchange_type=api_routing_config['exchange_type'],
-            message_class=VumiApiCommand)
+            message_class=VumiApiCommand, prefetch_count=1)
         return d.addCallback(lambda r: setattr(self, 'control_consumer', r))
 
     def _go_setup_event_publisher(self, config):

--- a/go/vumitools/tests/test_app_worker.py
+++ b/go/vumitools/tests/test_app_worker.py
@@ -142,3 +142,6 @@ class TestGoApplicationWorker(VumiTestCase):
         self.assertEqual(
             self.app_helper.get_published_metrics(self.app),
             [("campaigns.test-0-user.stores.some-store.some-metric", 42)])
+
+    def test_control_queue_prefetch(self):
+        self.assertEqual(self.app.control_consumer.prefetch_count, 1)


### PR DESCRIPTION
This is a special case of #875 that gets its own ticket because it doesn't address the general case.
