### PR TITLE
Manage message cache for arbitrary batch keys

### DIFF
--- a/go/base/management/commands/go_manage_message_cache.py
+++ b/go/base/management/commands/go_manage_message_cache.py
@@ -70,7 +70,7 @@ class Command(BaseGoCommand):
                 conv.batch.key for conv in user_api.active_conversations())
         if self.options.get('archived_conversations'):
             batches.update(
-                conv.batch.key for conv in user_api.finished_conversations())
+                conv.batch.key for conv in user_api.archived_conversations())
         if self.options.get('router_key'):
             conv = user_api.get_router(self.options['router_key'])
             batches.add(conv.batch.key)

--- a/go/base/management/commands/go_manage_message_cache.py
+++ b/go/base/management/commands/go_manage_message_cache.py
@@ -30,6 +30,17 @@ class Command(BaseGoCommand):
                     dest='archived_conversations',
                     action='store_true', default=False,
                     help='Act on all archived conversations.'),
+        make_option('--router-key',
+                    dest='router_key',
+                    help='Act on the given router.'),
+        make_option('--active-routers',
+                    dest='active_routers',
+                    action='store_true', default=False,
+                    help='Act on all active routers.'),
+        make_option('--archived-routers',
+                    dest='archived_routers',
+                    action='store_true', default=False,
+                    help='Act on all archived routers.'),
         make_option('--dry-run',
                     dest='dry_run',
                     action='store_true', default=False,
@@ -60,6 +71,15 @@ class Command(BaseGoCommand):
         if self.options.get('archived_conversations'):
             batches.update(
                 conv.batch.key for conv in user_api.finished_conversations())
+        if self.options.get('router_key'):
+            conv = user_api.get_router(self.options['router_key'])
+            batches.add(conv.batch.key)
+        if self.options.get('active_routers'):
+            batches.update(
+                conv.batch.key for conv in user_api.active_routers())
+        if self.options.get('archived_routers'):
+            batches.update(
+                conv.batch.key for conv in user_api.archived_routers())
         return list(batches)
 
     def _apply_to_batches_from_file(self, func, dry_run):

--- a/go/conversation/views.py
+++ b/go/conversation/views.py
@@ -30,7 +30,7 @@ def index(request):
 
     get_conversations = {
         'running': user_api.running_conversations,
-        'finished': user_api.finished_conversations,
+        'finished': user_api.archived_conversations,
         'draft': user_api.draft_conversations,
     }.get(conversation_status, user_api.active_conversations)
 

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -157,7 +157,7 @@ class VumiUserApi(object):
         conversations = []
         for bunch in conv_store.conversations.load_all_bunches(keys):
             conversations.extend((yield bunch))
-        returnValue([c for c in conversations if c.ended()])
+        returnValue([c for c in conversations if c.archived()])
 
     @Manager.calls_manager
     def active_conversations(self):
@@ -194,6 +194,15 @@ class VumiUserApi(object):
         for routers_bunch in self.router_store.load_all_bunches(keys):
             routers.extend((yield routers_bunch))
         returnValue(routers)
+
+    @Manager.calls_manager
+    def archived_routers(self):
+        conv_store = self.router_store
+        keys = yield conv_store.list_routers()
+        routers = []
+        for bunch in conv_store.routers.load_all_bunches(keys):
+            routers.extend((yield bunch))
+        returnValue([r for r in routers if r.archived()])
 
     @Manager.calls_manager
     def active_channels(self):

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -151,7 +151,7 @@ class VumiUserApi(object):
         returnValue(channel)
 
     @Manager.calls_manager
-    def finished_conversations(self):
+    def archived_conversations(self):
         conv_store = self.conversation_store
         keys = yield conv_store.list_conversations()
         conversations = []


### PR DESCRIPTION
The `go_manage_message_cache` command currently operates only on batches belonging to conversations. We need a way to operate on arbitrary batches by specifying batch keys.
