### PR TITLE
settings.py swallows all ImportErrors from production_settings import

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -311,8 +311,10 @@ CELERYBEAT_SCHEDULE = {
 
 try:
     from production_settings import *
-except ImportError:
-    pass
+except ImportError as err:
+    # The ImportError might be for something imported by production_settings.
+    if err.args[0] != "No module named production_settings":
+        raise
 
 
 # Compress Less with `lesscpy`


### PR DESCRIPTION
This means things break horribly and silently if production_settings fails to import something.
