### PR TITLE
Dialogues won't work properly over channels other than sms and ussd

### DIFF
--- a/go/apps/dialogue/templates/dialogue/edit.html
+++ b/go/apps/dialogue/templates/dialogue/edit.html
@@ -12,14 +12,14 @@
 {% block content_actions_right %}
   <div class="pull-left form-inline">
       <div class="form-group">
-          <input type="checkbox" id="repeatable">
+          <input id="repeatable" type="checkbox">
           <label>Enable users to submit multiple surveys</label>
       </div>
 
       <div class="form-group">
-          <select class="form-control">
+          <select id="delivery-class" class="form-control">
               {% for delivery_class in delivery_classes %}
-              <option value="{{ delivery_class }}" {% if delivery_class == default_delivery_class %} selected {% endif %}>
+              <option value="{{ delivery_class }}" {% if delivery_class == current_delivery_class %} selected {% endif %}>
                {{ delivery_class|title }}
                </option>
               {% endfor %}

--- a/go/apps/dialogue/templates/dialogue/edit.html
+++ b/go/apps/dialogue/templates/dialogue/edit.html
@@ -10,9 +10,23 @@
 {% endblock %}
 
 {% block content_actions_right %}
-  <div class="pull-left">
-    <input type="checkbox" id="repeatable">
-    Enable users to submit multiple surveys
+  <div class="pull-left form-inline">
+      <div class="form-group">
+          <input type="checkbox" id="repeatable">
+          <label>Enable users to submit multiple surveys</label>
+      </div>
+
+      <div class="form-group">
+          <select class="form-control">
+              {% for delivery_class in delivery_classes %}
+              <option value="{{ delivery_class }}" {% if delivery_class == default_delivery_class %} selected {% endif %}>
+               {{ delivery_class|title }}
+               </option>
+              {% endfor %}
+          </select>
+
+          <label>Channel type</label>
+      </div>
   </div>
 
   <div class="pull-right">

--- a/go/apps/dialogue/templates/dialogue/edit.html
+++ b/go/apps/dialogue/templates/dialogue/edit.html
@@ -18,9 +18,9 @@
 
       <div class="form-group">
           <select id="delivery-class" class="form-control">
-              {% for delivery_class in delivery_classes %}
+              {% for delivery_class, label in delivery_classes %}
               <option value="{{ delivery_class }}" {% if delivery_class == current_delivery_class %} selected {% endif %}>
-               {{ delivery_class|title }}
+               {{ label }}
                </option>
               {% endfor %}
           </select>

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -113,6 +113,13 @@ class TestDialogueViews(GoDjangoTestCase):
         self.assertContains(response, u"myconv")
         self.assertContains(response, 'diagram')
 
+        self.assertContains(response, 'Ussd')
+        self.assertContains(response, 'Sms')
+        self.assertContains(response, 'Gtalk')
+        self.assertContains(response, 'Mxit')
+        self.assertContains(response, 'Wechat')
+        self.assertContains(response, 'Twitter')
+
         conversation = conv_helper.get_conversation()
         group1 = yield self.app_helper.create_group(u'group1')
         group2 = yield self.app_helper.create_group(u'group2')

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -113,11 +113,11 @@ class TestDialogueViews(GoDjangoTestCase):
         self.assertContains(response, u"myconv")
         self.assertContains(response, 'diagram')
 
-        self.assertContains(response, 'Ussd')
-        self.assertContains(response, 'Sms')
-        self.assertContains(response, 'Gtalk')
+        self.assertContains(response, 'USSD')
+        self.assertContains(response, 'SMS')
+        self.assertContains(response, 'Google Talk')
         self.assertContains(response, 'Mxit')
-        self.assertContains(response, 'Wechat')
+        self.assertContains(response, 'WeChat')
         self.assertContains(response, 'Twitter')
 
         conversation = conv_helper.get_conversation()

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -7,6 +7,8 @@ from go.api.go_api import client
 from go.api.go_api.client import GoApiError
 from go.conversation.view_definition import (
     ConversationViewDefinitionBase, ConversationTemplateView)
+from go.vumitools.contact.models import (
+    DELIVERY_CLASS_ADDR_TYPES, DEFAULT_DELIVERY_CLASS)
 
 
 class DialogueEditView(ConversationTemplateView):
@@ -43,6 +45,8 @@ class DialogueEditView(ConversationTemplateView):
         model_data.update(r.json['result']['poll'])
 
         return self.render_to_response({
+            'default_delivery_class': DEFAULT_DELIVERY_CLASS,
+            'delivery_classes': DELIVERY_CLASS_ADDR_TYPES.keys(),
             'conversation': conversation,
             'session_id': request.session.session_key,
             'model_data': json.dumps(model_data),

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -44,8 +44,11 @@ class DialogueEditView(ConversationTemplateView):
         }
         model_data.update(r.json['result']['poll'])
 
+        metadata = model_data.get('poll_metadata', {})
+        delivery_class = metadata.get('delivery_class', DEFAULT_DELIVERY_CLASS)
+
         return self.render_to_response({
-            'default_delivery_class': DEFAULT_DELIVERY_CLASS,
+            'current_delivery_class': delivery_class,
             'delivery_classes': DELIVERY_CLASS_ADDR_TYPES.keys(),
             'conversation': conversation,
             'session_id': request.session.session_key,

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -8,7 +8,7 @@ from go.api.go_api.client import GoApiError
 from go.conversation.view_definition import (
     ConversationViewDefinitionBase, ConversationTemplateView)
 from go.vumitools.contact.models import (
-    DELIVERY_CLASS_ADDR_TYPES, DEFAULT_DELIVERY_CLASS)
+    DELIVERY_CLASSES, DEFAULT_DELIVERY_CLASS)
 
 
 class DialogueEditView(ConversationTemplateView):
@@ -46,10 +46,12 @@ class DialogueEditView(ConversationTemplateView):
 
         metadata = model_data.get('poll_metadata', {})
         delivery_class = metadata.get('delivery_class', DEFAULT_DELIVERY_CLASS)
+        delivery_classes = [
+            (d_name, d['label']) for d_name, d in DELIVERY_CLASSES.iteritems()]
 
         return self.render_to_response({
             'current_delivery_class': delivery_class,
-            'delivery_classes': DELIVERY_CLASS_ADDR_TYPES.keys(),
+            'delivery_classes': delivery_classes,
             'conversation': conversation,
             'session_id': request.session.session_key,
             'model_data': json.dumps(model_data),

--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -19,9 +19,18 @@ class PollConfigResource(SandboxResource):
         :returns:
             JSON string containg the configuration dictionary.
         """
+
         config = {
             "name": "poll-%s" % conversation.key
         }
+
+        poll = conversation.config.get("poll", {})
+        poll_metadata = poll.get('poll_metadata', {})
+        delivery_class = poll_metadata.get('delivery_class')
+
+        if delivery_class is not None:
+            config['delivery_class'] = delivery_class
+
         return json.dumps(config)
 
     def _get_poll(self, conversation):

--- a/go/base/static/css/conversations.less
+++ b/go/base/static/css/conversations.less
@@ -23,6 +23,20 @@
     .sidebar {
       background: #d9d8d3;
     }
+
+    .form-group {
+      padding-right: 15px;
+
+      label {
+        padding-left: 3px;
+        font-weight: normal;
+        margin-bottom: auto;
+      }
+
+      select.form-control {
+        width: auto;
+      }
+    }
   }
 
   #diagram {

--- a/go/base/static/css/vumigo.css
+++ b/go/base/static/css/vumigo.css
@@ -381,6 +381,17 @@ button {
 .dialogue .actions .sidebar {
   background: #d9d8d3;
 }
+.dialogue .actions .form-group {
+  padding-right: 15px;
+}
+.dialogue .actions .form-group label {
+  padding-left: 3px;
+  font-weight: normal;
+  margin-bottom: auto;
+}
+.dialogue .actions .form-group select.form-control {
+  width: auto;
+}
 .dialogue #diagram ._jsPlumb_connector {
   z-index: 1;
   opacity: 0.75;

--- a/go/base/static/js/src/apps/dialogue/views.js
+++ b/go/base/static/js/src/apps/dialogue/views.js
@@ -37,9 +37,12 @@
     render: function() {
       this.diagram.render();
 
-      this.$('#repeatable').prop(
-        'checked',
-        this.model.get('poll_metadata').get('repeatable'));
+      var metadata = this.model.get('poll_metadata');
+      this.$('#repeatable').prop('checked', metadata.get('repeatable'));
+
+      if (metadata.get('delivery_class')) {
+        this.$('#delivery-class').val(metadata.get('delivery_class'));
+      }
     },
 
     events: {
@@ -51,6 +54,12 @@
         this.model
           .get('poll_metadata')
           .set('repeatable', $(e.target).prop('checked'));
+      },
+
+      'change #delivery-class': function(e) {
+        this.model
+          .get('poll_metadata')
+          .set('delivery_class', $(e.target).val());
       },
     }
   });

--- a/go/base/static/js/test/apps/dialogue/testHelpers.js
+++ b/go/base/static/js/test/apps/dialogue/testHelpers.js
@@ -9,7 +9,10 @@
   var modelData = {
     campaign_id: 'campaign-1',
     conversation_key: 'conversation-1',
-    poll_metadata: {repeatable: false},
+    poll_metadata: {
+      repeatable: false,
+      delivery_class: 'ussd'
+    },
     start_state: {uuid: 'state1'},
     groups: [{
       key: 'group1',
@@ -111,6 +114,14 @@
         .append($('<input>')
           .attr('type', 'checkbox')
           .attr('id', 'repeatable'))
+        .append($('<select>')
+          .attr('id', 'delivery-class')
+            .append($('<option>')
+              .attr('value', 'ussd')
+              .text('Ussd'))
+            .append($('<option>')
+              .attr('value', 'twitter')
+              .text('Twitter')))
         .append($('<button>').attr('id', 'new-state'))
         .append($('<button>').attr('id', 'save'))
         .append($('<div>').attr('id', 'diagram')));

--- a/go/base/static/js/test/apps/dialogue/views.test.js
+++ b/go/base/static/js/test/apps/dialogue/views.test.js
@@ -128,5 +128,15 @@ describe("go.apps.dialogue.views", function() {
         assert(!view.model.get('poll_metadata').get('repeatable'));
       });
     });
+
+    describe("when '#delivery-class' is changed", function() {
+      it("should change the model metadata's 'delivery_class' attribute",
+      function() {
+        var metadata = view.model.get('poll_metadata');
+        assert.equal(metadata.get('delivery_class'), 'ussd');
+        view.$('#delivery-class').val('twitter').change();
+        assert.equal(metadata.get('delivery_class'), 'twitter');
+      });
+    });
   });
 });

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -13,13 +13,31 @@ from go.vumitools.contact.migrations import ContactMigrator
 from go.vumitools.opt_out import OptOutStore
 
 
-DELIVERY_CLASS_ADDR_TYPES = {
-    'sms': 'msisdn',
-    'ussd': 'msisdn',
-    'gtalk': 'gtalk_id',
-    'mxit': 'mxit_id',
-    'wechat': 'wechat_id',
-    'twitter': 'twitter_handle',
+DELIVERY_CLASSES = {
+    'sms': {
+        'field': 'msisdn',
+        'label': 'SMS',
+    },
+    'ussd': {
+        'field': 'msisdn',
+        'label': 'USSD',
+    },
+    'gtalk': {
+        'field': 'gtalk_id',
+        'label': 'Google Talk',
+    },
+    'mxit': {
+        'field': 'mxit_id',
+        'label': 'Mxit',
+    },
+    'wechat': {
+        'field': 'wechat_id',
+        'label': 'WeChat',
+    },
+    'twitter': {
+        'field': 'twitter_handle',
+        'label': 'Twitter',
+    },
 }
 
 
@@ -93,8 +111,11 @@ class Contact(Model):
             #        this hack.
             return self.msisdn
 
-        addr_type = DELIVERY_CLASS_ADDR_TYPES.get(delivery_class)
-        return getattr(self, addr_type) if addr_type is not None else None
+        delivery_class = DELIVERY_CLASSES.get(delivery_class)
+        if delivery_class is not None:
+            return getattr(self, delivery_class['field'])
+
+        return None
 
     def __unicode__(self):
         if self.name and self.surname:

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -13,6 +13,19 @@ from go.vumitools.contact.migrations import ContactMigrator
 from go.vumitools.opt_out import OptOutStore
 
 
+DELIVERY_CLASS_ADDR_TYPES = {
+    'sms': 'msisdn',
+    'ussd': 'msisdn',
+    'gtalk': 'gtalk_id',
+    'mxit': 'mxit_id',
+    'wechat': 'wechat_id',
+    'twitter': 'twitter_handle',
+}
+
+
+DEFAULT_DELIVERY_CLASS = 'ussd'
+
+
 class ContactError(Exception):
     """Raised when an error occurs accessing or manipulating a Contact"""
 
@@ -79,19 +92,9 @@ class Contact(Model):
             # FIXME: Find a better way to do get delivery_class and get rid of
             #        this hack.
             return self.msisdn
-        # TODO: delivery classes need to be defined somewhere
-        if delivery_class in ('sms', 'ussd'):
-            return self.msisdn
-        elif delivery_class == 'gtalk':
-            return self.gtalk_id
-        elif delivery_class == 'twitter':
-            return self.twitter_handle
-        elif delivery_class == 'mxit':
-            return self.mxit_id
-        elif delivery_class == 'wechat':
-            return self.wechat_id
-        else:
-            return None
+
+        addr_type = DELIVERY_CLASS_ADDR_TYPES.get(delivery_class)
+        return getattr(self, addr_type) if addr_type is not None else None
 
     def __unicode__(self):
         if self.name and self.surname:


### PR DESCRIPTION
Dialogue applications store each user's answers on their contact. For jsbox apps, we look up a contact based on the contact's address. At the moment, we need to explicitly set the delivery class for a jsbox conversation in order to figure out which type of contact address to use when looking up the contact, and default to `ussd` as the delivery class if none is given. Since `ussd` and `sms` delivery classes map to a contact's `msisdn`, dialogue apps will work for those two channel types. For other channels types (for e.g, twitter), this won't work, since we will still be looking up contacts by their msisdn.

The short way round would be to add a delivery class drop down to UI for dialogue apps.

The longer, better way round would be to change jsbox apps to figure out the type of contact address to look up based on the received message's address type. We will need praekelt/vumi#581 for this.
