### PR TITLE
Contact view can access ``smart_form_group`` before it's defined.

### DIFF
--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -278,7 +278,8 @@ class TestContacts(BaseContactsTestCase):
         self.assertRedirects(response, group_url(group.key))
         self.assertEqual(len(group.backlinks.contacts()), 0)
 
-        self.specify_columns(group.key)
+        response = self.specify_columns(group.key)
+        self.assertRedirects(response, group_url(group.key))
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
@@ -294,7 +295,8 @@ class TestContacts(BaseContactsTestCase):
         self.assertRedirects(response, group_url(group.key))
         group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 0)
-        self.specify_columns(group.key)
+        response = self.specify_columns(group.key)
+        self.assertRedirects(response, group_url(group.key))
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
@@ -309,7 +311,8 @@ class TestContacts(BaseContactsTestCase):
         })
         self.assertRedirects(response, group_url(group.key))
 
-        self.specify_columns(group.key)
+        response = self.specify_columns(group.key)
+        self.assertRedirects(response, group_url(group.key))
         group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(len(mail.outbox), 1)
@@ -328,7 +331,7 @@ class TestContacts(BaseContactsTestCase):
         })
         self.assertRedirects(response, group_url(group.key))
 
-        self.specify_columns(group.key, columns={
+        response = self.specify_columns(group.key, columns={
             'column-0': 'msisdn',
             'column-1': 'area',
             'column-2': 'nairobi_1',
@@ -346,6 +349,7 @@ class TestContacts(BaseContactsTestCase):
             'normalize-6': '',
             'normalize-7': '',
         })
+        self.assertRedirects(response, group_url(group.key))
         group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 2)
         self.assertEqual(len(mail.outbox), 1)
@@ -364,10 +368,11 @@ class TestContacts(BaseContactsTestCase):
         })
         self.assertRedirects(response, group_url(group.key))
 
-        self.specify_columns(group.key, columns={
+        response = self.specify_columns(group.key, columns={
             'column-0': 'msisdn',
             'normalize-0': '',
         })
+        self.assertRedirects(response, group_url(group.key))
 
         group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 2)
@@ -452,7 +457,7 @@ class TestContacts(BaseContactsTestCase):
         })
 
         self.assertRedirects(response, group_url(group.key))
-        self.specify_columns(group.key, columns={
+        response = self.specify_columns(group.key, columns={
             'column-0': 'key',
             'column-1': 'name',
             'column-2': 'surname',
@@ -461,6 +466,7 @@ class TestContacts(BaseContactsTestCase):
             'column-5': 'litmus_new',
             'normalize-3': 'msisdn_za',
         }, import_rule='upload_is_truth')
+        self.assertRedirects(response, group_url(group.key))
 
         group = self.contact_store.get_group(group.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
@@ -544,7 +550,7 @@ class TestContacts(BaseContactsTestCase):
         })
 
         self.assertRedirects(response, group_url(group1.key))
-        self.specify_columns(group1.key, columns={
+        response = self.specify_columns(group1.key, columns={
             'column-0': 'key',
             'column-1': 'name',
             'column-2': 'surname',
@@ -553,6 +559,7 @@ class TestContacts(BaseContactsTestCase):
             'column-5': 'litmus_new',
             'normalize-3': 'msisdn_za',
         }, import_rule='existing_is_truth')
+        self.assertRedirects(response, group_url(group1.key))
 
         group = self.contact_store.get_group(group1.key)
         self.assertEqual(len(group.backlinks.contacts()), 3)
@@ -619,7 +626,8 @@ class TestContacts(BaseContactsTestCase):
         group = newest(self.contact_store.list_groups())
         self.assertEqual(group.name, new_group_name)
         self.assertRedirects(response, group_url(group.key))
-        self.specify_columns(group_key=group.key)
+        response = self.specify_columns(group_key=group.key)
+        self.assertRedirects(response, group_url(group.key))
         self.assertEqual(len(group.backlinks.contacts()), 3)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTrue('successfully' in mail.outbox[0].subject)
@@ -876,10 +884,11 @@ class TestGroups(BaseContactsTestCase):
 
         # Delete the groups
         groups_url = reverse('contacts:groups')
-        self.client.post(groups_url, {
+        response = self.client.post(groups_url, {
             'group': [group_1.key, group_2.key],
             '_delete': True,
         })
+        self.assertRedirects(response, groups_url)
         self.assertEqual(self.contact_store.list_groups(), [])
 
     def test_removing_contacts_from_group(self):
@@ -888,10 +897,11 @@ class TestGroups(BaseContactsTestCase):
         c2 = self.mkcontact(groups=[group])
 
         group_url = reverse('contacts:group', kwargs={'group_key': group.key})
-        self.client.post(group_url, {
+        response = self.client.post(group_url, {
             '_remove': True,
             'contact': [c1.key]
         })
+        self.assertRedirects(response, group_url)
 
         self.assertEqual(
             [c2.key],

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -801,6 +801,9 @@ class TestGroups(BaseContactsTestCase):
     def get_latest_contact(self):
         return max(self.get_all_contacts(), key=lambda c: c.created_at)
 
+    def list_group_keys(self):
+        return [group.key for group in self.contact_store.list_groups()]
+
     def test_groups_creation(self):
         response = self.client.post(reverse('contacts:groups'), {
             'name': 'a new group',
@@ -893,6 +896,16 @@ class TestGroups(BaseContactsTestCase):
         self.assertEqual(
             [c2.key],
             self.contact_store.get_contacts_for_group(group))
+
+    def test_group_empty_post(self):
+        group = self.contact_store.new_group(TEST_GROUP_NAME)
+
+        self.assertEqual(self.list_group_keys(), [group.key])
+        group_url = reverse('contacts:group', kwargs={'group_key': group.key})
+        response = self.client.post(group_url)
+        self.assertRedirects(response, group_url)
+
+        self.assertEqual(self.list_group_keys(), [group.key])
 
     def test_group_deletion(self):
         group = self.contact_store.new_group(TEST_GROUP_NAME)

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -69,6 +69,7 @@ def groups(request, type=None):
                                          group.key)
             messages.info(request, '%d groups will be deleted '
                                    'shortly.' % len(groups))
+            return redirect(reverse('contacts:groups'))
         elif '_export' in request.POST:
             tasks.export_many_group_contacts.delay(
                 request.user_api.user_account_key,
@@ -76,6 +77,7 @@ def groups(request, type=None):
 
             messages.info(request, 'The export is scheduled and should '
                                    'complete within a few minutes.')
+            return redirect(reverse('contacts:groups'))
     else:
         contact_group_form = ContactGroupForm()
         smart_group_form = SmartGroupForm()
@@ -158,7 +160,7 @@ def _static_group(request, contact_store, group):
                           'The export is scheduled and should '
                           'complete within a few minutes.')
             return redirect(_group_url(group.key))
-        if '_remove' in request.POST:
+        elif '_remove' in request.POST:
             contacts = request.POST.getlist('contact')
             for person_key in contacts:
                 contact = contact_store.get_contact_by_key(person_key)
@@ -167,6 +169,7 @@ def _static_group(request, contact_store, group):
             messages.info(
                 request,
                 '%d Contacts removed from group' % len(contacts))
+            return redirect(_group_url(group.key))
         elif '_delete_group_contacts' in request.POST:
             tasks.delete_group_contacts.delay(
                 request.user_api.user_account_key, group.key)
@@ -193,12 +196,12 @@ def _static_group(request, contact_store, group):
                     'We will notify you via email when the import '
                     'has been completed')
 
-                return redirect(_group_url(group.key))
-
             except (ContactParserException,):
                 messages.error(request, 'Something is wrong with the file')
                 _, file_path = utils.get_file_hints_from_session(request)
                 default_storage.delete(file_path)
+
+            return redirect(_group_url(group.key))
 
         else:
             upload_contacts_form = UploadContactsForm(request.POST,

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -209,6 +209,11 @@ def _static_group(request, contact_store, group):
                 utils.store_file_hints_in_session(
                     request, file_name, file_path)
                 return redirect(_group_url(group.key))
+            else:
+                # We didn't get any useful POST variables, so just redirect
+                # back to the group page without doing anything.
+                return redirect(_group_url(group.key))
+
     else:
         group_form = ContactGroupForm({
             'name': group.name,

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -294,6 +294,10 @@ def _smart_group(request, contact_store, group):
                                      group.key)
             messages.info(request, 'The group will be deleted shortly.')
             return redirect(reverse('contacts:index'))
+        else:
+            # We didn't get any useful POST variables, so just redirect back to
+            # the group page without doing anything.
+            return redirect(_group_url(group.key))
     else:
         smart_group_form = SmartGroupForm({
             'name': group.name,


### PR DESCRIPTION
```
Stacktrace (most recent call last):

(4 additional frame(s) were not displayed)
...
  File "django/utils/decorators.py", line 91, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "go/contacts/views.py", line 133, in _group
    return _smart_group(request, contact_store, group)
  File "django/utils/decorators.py", line 91, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "django/contrib/auth/decorators.py",
  line 25, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "go/contacts/views.py", line 315, in _smart_group
    'group_form': smart_group_form,
```

I think this is an unhandled error path in the `if` statement higher up in the code.
