### PR TITLE
Fix routing of events related to replies to unroutable messages.

### DIFF
--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -177,8 +177,12 @@ class RoutingMetadata(object):
         hops = self.get_hops()
         outbound_hops = self.get_outbound_hops()
         if not hops and not outbound_hops:
+            # if hops and outbound hops are both either None or empty, consider
+            # them equal
             return True
         if not hops or not outbound_hops:
+            # if only one of hops or outbound hops are None or empty, consider
+            # them not equal
             return False
         [dst, src] = hops[-1]
         [outbound_src, outbound_dst] = outbound_hops[0]

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -170,7 +170,7 @@ class RoutingMetadata(object):
     def unroutable_event_done(self):
         """
         Return True if the message is an event for an unroutable reply
-        and it's hops are done.
+        and its hops are done.
         """
         if not self.get_unroutable_reply():
             return False

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -800,7 +800,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
         if not msg_unroutable or msg_hops:
             # unroutable replies without hops were never associated with a
-            # user account and so aren't require to have on. All other
+            # user account and so aren't require to have one. All other
             # messages must.
             if not msg_mdh.has_user_account():
                 raise UnroutableMessageError(

--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -800,7 +800,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
         if not msg_unroutable or msg_hops:
             # unroutable replies without hops were never associated with a
-            # user account and so aren't require to have one. All other
+            # user account and so aren't required to have one. All other
             # messages must.
             if not msg_mdh.has_user_account():
                 raise UnroutableMessageError(

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -232,6 +232,48 @@ class TestRoutingMetadata(VumiTestCase):
         rmeta.set_unroutable_reply()
         self.assertEqual(rmeta.get_unroutable_reply(), True)
 
+    def test_unroutable_event_done_not_unroutable(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        self.assertEqual(rmeta.unroutable_event_done(), False)
+
+    def test_unroutable_event_done_no_hops_at_all(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        rmeta.set_unroutable_reply()
+        self.assertEqual(rmeta.unroutable_event_done(), True)
+
+    def test_unroutable_event_done_no_hops(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        rmeta.set_unroutable_reply()
+        self.set_outbound_hops(msg, [["sc1", "se1"], ["dc1", "de1"]])
+        self.assertEqual(rmeta.unroutable_event_done(), False)
+
+    def test_unroutable_event_done_no_outbound_hops(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        rmeta.set_unroutable_reply()
+        self.set_hops(msg, [["sc1", "se1"], ["dc1", "de1"]])
+        self.assertEqual(rmeta.unroutable_event_done(), False)
+
+    def test_unroutable_event_done_hops_mismatched_src(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        rmeta.set_unroutable_reply()
+        self.set_hops(msg, [["sc1", "dc1"], ["sc2", "dc2"]])
+        self.set_outbound_hops(msg, [["dc2", "other"], ["dc1", "sc1"]])
+        self.assertEqual(rmeta.unroutable_event_done(), False)
+
+    def test_unroutable_event_done_hops_mismatched_dst(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        rmeta.set_unroutable_reply()
+        self.set_hops(msg, [["sc1", "dc1"], ["sc2", "dc2"]])
+        self.set_outbound_hops(msg, [["other", "sc2"], ["dc1", "sc1"]])
+        self.assertEqual(rmeta.unroutable_event_done(), False)
+
+    def test_unroutable_event_done_hops_match(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        rmeta.set_unroutable_reply()
+        self.set_hops(msg, [["sc1", "dc1"], ["sc2", "dc2"]])
+        self.set_outbound_hops(msg, [["dc2", "sc2"], ["dc1", "sc1"]])
+        self.assertEqual(rmeta.unroutable_event_done(), True)
+
 
 class RoutingTableDispatcherTestCase(VumiTestCase):
     """Base class for ``AccountRoutingTableDispatcher`` test cases"""

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -216,6 +216,22 @@ class TestRoutingMetadata(VumiTestCase):
             [['dc1', 'de1'], ['sc1', 'se1']],
         ], 'se2')
 
+    def assert_unroutable(self, msg, unroutable):
+        self.assertEqual(msg['routing_metadata'].get('is_reply_to_unroutable'),
+                         unroutable)
+
+    def test_set_unroutable_reply(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        self.assert_unroutable(msg, None)
+        rmeta.set_unroutable_reply()
+        self.assert_unroutable(msg, True)
+
+    def test_get_unroutable_reply(self):
+        msg, rmeta = self.mk_msg_rmeta()
+        self.assertEqual(rmeta.get_unroutable_reply(), False)
+        rmeta.set_unroutable_reply()
+        self.assertEqual(rmeta.get_unroutable_reply(), True)
+
 
 class RoutingTableDispatcherTestCase(VumiTestCase):
     """Base class for ``AccountRoutingTableDispatcher`` test cases"""


### PR DESCRIPTION
Errors seen that seem relevant:

```
UnroutableMessageError: ('Could not find next hop for event.', ...
```

and

```
'Error routing message for billing_dispatcher_ro'
```

and maybe

```
UnroutableMessageError: ('Outbound message for event has no associated user account:
```
