### PR TITLE
Report missing MSISDN fields more usefully in contact imports

### DIFF
--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -766,26 +766,24 @@ class TestContacts(BaseContactsTestCase):
         # We only get one column here.
         self.assertContains(response, 'column-0')
         self.assertNotContains(response, 'column-1')
-        # Pretend we got all three so we can explode again in the next bit.
+        # Now we follow the response and check that we fail sensibly by
+        # reporting that we don't have the expected fields.
         response = self.specify_columns(group_key=group.key, columns={
             'column-0': 'name',
-            'column-1': 'surname',
-            'column-2': 'msisdn',
             'normalize-0': '',
-            'normalize-1': '',
-            'normalize-2': '',
         }, follow=True)
         self.assertRedirects(response, group_url(group.key))
 
         messages = [(m.tags, m.message) for m in response.context['messages']]
         self.assertEqual(messages, [
-            ("error", "Something is wrong with the file"),
+            ("error", "Please specify a Contact Number field."),
         ])
 
         group = newest(self.contact_store.list_groups())
         contacts = group.backlinks.contacts()
         self.assertEqual(len(contacts), 0)
         self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(default_storage.listdir("tmp"), ([], []))
 
     def test_contact_parsing_failure_no_msisdn_field(self):
         csv_file = open(path.join(settings.PROJECT_ROOT, 'base',

--- a/go/contacts/tests.py
+++ b/go/contacts/tests.py
@@ -12,7 +12,6 @@ from django.core import mail
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 from django.utils.html import escape
-from django.contrib.messages import get_messages
 
 from go.contacts.parsers.base import FieldNormalizer
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper


### PR DESCRIPTION
Currently leaving out the MSISDN field results in an extremely obscure emailed traceback:

```
[&#39;  File &quot;/var/praekelt/vumi-go/go/contacts/tasks.py&quot;, line 276, in import_new_contacts_file\n    contact = contact_store.new_contact(**contact_dictionary)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py&quot;, line 650, in wrapper\n    return manager.call_decorator(func)(self, *args, **kw)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/utils.py&quot;, line 369, in wrapped\n    result = gen.send(result)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/go/vumitools/contact/models.py&quot;, line 181, in new_contact\n    **self.settable_contact_fields(**fields))\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py&quot;, line 832, in __call__\n    return self._modelcls(self._manager, key, **data)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py&quot;, line 211, in __init__\n    descriptor.initialize(self, field_value)\n&#39;, &#39;  File &quot;/var/praekelt/vumi
 -go/ve/src/vumi/vumi/persist/fields.py&quot;, line 37, in initialize\n    self.__set__(modelobj, value)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/fields.py&quot;, line 85, in __set__\n    self.validate(value)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/fields.py&quot;, line 34, in validate\n    self.field.validate(value)\n&#39;, &#39;  File &quot;/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/fields.py&quot;, line 126, in validate\n    raise ValidationError(&quot;None is not allowed as a value for non-null&quot;\n&#39;]
```

We should instead report a more useful error and do it straight away before even starting the celery task.
