### PR TITLE
Optionally list more tag and pool information when printing accounts in go_list_accounts

### DIFF
--- a/go/base/management/commands/go_list_accounts.py
+++ b/go/base/management/commands/go_list_accounts.py
@@ -1,7 +1,10 @@
+from optparse import make_option
+
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 
 from go.base.command_utils import get_users, user_details_as_string
+from go.base.utils import vumi_api_for_user
 
 
 class Command(BaseCommand):
@@ -24,6 +27,17 @@ class Command(BaseCommand):
     args = "[optional username regex]"
     encoding = 'utf-8'
 
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--show-pools', dest='show-pools', default=False,
+            action='store_true',
+            help="Show tag pool permissions in account listing"),
+        make_option(
+            '--show-tags', dest='show-tags', default=False,
+            action='store_true',
+            help="Show owned tags in account listing"),
+    )
+
     def handle(self, *usernames, **options):
         users = get_users()
         if usernames:
@@ -33,5 +47,21 @@ class Command(BaseCommand):
         if not users.exists():
             self.stderr.write('No accounts found.\n')
         for index, user in enumerate(users):
-            output = u"%s. %s\n" % (index, user_details_as_string(user))
-            self.stdout.write(output.encode(self.encoding))
+            self.print_account(index, user, options)
+
+    def print_account(self, index, user, options):
+        output = u"%s. %s\n" % (index, user_details_as_string(user))
+        self.stdout.write(output.encode(self.encoding))
+        user_api = vumi_api_for_user(user)
+        if options.get('show-pools'):
+            self.stdout.write("  Pools:\n")
+            user_account = user_api.get_user_account()
+            for tp_bunch in user_account.tagpools.load_all_bunches():
+                for tp in tp_bunch:
+                    self.stdout.write(
+                        "    %r (max-keys: %s)" % (tp.tagpool, tp.max_keys))
+        if options.get('show-tags'):
+            self.stdout.write("  Tags:\n")
+            for channel in user_api.active_channels():
+                self.stdout.write(
+                    "    (%r, %r)\n" % (channel.tagpool, channel.tag))

--- a/go/base/tests/test_go_list_accounts.py
+++ b/go/base/tests/test_go_list_accounts.py
@@ -42,3 +42,26 @@ class TestGoListAccountsCommand(GoDjangoTestCase):
         self.assertEqual(self.command.stderr.getvalue(),
             'No accounts found.\n')
         self.assertEqual(self.command.stdout.getvalue(), '')
+
+    def test_show_pools(self):
+        self.vumi_helper.setup_tagpool(u"pool-1", [])
+        self.user_helper.add_tagpool_permission(u"pool-1")
+
+        self.command.handle(**{'show-pools': True})
+        self.assertEqual(self.command.stdout.getvalue().splitlines(), [
+            "0. Test User <user@domain.com> [test-0-user]",
+            "  Pools:",
+            "    u'pool-1' (max-keys: None)",
+        ])
+
+    def test_show_tags(self):
+        self.vumi_helper.setup_tagpool(u"pool-1", [u"tag-1"])
+        self.user_helper.add_tagpool_permission(u"pool-1")
+        self.user_helper.user_api.acquire_specific_tag((u"pool-1", u"tag-1"))
+
+        self.command.handle(**{'show-tags': True})
+        self.assertEqual(self.command.stdout.getvalue().splitlines(), [
+            "0. Test User <user@domain.com> [test-0-user]",
+            "  Tags:",
+            "    (u'pool-1', u'tag-1')",
+        ])


### PR DESCRIPTION
Currently we only print out the basic account information and sometimes one wants more, specifically information about tags acquired and pools accounts have access to.
