### PR TITLE
Update dependencies to use released versions

### DIFF
--- a/requirements-docs.pip
+++ b/requirements-docs.pip
@@ -4,4 +4,4 @@
 Sphinx
 sphinxcontrib-blockdiag>=1.3.1
 protobuf==2.5.0
--e git+https://github.com/praekelt/vumi.git#egg=vumi
+vumi>=0.5.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,13 +1,3 @@
 # Our dependencies are all specified in setup.py.
 
-# The following three packages need to be installed from the their repositories
-# because we depend on dev versions. To upgrade, use the following command:
-#   pip install --exists-action i -U -r requirements.pip
-# This will ignore any existing repository clones. They can be updated manually
-# if desired.
-
--e git+https://github.com/praekelt/vumi.git#egg=vumi
--e git+https://github.com/praekelt/vxpolls.git#egg=vxpolls
--e git+https://github.com/praekelt/vumi-wikipedia.git#egg=vumi-wikipedia
-
 -e .

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,9 @@ setup(
     author_email='dev@praekeltfoundation.org',
     packages=find_packages(),
     install_requires=[
-        'vumi>0.4',
+        'vumi>=0.5.0',
         'vxpolls',
         'vumi-wikipedia',
-        # We need dev versions of the three packages above, so they have to be
-        # installed before us. They're listed first so that we fail fast
-        # instead of working through all the other requirements before
-        # discovering that they aren't available should that be the case.
         'Django==1.5.8',
         'gunicorn==0.15.0',
         'South==0.8.2',


### PR DESCRIPTION
We now have releases of our three previously-github-only dependencies, so we should use them.
