### PR TITLE
CSV contact importer attempts to coerce list to Unicode

### DIFF
--- a/go/base/fixtures/sample-contacts-with-headers-and-extra-fields.csv
+++ b/go/base/fixtures/sample-contacts-with-headers-and-extra-fields.csv
@@ -1,0 +1,24 @@
+name,surname,msisdn
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Name 1,Surname 1,+27761234561
+Name 2,Surname 2,+27761234562,baz
+Name 3,Surname 3,+27761234563,foo,bar
+Name 4,Surname 4,+27761234564

--- a/go/base/fixtures/sample-contacts-with-headers-and-missing-fields.csv
+++ b/go/base/fixtures/sample-contacts-with-headers-and-missing-fields.csv
@@ -1,0 +1,24 @@
+name,surname,msisdn
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Extra rows,to get past dialect sniffing,+27761234560
+Name 1,Surname 1,+27761234561
+Name 2,Surname 2
++27761234563
+Name 4,Surname 4,+27761234564

--- a/go/contacts/parsers/csv_parser.py
+++ b/go/contacts/parsers/csv_parser.py
@@ -39,10 +39,24 @@ class CSVFileParser(ContactFileParser):
             for row in reader:
                 # Only process rows that actually have data
                 if any([column for column in row]):
+                    if None in row:
+                        # Any extra fields are stuck in a list with a key of
+                        # `None`. The presence of this key means we have a row
+                        # with too many fields. We don't know how to handle
+                        # this case, so we abort.
+                        raise ContactParserException(
+                            'Invalid row: too many fields.')
+                    if None in row.values():
+                        # Any missing fields are given a value of `None`. Since
+                        # all legitimate field values are strings, this is a
+                        # reliable indicator of a missing field. We don't know
+                        # how to handle this case, so we abort.
+                        raise ContactParserException(
+                            'Invalid row: not enough fields.')
                     # Our Riak client requires unicode for all keys & values
                     # stored.
                     unicoded_row = dict([(key, unicode(value or '', 'utf-8'))
-                                            for key, value in row.items()])
+                                         for key, value in row.items()])
                     yield unicoded_row
         except csv.Error as e:
             raise ContactParserException(e)

--- a/go/contacts/parsers/csv_parser.py
+++ b/go/contacts/parsers/csv_parser.py
@@ -37,22 +37,23 @@ class CSVFileParser(ContactFileParser):
             if has_header:
                 reader.next()
             for row in reader:
+                if None in row:
+                    # Any extra fields are stuck in a list with a key of
+                    # `None`. The presence of this key means we have a row
+                    # with too many fields. We don't know how to handle
+                    # this case, so we abort.
+                    raise ContactParserException(
+                        'Invalid row: too many fields.')
+                if None in row.values():
+                    # Any missing fields are given a value of `None`. Since
+                    # all legitimate field values are strings, this is a
+                    # reliable indicator of a missing field. We don't know
+                    # how to handle this case, so we abort.
+                    raise ContactParserException(
+                        'Invalid row: not enough fields.')
+
                 # Only process rows that actually have data
                 if any([column for column in row]):
-                    if None in row:
-                        # Any extra fields are stuck in a list with a key of
-                        # `None`. The presence of this key means we have a row
-                        # with too many fields. We don't know how to handle
-                        # this case, so we abort.
-                        raise ContactParserException(
-                            'Invalid row: too many fields.')
-                    if None in row.values():
-                        # Any missing fields are given a value of `None`. Since
-                        # all legitimate field values are strings, this is a
-                        # reliable indicator of a missing field. We don't know
-                        # how to handle this case, so we abort.
-                        raise ContactParserException(
-                            'Invalid row: not enough fields.')
                     # Our Riak client requires unicode for all keys & values
                     # stored.
                     unicoded_row = dict([(key, unicode(value or '', 'utf-8'))

--- a/go/contacts/parsers/test_parsers.py
+++ b/go/contacts/parsers/test_parsers.py
@@ -5,6 +5,7 @@ from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
 from go.base.tests.helpers import GoDjangoTestCase
+from go.contacts.parsers import ContactParserException
 from go.contacts.parsers.csv_parser import CSVFileParser
 from go.contacts.parsers.xls_parser import XLSFileParser
 
@@ -102,6 +103,50 @@ class TestCSVParser(ParserTestCase):
                 'surname': 'Surname 3',
                 'name': 'Name 3'},
             ])
+
+    def test_contacts_with_missing_fields(self):
+        csv_file = self.fixture(
+            'sample-contacts-with-headers-and-missing-fields.csv')
+        fp = default_storage.open(csv_file, 'rU')
+        contacts_iter = self.parser.parse_file(fp, zip(
+            ['name', 'surname', 'msisdn'],
+            ['string', 'string', 'msisdn_za']), has_header=True)
+        contacts = []
+        try:
+            for contact in contacts_iter:
+                if contact['name'] == 'Extra rows':
+                    # We don't care about these rows.
+                    continue
+                contacts.append(contact)
+        except ContactParserException as err:
+            self.assertEqual(err.args[0], 'Invalid row: not enough fields.')
+        self.assertEqual(contacts, [{
+            'msisdn': '+27761234561',
+            'surname': 'Surname 1',
+            'name': 'Name 1',
+        }])
+
+    def test_contacts_with_extra_fields(self):
+        csv_file = self.fixture(
+            'sample-contacts-with-headers-and-extra-fields.csv')
+        fp = default_storage.open(csv_file, 'rU')
+        contacts_iter = self.parser.parse_file(fp, zip(
+            ['name', 'surname', 'msisdn'],
+            ['string', 'string', 'msisdn_za']), has_header=True)
+        contacts = []
+        try:
+            for contact in contacts_iter:
+                if contact['name'] == 'Extra rows':
+                    # We don't care about these rows.
+                    continue
+                contacts.append(contact)
+        except ContactParserException as err:
+            self.assertEqual(err.args[0], 'Invalid row: too many fields.')
+        self.assertEqual(contacts, [{
+            'msisdn': '+27761234561',
+            'surname': 'Surname 1',
+            'name': 'Name 1',
+        }])
 
 
 class TestXLSParser(ParserTestCase):


### PR DESCRIPTION
```
Stacktrace (most recent call last):

(1 additional frame(s) were not displayed)
...
  File "celery/task/trace.py", line 420, in __protected_call__
    return self.run(*args, **kwargs)
  File "go/contacts/tasks.py", line 382, in import_upload_is_truth_contacts_file
    fields, has_header)
  File "go/contacts/tasks.py", line 330, in import_and_update_contacts
    for contact_dictionary in contact_dictionaries:
  File "go/contacts/parsers/base.py", line 230, i
 n parse_file
    for data_dictionary in data_dictionaries:
  File "go/contacts/parsers/csv_parser.py", line 45, in read_data_from_file
    for key, value in row.items()])
```
