### PR TITLE
Automatically configure dialogue endpoints

### DIFF
--- a/go/apps/dialogue/tests/dummy_polls.py
+++ b/go/apps/dialogue/tests/dummy_polls.py
@@ -4,7 +4,9 @@ def simple_poll():
         "start_state": {"uuid": "choice-1"},
         "poll_metadata": {
             "repeatable": True,
+            'delivery_class': 'ussd'
         },
+        'channel_types': [],
         "states": [
             {
                 # these are common to all state types

--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -15,7 +15,7 @@ from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 
 from go.apps.dialogue.vumi_app import (
-    DialogueApplication, PollConfigResource)
+    DialogueApplication, PollConfigResource, dialogue_js_config)
 from go.apps.dialogue.tests.dummy_polls import simple_poll
 from go.apps.tests.helpers import AppWorkerHelper
 
@@ -257,17 +257,61 @@ class TestPollConfigResource(ResourceTestCaseBase):
         yield self.create_resource({})
 
     @inlineCallbacks
-    def test_config_delivery_class(self):
+    def test_get(self):
         conv = yield self.app_helper.create_conversation(
-            config={
-                'poll': {
-                    'poll_metadata': {'delivery_class': 'twitter'}
-                }
-            })
-
+            config={'poll': simple_poll()})
         self.app_worker.conv = conv
 
         reply = yield self.dispatch_command('get', key='config')
         config = json.loads(reply['value'])
 
+        self.assertEqual(config, dialogue_js_config(conv))
+
+
+class TestDialogueJsConfig(VumiTestCase):
+    @inlineCallbacks
+    def setUp(self):
+        self.app_helper = self.add_helper(AppWorkerHelper(DialogueApplication))
+        self.app = yield self.app_helper.get_app_worker({})
+
+    @inlineCallbacks
+    def test_config_delivery_class(self):
+        poll = simple_poll()
+        poll['poll_metadata']['delivery_class'] = 'twitter'
+
+        conv = yield self.app_helper.create_conversation(config={'poll': poll})
+
+        config = dialogue_js_config(conv)
         self.assertEqual(config['delivery_class'], 'twitter')
+
+    @inlineCallbacks
+    def test_config_endpoints(self):
+        poll = simple_poll()
+
+        poll['channel_types'] = [{
+            'name': 'sms',
+            'label': 'SMS'
+        }, {
+            'name': 'twitter',
+            'label': 'Twitter'
+        }]
+
+        poll['states'] = [{
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }, {
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'twitter'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }]
+
+        conv = yield self.app_helper.create_conversation(config={'poll': poll})
+
+        config = dialogue_js_config(conv)
+        self.assertEqual(config['endpoints'], ['SMS', 'Twitter'])

--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -11,7 +11,7 @@ from go.apps.jsbox.vumi_app import JsBoxConfig, JsBoxApplication
 def determine_endpoints(poll):
     names = set(
         s['channel_type']
-        for s in poll['states'] if s['type'] == 'send')
+        for s in poll.get('states', []) if s['type'] == 'send')
 
     types = poll.get('channel_types', [])
     return [t['label'] for t in types if t['name'] in names]

--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -8,12 +8,23 @@ from vumi.application.sandbox import SandboxResource
 from go.apps.jsbox.vumi_app import JsBoxConfig, JsBoxApplication
 
 
+def determine_endpoints(poll):
+    names = set(
+        s['channel_type']
+        for s in poll['states'] if s['type'] == 'send')
+
+    types = poll.get('channel_types', [])
+    return [t['label'] for t in types if t['name'] in names]
+
+
 def dialogue_js_config(conv):
+    poll = conv.config.get("poll", {})
+
     config = {
-        "name": "poll-%s" % conv.key
+        "name": "poll-%s" % conv.key,
+        "endpoints": determine_endpoints(poll)
     }
 
-    poll = conv.config.get("poll", {})
     poll_metadata = poll.get('poll_metadata', {})
     delivery_class = poll_metadata.get('delivery_class')
 


### PR DESCRIPTION
Once #1042 lands, we will need a way of automatically determining which endpoints to use based on the chosen channel types.
