### PR TITLE
New groups aren't listed after a conversation is created

### DIFF
--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -107,6 +107,11 @@ class TestDialogueViews(GoDjangoTestCase):
         conv_helper = self.setup_conversation(
             with_group=False, started=False, name=u"myconv")
 
+        conversation = conv_helper.get_conversation()
+        group1 = self.app_helper.create_group(u'group1')
+        group2 = self.app_helper.create_group(u'group2')
+        conversation.add_group(group1)
+
         poll = {"foo": "bar"}
         self.mock_rpc.set_response(result={"poll": poll})
         response = self.client.get(conv_helper.get_view_url('edit'))
@@ -119,11 +124,6 @@ class TestDialogueViews(GoDjangoTestCase):
         self.assertContains(response, 'Mxit')
         self.assertContains(response, 'WeChat')
         self.assertContains(response, 'Twitter')
-
-        conversation = conv_helper.get_conversation()
-        group1 = yield self.app_helper.create_group(u'group1')
-        group2 = yield self.app_helper.create_group(u'group2')
-        conversation.add_group(group1)
 
         expected = poll.copy()
         expected.update({

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -112,7 +112,12 @@ class TestDialogueViews(GoDjangoTestCase):
         group2 = self.app_helper.create_group(u'group2')
         conversation.add_group(group1)
 
-        poll = {"foo": "bar"}
+        poll = {
+            'groups': [{
+                'key': '123',
+                'name': 'foo'
+            }]
+        }
         self.mock_rpc.set_response(result={"poll": poll})
         response = self.client.get(conv_helper.get_view_url('edit'))
         self.assertContains(response, u"myconv")

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -32,7 +32,8 @@ class DialogueEditView(ConversationTemplateView):
         contact_store = conversation.user_api.contact_store
         groups = contact_store.list_static_groups()
 
-        model_data = {
+        model_data = r.json['result']['poll']
+        model_data.update({
             'campaign_id': request.user_api.user_account_key,
             'conversation_key': conversation.key,
             'groups': [g.get_data() for g in groups],
@@ -41,8 +42,7 @@ class DialogueEditView(ConversationTemplateView):
                     'show',
                     conversation_key=conversation.key)
             }
-        }
-        model_data.update(r.json['result']['poll'])
+        })
 
         metadata = model_data.get('poll_metadata', {})
         delivery_class = metadata.get('delivery_class', DEFAULT_DELIVERY_CLASS)


### PR DESCRIPTION
The dialogue application uses `contact_store.list_static_groups()` to get the list of static groups on the account for use in the dialogue group state, but for some reason, groups created after the conversation is created don't show up in this list.
