### PR TITLE
opt_out_id can produce unicode keys

### DIFF
--- a/go/vumitools/opt_out/models.py
+++ b/go/vumitools/opt_out/models.py
@@ -22,7 +22,8 @@ class OptOutStore(PerAccountStore):
         self.opt_outs = self.manager.proxy(OptOut)
 
     def opt_out_id(self, addr_type, addr_value):
-        return "%s:%s" % (addr_type, addr_value)
+        # this returns a Riak key which must be a binary string
+        return (u"%s:%s" % (addr_type, addr_value)).encode('utf-8')
 
     @Manager.calls_manager
     def new_opt_out(self, addr_type, addr_value, message):

--- a/go/vumitools/opt_out/tests/test_models.py
+++ b/go/vumitools/opt_out/tests/test_models.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 """Tests for go.vumitools.opt_out.models."""
 
 from datetime import datetime, timedelta

--- a/go/vumitools/opt_out/tests/test_models.py
+++ b/go/vumitools/opt_out/tests/test_models.py
@@ -28,6 +28,10 @@ class TestOptOutStore(VumiTestCase):
         self.assertEqual(self.opt_out_store.opt_out_id("msisdn", "+1234"),
                          "msisdn:+1234")
 
+    def test_opt_out_id_with_unicode(self):
+        self.assertEqual(self.opt_out_store.opt_out_id("mxit", u"foö"),
+                         u"mxit:foö".encode('utf-8'))
+
     @inlineCallbacks
     def test_new_opt_out(self):
         msg = self.msg_helper.make_inbound("STOP")


### PR DESCRIPTION
Riak requires string keys.

```
  File "/mnt/praekelt/vumi-go/go/vumitools/opt_out/models.py", line 44, in get_opt_out
    return self.opt_outs.load(self.opt_out_id(addr_type, addr_value))
  File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py", line 731, in load
    return self._modelcls.load(self._manager, key)
  File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py", line 268, in load
    return manager.load(cls, key, result=result)
  File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/persist/txriak_manager.py", line 104, in load
    riak_object = self.riak_object(modelcls, key, result)
  File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/persist/txriak_manager.py", line 72, in riak_object
    riak_object = RiakObject(self.client, bucket, key)
  File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/riakasaurus/riak_object.py", line 52, in __init__
    raise TypeError('Unicode keys are not supported.')
exceptions.TypeError: Unicode keys are not supported.
```
