### PR TITLE
Contact imports treat created_at as an extra

### DIFF
--- a/go/contacts/parsers/base.py
+++ b/go/contacts/parsers/base.py
@@ -135,6 +135,7 @@ class ContactFileParser(object):
 
     DEFAULT_HEADERS = {
         'key': 'UUID',
+        'created_at': 'Creation Date',
         'name': 'Name',
         'surname': 'Surname',
         'bbm_pin': 'BBM Pin',


### PR DESCRIPTION
Exporting a contact, then importing them results in an extra being created for the `created_at` attribute, when it should be updating the actual `created_at` contact model attribute.
