### PR TITLE
Allow releasing tags without owner set

### DIFF
--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -401,7 +401,8 @@ class VumiUserApi(object):
             log.error("Tag not allocated to account: %s" % (tag,), e)
         else:
             tag_info = yield self.api.mdb.get_tag_info(tag)
-            del tag_info.metadata['user_account']
+            if 'user_account' in tag_info.metadata:
+                del tag_info.metadata['user_account']
             yield tag_info.save()
             # NOTE: This loads and saves the CurrentTag object a second time.
             #       We should probably refactor the message store to make this

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -171,6 +171,20 @@ class TestTxVumiUserApi(VumiTestCase):
         yield self.assert_account_tags([list(tag1), list(tag2)])
 
     @inlineCallbacks
+    def test_release_tag_without_owner(self):
+        [tag] = yield self.vumi_helper.setup_tagpool(u"pool1", [u"1234"])
+        yield self.user_helper.add_tagpool_permission(u"pool1")
+        yield self.user_api.acquire_specific_tag(tag)
+
+        tag_info = yield self.vumi_api.mdb.get_tag_info(tag)
+        del tag_info.metadata['user_account']
+        yield tag_info.save()
+
+        yield self.assert_account_tags([list(tag)])
+        yield self.user_api.release_tag(tag)
+        yield self.assert_account_tags([])
+
+    @inlineCallbacks
     def test_batch_id_for_specific_tag(self):
         [tag] = yield self.vumi_helper.setup_tagpool(u"poolA", [u"tag1"])
         yield self.user_helper.add_tagpool_permission(u"poolA")


### PR DESCRIPTION
```
  File "/var/praekelt/vumi-go/go/channel/view_definition.py", line 49, in post
    channel.release(request.user_api)

  File "/var/praekelt/vumi-go/go/vumitools/channel/models.py", line 27, in release
    user_api.release_tag((self.tagpool, self.tag))

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py", line 567, in wrapper
    return manager.call_decorator(func)(self, *args, **kw)

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/utils.py", line 369, in wrapped
    result = gen.send(result)

  File "/var/praekelt/vumi-go/go/vumitools/api.py", line 404, in release_tag
    del tag_info.metadata['user_account']

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/fields.py", line 466, in __delitem__
    self._descriptor.delete_dynamic_value(self._modelobj, key)

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/fields.py", line 420, in delete_dynamic_value
    del modelobj._riak_object._data[key]

KeyError: 'metadata.user_account'
```
