### PR TITLE
Expose raw message exports via UI.

### DIFF
--- a/go/apps/multi_surveys/tests/test_views.py
+++ b/go/apps/multi_surveys/tests/test_views.py
@@ -45,11 +45,10 @@ class TestMultiSurveyViews(GoDjangoTestCase):
             5, start_date=date(2012, 1, 1), time_multiplier=12)
         conversation = conv_helper.get_conversation()
         conv_helper.add_stored_replies(msgs)
-        conv_url = conv_helper.get_view_url('message_list')
-        response = self.client.post(conv_url, {
-            '_export_conversation_messages': True,
-            })
-        self.assertRedirects(response, conv_url)
+        export_url = conv_helper.get_view_url('export_messages')
+        message_url = conv_helper.get_view_url('message_list')
+        response = self.client.post(export_url)
+        self.assertRedirects(response, message_url)
         [email] = mail.outbox
         django_user = self.app_helper.get_or_create_user().get_django_user()
         self.assertEqual(email.recipients(), [django_user.email])

--- a/go/base/tests/test_utils.py
+++ b/go/base/tests/test_utils.py
@@ -10,7 +10,7 @@ from go.base.tests.helpers import GoDjangoTestCase
 import go.base.utils
 from go.base.utils import (
     get_conversation_view_definition, get_router_view_definition,
-    UnicodeDictWriter, extract_auth_from_url)
+    UnicodeDictWriter, extract_auth_from_url, sendfile)
 from go.errors import UnknownConversationType, UnknownRouterType
 
 
@@ -133,3 +133,7 @@ class TestRandomUtils(TestCase):
         auth, url = extract_auth_from_url('http://u@go.vumi.org')
         self.assertEqual(auth, ('u', None))
         self.assertEqual(url, 'http://go.vumi.org')
+
+    def test_sendfile(self):
+        resp = sendfile('/foo')
+        self.assertEqual(resp['X-Accel-Redirect'], '/foo')

--- a/go/base/tests/test_utils.py
+++ b/go/base/tests/test_utils.py
@@ -117,7 +117,7 @@ class TestUnicodeDictWriter(TestCase):
             rows)
 
 
-class TestRandomUtils(TestCase):
+class TestRandomUtils(GoDjangoTestCase):
 
     def test_extract_auth_from_url_no_auth(self):
         auth, url = extract_auth_from_url('http://go.vumi.org')
@@ -143,3 +143,14 @@ class TestRandomUtils(TestCase):
         resp = sendfile('/foo', buffering=False)
         self.assertEqual(resp['X-Accel-Redirect'], '/foo')
         self.assertEqual(resp['X-Accel-Buffering'], 'no')
+
+    def test_sendfile_debug(self):
+        with self.settings(DEBUG=True):
+            resp = sendfile('/foo')
+            self.assertEqual(resp['X-Accel-Redirect'], '/foo')
+            self.assertEqual(resp.content, '/foo')
+
+        with self.settings(DEBUG=False):
+            resp = sendfile('/foo')
+            self.assertEqual(resp['X-Accel-Redirect'], '/foo')
+            self.assertEqual(resp.content, '')

--- a/go/base/tests/test_utils.py
+++ b/go/base/tests/test_utils.py
@@ -137,3 +137,9 @@ class TestRandomUtils(TestCase):
     def test_sendfile(self):
         resp = sendfile('/foo')
         self.assertEqual(resp['X-Accel-Redirect'], '/foo')
+        self.assertEqual(resp['X-Accel-Buffering'], 'yes')
+
+    def test_sendfile_streaming(self):
+        resp = sendfile('/foo', buffering=False)
+        self.assertEqual(resp['X-Accel-Redirect'], '/foo')
+        self.assertEqual(resp['X-Accel-Buffering'], 'no')

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -31,9 +31,10 @@ def router_or_404(user_api, key):
     return router
 
 
-def sendfile(url):
+def sendfile(url, buffering=True):
     response = HttpResponse()
     response['X-Accel-Redirect'] = url
+    response['X-Accel-Buffering'] = 'yes' if buffering else 'no'
     return response
 
 

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -6,7 +6,7 @@ from StringIO import StringIO
 from urlparse import urlparse, urlunparse
 
 from django import forms
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.conf import settings
 
 from go.errors import UnknownConversationType, UnknownRouterType
@@ -29,6 +29,12 @@ def router_or_404(user_api, key):
     if router is None:
         raise Http404("Router not found.")
     return router
+
+
+def sendfile(url):
+    response = HttpResponse()
+    response['X-Accel-Redirect'] = url
+    return response
 
 
 def vumi_api():

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -35,6 +35,10 @@ def sendfile(url, buffering=True):
     response = HttpResponse()
     response['X-Accel-Redirect'] = url
     response['X-Accel-Buffering'] = 'yes' if buffering else 'no'
+
+    if settings.DEBUG:
+        response.write(url)
+
     return response
 
 

--- a/go/conversation/templates/conversation/message_list.html
+++ b/go/conversation/templates/conversation/message_list.html
@@ -155,7 +155,7 @@
                     </span><br/></p>
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary" data-loading-text="uploading...">Schedule Export</button>
+                    <button type="submit" class="btn btn-primary">Schedule Export</button>
                 </div>
             </form>
         </div>

--- a/go/conversation/templates/conversation/message_list.html
+++ b/go/conversation/templates/conversation/message_list.html
@@ -24,7 +24,10 @@
         <a href="{{ conversation.get_absolute_url }}aggregates.csv?direction=inbound">Download Received Stats</a>
         <a href="{{ conversation.get_absolute_url }}aggregates.csv?direction=outbound">Download Sent Stats</a>
         -->
-        <a class="btn btn-default" data-toggle="modal" href="#expMessagesFrm">Export</a>
+        <a class="btn btn-default" data-toggle="modal" href="#expMessagesFrm">Export CSV via email</a>
+        <a class="btn btn-default" href="{% conversation_screen conversation "export_messages" %}?direction={{message_direction}}">
+          Download {% if message_direction == 'inbound' %}received{% else %}sent{% endif %} messages as JSON
+        </a>
     </div>
 
     <form id="search-filter" name="search-filter" action="" method="get" class="form-inline pull-right">
@@ -142,7 +145,7 @@
                 <a class="close" data-dismiss="modal">×</a>
                 <h3>Schedule CSV Export of Messages</h3>
             </div>
-            <form method="post" action="" class="form-horizontal">
+            <form method="post" action="{% conversation_screen conversation "export_messages" %}" class="form-horizontal">
                 {% csrf_token %}
                 <div class="modal-body">
                     <p><span class="help-block">
@@ -152,7 +155,7 @@
                     </span><br/></p>
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" name="_export_conversation_messages" class="btn btn-primary" data-loading-text="uploading...">Schedule Export</button>
+                    <button type="submit" class="btn btn-primary" data-loading-text="uploading...">Schedule Export</button>
                 </div>
             </form>
         </div>

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -570,6 +570,7 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertEqual(
             response['X-Accel-Redirect'],
             '/message_store_exporter/%s/inbound.json' % (conv.batch.key,))
+        self.assertEqual(response['X-Accel-Buffering'], 'no')
 
     def test_download_json_messages_outbound(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
@@ -578,6 +579,7 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertEqual(
             response['X-Accel-Redirect'],
             '/message_store_exporter/%s/outbound.json' % (conv.batch.key,))
+        self.assertEqual(response['X-Accel-Buffering'], 'no')
 
     def test_message_list_pagination(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -206,7 +206,7 @@ class ExportMessageView(ConversationApiView):
         url = '/message_store_exporter/%s/%s.json' % (conversation.batch.key,
                                                       direction)
 
-        response = sendfile(url)
+        response = sendfile(url, buffering=False)
         if settings.DEBUG:
             response.write(url)
 

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -205,12 +205,7 @@ class ExportMessageView(ConversationApiView):
 
         url = '/message_store_exporter/%s/%s.json' % (conversation.batch.key,
                                                       direction)
-
-        response = sendfile(url, buffering=False)
-        if settings.DEBUG:
-            response.write(url)
-
-        return response
+        return sendfile(url, buffering=False)
 
     def post(self, request, conversation):
         export_conversation_messages_unsorted.delay(

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -194,7 +194,7 @@ class ShowConversationView(ConversationTemplateView):
         return self.render_to_response(params)
 
 
-class ExportMessageView(ConversationTemplateView):
+class ExportMessageView(ConversationApiView):
     view_name = 'export_messages'
     path_suffix = 'export_messages/'
 

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -17,7 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from go.base import message_store_client as ms_client
-from go.base.utils import page_range_window
+from go.base.utils import page_range_window, sendfile
 from go.vumitools.exceptions import ConversationSendError
 from go.token.django_token_manager import DjangoTokenManager
 from go.conversation.forms import (ConfirmConversationForm, ReplyToMessageForm,
@@ -203,15 +203,13 @@ class ExportMessageView(ConversationApiView):
         if direction not in ['inbound', 'outbound']:
             raise Http404()
 
-        response = HttpResponse()
-
         url = '/message_store_exporter/%s/%s.json' % (conversation.batch.key,
                                                       direction)
 
+        response = sendfile(url)
         if settings.DEBUG:
             response.write(url)
 
-        response['X-Accel-Redirect'] = url
         return response
 
     def post(self, request, conversation):


### PR DESCRIPTION
Combining the stuff that's landed in https://github.com/praekelt/vumi#723 (message store resource) and http://wiki.nginx.org/XSendfile allows us to provide access to raw message downloads.

Django could return the appropriate http header in the response, nginx then grabs the file from twistd using the batch_id and streams it to the end user. 
