### PR TITLE
Contact import stuff should recognise header when `key` column present

### DIFF
--- a/go/base/fixtures/sample-contacts-with-key-header.csv
+++ b/go/base/fixtures/sample-contacts-with-key-header.csv
@@ -1,0 +1,2 @@
+key,surname
+foo,Surname 1

--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -165,7 +165,7 @@ class ContactFileParser(object):
         at the row being a row with column headers and not column values.
         """
         column_set = set([column.lower().strip() for column in columns])
-        hint_set = set(['phone', 'contact', 'msisdn', 'number'])
+        hint_set = set(['phone', 'contact', 'msisdn', 'number', 'key'])
         return hint_set.intersection(column_set)
 
     @classmethod

--- a/go/contacts/parsers/test_parsers.py
+++ b/go/contacts/parsers/test_parsers.py
@@ -44,6 +44,17 @@ class TestCSVParser(ParserTestCase):
             'msisdn': '+27761234561',
             })
 
+    def test_guess_headers_and_row_with_key_header(self):
+        csv_file = self.fixture('sample-contacts-with-key-header.csv')
+        data = self.parser.guess_headers_and_row(csv_file)
+        has_headers, known_headers, sample_row = data
+        self.assertTrue(has_headers)
+        self.assertEqual(known_headers, self.parser.DEFAULT_HEADERS)
+        self.assertEqual(sample_row, {
+            'key': 'foo',
+            'surname': 'Surname 1',
+        })
+
     def test_guess_headers_and_row_one_column_with_plus(self):
         csv_file = self.fixture('sample-contacts-one-column-with-plus.csv')
         data = self.parser.guess_headers_and_row(csv_file)


### PR DESCRIPTION
Currently it doesn't.
