### PR TITLE
Update grunt-mocha-test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ var path = require('path');
 module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-bower-task');
   grunt.loadNpmTasks('grunt-contrib-jst');
-  grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.loadNpmTasks('grunt-mocha-cli');
   grunt.loadNpmTasks('grunt-mocha-cov');
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-exec');
@@ -20,10 +20,10 @@ module.exports = function (grunt) {
         }
       }
     },
-    mochaTest: {
+    mochacli: {
       jsbox_apps: {
-        src: ['<%= paths.tests.jsbox_apps.spec %>'],
-        reporter: 'dot',
+        options: {reporter: 'dot'},
+        src: ['<%= paths.tests.jsbox_apps.spec %>']
       },
     },
     mochacov: {
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('test:jsbox_apps', [
-    'mochaTest:jsbox_apps',
+    'mochacli:jsbox_apps',
     'mochacov:jsbox_apps'
   ]);
 

--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -1,4 +1,3 @@
-require('mocha-as-promised')();
 var assert = require('assert');
 
 var _ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "js-yaml": "~2.1.0",
     "grunt": "~0.4.1",
-    "grunt-mocha-test": "~0.6.3",
+    "grunt-mocha-test": "^0.12.1",
     "grunt-contrib-jst": "~0.5.1",
     "bower": "^1.3.11",
     "grunt-cli": "~0.1.9",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.0-dev",
   "scripts": {
     "install": "./utils/npm-post-install.sh || echo 'skipping post install hook'",
+    "test": "grunt test",
     "blanket": {
       "pattern": "/go/"
     }
@@ -22,13 +23,13 @@
   "devDependencies": {
     "js-yaml": "~2.1.0",
     "grunt": "~0.4.1",
-    "grunt-mocha-test": "^0.12.1",
+    "grunt-mocha-cli": "^1.10.0",
     "grunt-contrib-jst": "~0.5.1",
     "bower": "^1.3.11",
     "grunt-cli": "~0.1.9",
     "yuglify": "0.1.4",
     "karma": "~0.12.8",
-    "karma-mocha": "^0.1.9",
+    "karma-mocha": "^0.1.0",
     "grunt-karma": "~0.8.3",
     "karma-phantomjs-launcher": "~0.1.0",
     "grunt-bower-task": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-cli": "~0.1.9",
     "yuglify": "0.1.4",
     "karma": "~0.12.8",
-    "karma-mocha": "~0.1.0",
+    "karma-mocha": "^0.1.9",
     "grunt-karma": "~0.8.3",
     "karma-phantomjs-launcher": "~0.1.0",
     "grunt-bower-task": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "grunt-exec": "~0.4.2",
     "karma-coverage": "~0.1.0",
     "less": "~1.5.1",
-    "grunt-mocha-cov": "~0.2.1",
-    "mocha-as-promised": "~2.0.0"
+    "grunt-mocha-cov": "~0.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current grunt-mocha-test uses an old mocha version that doesn't support promises, which means we are using mocha-as-promised, which means there is a dependency clash with karma, which means travis isn't happy.
