### PR TITLE
appmux router leaks redis connections

### DIFF
--- a/go/routers/app_multiplexer/tests/test_vumi_app.py
+++ b/go/routers/app_multiplexer/tests/test_vumi_app.py
@@ -201,7 +201,7 @@ class TestApplicationMultiplexerRouter(VumiTestCase):
         msg = yield self.router_helper.ri.make_dispatch_inbound(
             'foo', router=router, from_addr='123', session_event='resume')
 
-         # assert that the user received a response
+        # assert that the user received a response
         [msg] = self.router_helper.ri.get_dispatched_outbound()
         self.assertEqual(msg['content'],
                          'Bad choice.\n1) Try Again')
@@ -229,7 +229,7 @@ class TestApplicationMultiplexerRouter(VumiTestCase):
         msg = yield self.router_helper.ri.make_dispatch_inbound(
             'foo', router=router, from_addr='123', session_event='resume')
 
-         # assert that the user received a response
+        # assert that the user received a response
         [msg] = self.router_helper.ri.get_dispatched_outbound()
         self.assertEqual(msg['content'],
                          'Bad choice.\n1) Try Again')
@@ -257,7 +257,7 @@ class TestApplicationMultiplexerRouter(VumiTestCase):
         msg = yield self.router_helper.ri.make_dispatch_inbound(
             '1', router=router, from_addr='123', session_event='resume')
 
-         # assert that the user received a response
+        # assert that the user received a response
         [msg] = self.router_helper.ri.get_dispatched_outbound()
         self.assertEqual(msg['content'],
                          'Please select a choice.\n1) Flappy Bird')

--- a/go/routers/app_multiplexer/tests/test_vumi_app.py
+++ b/go/routers/app_multiplexer/tests/test_vumi_app.py
@@ -3,6 +3,7 @@ import copy
 from twisted.internet.defer import inlineCallbacks
 
 from vumi.tests.helpers import VumiTestCase
+
 from go.routers.app_multiplexer.vumi_app import ApplicationMultiplexer
 from go.routers.tests.helpers import RouterWorkerHelper
 

--- a/go/routers/app_multiplexer/vumi_app.py
+++ b/go/routers/app_multiplexer/vumi_app.py
@@ -85,11 +85,9 @@ class ApplicationMultiplexer(GoRouterWorker):
         return d
 
     def session_manager(self, config):
-        return SessionManager.from_redis_config(
-            config.redis_manager,
-            key_prefix=':'.join((self.worker_name, config.router.key)),
-            max_session_length=config.session_expiry
-        )
+        key_prefix = ':'.join((self.worker_name, config.router.key))
+        redis = self.redis.sub_manager(key_prefix)
+        return SessionManager(redis, max_session_length=config.session_expiry)
 
     def target_endpoints(self, config):
         """


### PR DESCRIPTION
It calls `SessionManager.from_redis_config()` (which creates a redis connection) on every inbound message.
