### PR TITLE
Use account's static groups for dialogue group state

### DIFF
--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -117,7 +117,6 @@ class TestDialogueViews(GoDjangoTestCase):
         group1 = yield self.app_helper.create_group(u'group1')
         group2 = yield self.app_helper.create_group(u'group2')
         conversation.add_group(group1)
-        conversation.add_group(group2)
 
         expected = poll.copy()
         expected.update({

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -27,10 +27,13 @@ class DialogueEditView(ConversationTemplateView):
                 "Failed to load dialogue from Go API:"
                 " (%r) %r." % (r.status_code, r.text))
 
+        contact_store = conversation.user_api.contact_store
+        groups = contact_store.list_static_groups()
+
         model_data = {
             'campaign_id': request.user_api.user_account_key,
             'conversation_key': conversation.key,
-            'groups': [g.get_data() for g in conversation.get_groups()],
+            'groups': [g.get_data() for g in groups],
             'urls': {
                 'show': self.get_view_url(
                     'show',


### PR DESCRIPTION
At the moment, the conversation's groups are used instead of the account's groups. This means the flow is broken when we set up a new dialogue conversation.
