### PR TITLE
update_contact() ignores dynamic fields

### DIFF
--- a/go/contacts/tasks.py
+++ b/go/contacts/tasks.py
@@ -356,6 +356,10 @@ def import_and_update_contacts(contact_mangler, account_key, group_key,
     default_storage.delete(file_path)
 
 
+def mkdynamic(prefix, data):
+    return dict((prefix + k, v) for k, v in data.iteritems())
+
+
 @task(ignore_result=True)
 def import_upload_is_truth_contacts_file(account_key, group_key, file_name,
                                          file_path, fields, has_header):
@@ -371,8 +375,8 @@ def import_upload_is_truth_contacts_file(account_key, group_key, file_name,
         new_subscription.update(dict(contact.subscription))
         new_subscription.update(contact_dictionary.pop('subscription', {}))
 
-        contact_dictionary['extra'] = new_extra
-        contact_dictionary['subscription'] = new_subscription
+        contact_dictionary.update(mkdynamic("extras-", new_extra))
+        contact_dictionary.update(mkdynamic("subscription-", new_subscription))
         contact_dictionary['groups'] = [group_key]
         return contact_dictionary
 
@@ -395,12 +399,13 @@ def import_existing_is_truth_contacts_file(account_key, group_key, file_name,
         new_extra = {}
         new_extra.update(contact_dictionary.pop('extra', {}))
         new_extra.update(dict(contact.extra))
-        cloned_contact_dictionary['extra'] = new_extra
+        cloned_contact_dictionary.update(mkdynamic("extras-", new_extra))
 
         new_subscription = {}
         new_subscription.update(contact_dictionary.pop('subscription', {}))
         new_subscription.update(dict(contact.subscription))
-        cloned_contact_dictionary['subscription'] = new_subscription
+        cloned_contact_dictionary.update(
+            mkdynamic("subscription-", new_subscription))
 
         for key in contact_dictionary.keys():
             # NOTE: If the contact already has any kind of value that

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -193,9 +193,23 @@ class ContactStore(PerAccountStore):
         fields = self.settable_contact_fields(**fields)
 
         contact = yield self.get_contact_by_key(key)
-        for field_name, field_value in fields.iteritems():
-            if field_name in contact.field_descriptors:
-                setattr(contact, field_name, field_value)
+
+        def dynamic_key(key, prefix):
+            if not isinstance(key, unicode):
+                key = key.decode("utf-8")
+            return key[len(descriptor.prefix):]
+
+        # TODO: Move this logic to the model or field code somehow.
+        for field_name, descriptor in contact.field_descriptors.iteritems():
+            if hasattr(descriptor, "prefix"):
+                dynamic_fields = dict(
+                    (dynamic_key(k, descriptor.prefix), v)
+                    for k, v in fields.iteritems()
+                    if k.startswith(descriptor.prefix))
+                getattr(contact, field_name).update(dynamic_fields)
+            else:
+                if descriptor.key in fields:
+                    setattr(contact, field_name, fields[descriptor.key])
 
         for group in groups:
             contact.add_to_group(group)

--- a/go/vumitools/tests/test_contact.py
+++ b/go/vumitools/tests/test_contact.py
@@ -163,6 +163,28 @@ class TestContactStore(VumiTestCase):
                          updated_contact.groups.keys())
         self.assert_models_equal(dbcontact, updated_contact)
 
+    @inlineCallbacks
+    def test_update_contact_with_dynamic_fields(self):
+        contact = yield self.store.new_contact(
+            name=u'J Random', surname=u'Person', msisdn=u'27831234567')
+        contact.add_to_group(u'group-a')
+        contact.add_to_group(u'group-b')
+        yield contact.save()
+
+        updated_contact = yield self.store.update_contact(
+            contact.key, surname=u'Jackal', groups=['group-a', u'group-c'], **{
+                "extras-mood": u"grumpy",
+            })
+        dbcontact = yield self.store.get_contact_by_key(contact.key)
+
+        self.assertEqual(u'J Random', updated_contact.name)
+        self.assertEqual(u'Jackal', updated_contact.surname)
+        self.assertEqual(u'27831234567', updated_contact.msisdn)
+        self.assertEqual([u'group-a', u'group-b', u'group-c'],
+                         updated_contact.groups.keys())
+        self.assertEqual(u"grumpy", updated_contact.extra[u"mood"])
+        self.assert_models_equal(dbcontact, updated_contact)
+
     def test_update_contact_for_nonexistent_contact(self):
         return self.assertFailure(
             self.store.update_contact('123124'), ContactNotFoundError)


### PR DESCRIPTION
Necessary for praekelt/go-contacts-api#13.
