### PR TITLE
Bump kombu requirement to latest 2.5.x release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'mock==1.0.1',
         'raven>=2.0,<3.0',
         'django-debug-toolbar==0.9.4',
-        'kombu==2.5.6',
+        'kombu>=2.5,<3.0',
         'librabbitmq==1.0.1',
         'hiredis==0.1.4',
         'django-pipeline==1.3.6',


### PR DESCRIPTION
Requiring 2.5.6 is causing a version conflict with other packages which prevents installing `vumi-go` for http://github.com/praekelt/go-contacts-api. Plus it would be good to have the latest release anyway.
