### PR TITLE
Add conversation definition helper for updating config

### DIFF
--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -469,7 +469,8 @@ class EditConversationView(ConversationTemplateView):
             else:
                 config[key] = self.process_form(edit_form)
 
-        self.view_def._conv_def.update_config(request.user_api, config)
+        user_account = request.user_api.get_user_account()
+        self.view_def._conv_def.update_config(user_account, config)
         conversation.save()
 
 

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -769,11 +769,7 @@ class ConversationViewDefinitionBase(object):
         return self._conv_def.extra_static_endpoints
 
     def get_endpoints(self, config):
-        endpoints = list(self.extra_static_endpoints)
-        for endpoint in self._conv_def.configured_endpoints(config):
-            if (endpoint != 'default') and (endpoint not in endpoints):
-                endpoints.append(endpoint)
-        return endpoints
+        return self._conv_def.get_endpoints(config)
 
     @property
     def is_editable(self):

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -468,9 +468,8 @@ class EditConversationView(ConversationTemplateView):
                 config = self.process_form(edit_form)
             else:
                 config[key] = self.process_form(edit_form)
-        conversation.set_config(config)
-        conversation.c.extra_endpoints = self.view_def.get_endpoints(config)
 
+        self.view_def._conv_def.update_config(request.user_api, config)
         conversation.save()
 
 

--- a/go/vumitools/conversation/definition.py
+++ b/go/vumitools/conversation/definition.py
@@ -2,16 +2,15 @@ from go.vumitools.metrics import (
     ConversationMetricSet, MessagesSentMetric, MessagesReceivedMetric)
 
 
-def detach_removed_endpoints(conv, user_api, old, new):
+def detach_removed_endpoints(conv, user_account, old, new):
     conn = conv.get_connector()
-    user_account = user_api.get_user_account()
     rt = user_account.routing_table
 
     for endpoint in set(old) - set(new):
         rt.remove_endpoint(conn, endpoint)
 
     rt.validate_all_entries()
-    user_account.save()
+    return user_account.save()
 
 
 class ConversationDefinitionBase(object):
@@ -68,13 +67,15 @@ class ConversationDefinitionBase(object):
 
         return endpoints
 
-    def update_config(self, user_api, config):
+    def update_config(self, user_account, config):
         old_endpoints = self.get_endpoints(self.conv.config)
         endpoints = self.get_endpoints(config)
-        detach_removed_endpoints(self.conv, user_api, old_endpoints, endpoints)
 
         self.conv.set_config(config)
         self.conv.extra_endpoints = endpoints
+
+        return detach_removed_endpoints(
+            self.conv, user_account, old_endpoints, endpoints)
 
     def is_config_valid(self):
         raise NotImplementedError()

--- a/go/vumitools/conversation/definition.py
+++ b/go/vumitools/conversation/definition.py
@@ -72,7 +72,7 @@ class ConversationDefinitionBase(object):
         endpoints = self.get_endpoints(config)
 
         self.conv.set_config(config)
-        self.conv.extra_endpoints = endpoints
+        self.conv.c.extra_endpoints = endpoints
 
         return detach_removed_endpoints(
             self.conv, user_account, old_endpoints, endpoints)

--- a/go/vumitools/conversation/definition.py
+++ b/go/vumitools/conversation/definition.py
@@ -21,6 +21,13 @@ class ConversationDefinitionBase(object):
         MessagesSentMetric,
         MessagesReceivedMetric)
 
+    # set to an sub-class of go.api.go_api.action_dispatcher
+    # .ConversationActionDispatcher to provide API methods
+    api_dispatcher_cls = None
+
+    def __init__(self, conv=None):
+        self.conv = conv
+
     @classmethod
     def get_default_config(cls, name, description):
         """
@@ -28,13 +35,6 @@ class ConversationDefinitionBase(object):
         conversation config.
         """
         return {}
-
-    # set to an sub-class of go.api.go_api.action_dispatcher
-    # .ConversationActionDispatcher to provide API methods
-    api_dispatcher_cls = None
-
-    def __init__(self, conv=None):
-        self.conv = conv
 
     def get_actions(self):
         return [action(self.conv) for action in self.actions]
@@ -46,6 +46,15 @@ class ConversationDefinitionBase(object):
 
     def configured_endpoints(self, config):
         return []
+
+    def get_endpoints(self, config):
+        endpoints = list(self.extra_static_endpoints)
+
+        for endpoint in self.configured_endpoints(config):
+            if (endpoint != 'default') and (endpoint not in endpoints):
+                endpoints.append(endpoint)
+
+        return endpoints
 
     def is_config_valid(self):
         raise NotImplementedError()

--- a/go/vumitools/conversation/definition.py
+++ b/go/vumitools/conversation/definition.py
@@ -2,22 +2,13 @@ from go.vumitools.metrics import (
     ConversationMetricSet, MessagesSentMetric, MessagesReceivedMetric)
 
 
-def detach_endpoint(rt, conn, endpoint):
-    src = rt.lookup_source(conn, endpoint)
-
-    if src is not None:
-        rt.remove_entry(*src)
-
-    rt.remove_entry(conn, endpoint)
-
-
 def detach_removed_endpoints(conv, user_api, old, new):
     conn = conv.get_connector()
     user_account = user_api.get_user_account()
     rt = user_account.routing_table
 
     for endpoint in set(old) - set(new):
-        detach_endpoint(rt, conn, endpoint)
+        rt.remove_endpoint(conn, endpoint)
 
     rt.validate_all_entries()
     user_account.save()

--- a/go/vumitools/conversation/tests/test_definition.py
+++ b/go/vumitools/conversation/tests/test_definition.py
@@ -30,17 +30,17 @@ class TestConversationDefinitionBase(VumiTestCase):
     def test_get_endpoints(self):
         dfn = DummyConversationDefinition(self.conv)
         self.assertEqual(
-            dfn.get_endpoints({'endpoints': ['foo', 'bar']}),
-            ['foo', 'bar'])
+            dfn.get_endpoints({'endpoints': [u'foo', u'bar']}),
+            [u'foo', u'bar'])
 
     def test_get_endpoints_extra_endpoints(self):
         class ConversationDefinition(DummyConversationDefinition):
-            extra_static_endpoints = ('foo', 'bar')
+            extra_static_endpoints = (u'foo', u'bar')
 
         dfn = ConversationDefinition(self.conv)
         self.assertEqual(
-            dfn.get_endpoints({'endpoints': ['baz', 'quux']}),
-            ['foo', 'bar', 'baz', 'quux'])
+            dfn.get_endpoints({'endpoints': [u'baz', u'quux']}),
+            [u'foo', u'bar', u'baz', u'quux'])
 
     @inlineCallbacks
     def test_update_config(self):
@@ -57,16 +57,16 @@ class TestConversationDefinitionBase(VumiTestCase):
         user_account = yield self.user_api.get_user_account()
 
         dfn = DummyConversationDefinition(self.conv)
-        self.conv.set_config({'endpoints': ['foo', 'bar']})
+        self.conv.set_config({'endpoints': [u'foo', u'bar']})
 
-        yield dfn.update_config(user_account, {'endpoints': ['bar', 'baz']})
-        self.assertEqual(self.conv.extra_endpoints, ['bar', 'baz'])
+        yield dfn.update_config(user_account, {'endpoints': [u'bar', u'baz']})
+        self.assertEqual(list(self.conv.extra_endpoints), [u'bar', u'baz'])
 
     @inlineCallbacks
     def test_update_config_detach_removed_endpoints(self):
         user_account = yield self.user_api.get_user_account()
         rt = user_account.routing_table
-        self.conv.set_config({'endpoints': ['foo', 'bar', 'baz']})
+        self.conv.set_config({'endpoints': [u'foo', u'bar', u'baz']})
 
         chan1 = yield self.mk_channel(u'c1')
         chan2 = yield self.mk_channel(u'c2')
@@ -74,30 +74,30 @@ class TestConversationDefinitionBase(VumiTestCase):
         chan4 = yield self.mk_channel(u'c4')
         conv_conn = self.conv.get_connector()
 
-        rt.add_entry(chan1.get_connector(), 'default', conv_conn, 'foo')
-        rt.add_entry(conv_conn, 'foo', chan2.get_connector(), 'default')
-        rt.add_entry(chan3.get_connector(), 'default', conv_conn, 'bar')
-        rt.add_entry(conv_conn, 'bar', chan4.get_connector(), 'default')
+        rt.add_entry(chan1.get_connector(), u'default', conv_conn, u'foo')
+        rt.add_entry(conv_conn, u'foo', chan2.get_connector(), u'default')
+        rt.add_entry(chan3.get_connector(), u'default', conv_conn, 'bar')
+        rt.add_entry(conv_conn, u'bar', chan4.get_connector(), u'default')
 
         rt.validate_all_entries()
         yield user_account.save()
 
         dfn = DummyConversationDefinition(self.conv)
-        yield dfn.update_config(user_account, {'endpoints': ['bar']})
+        yield dfn.update_config(user_account, {'endpoints': [u'bar']})
 
         user_account = yield self.user_api.get_user_account()
         rt = user_account.routing_table
 
-        self.assertEqual(rt.lookup_source(conv_conn, 'foo'), None)
-        self.assertEqual(rt.lookup_target(conv_conn, 'foo'), None)
+        self.assertEqual(rt.lookup_source(conv_conn, u'foo'), None)
+        self.assertEqual(rt.lookup_target(conv_conn, u'foo'), None)
 
         self.assertEqual(
-            rt.lookup_source(conv_conn, 'bar'),
-            [chan3.get_connector(), 'default'])
+            rt.lookup_source(conv_conn, u'bar'),
+            [chan3.get_connector(), u'default'])
 
         self.assertEqual(
-            rt.lookup_target(conv_conn, 'bar'),
-            [chan4.get_connector(), 'default'])
+            rt.lookup_target(conv_conn, u'bar'),
+            [chan4.get_connector(), u'default'])
 
-        self.assertEqual(rt.lookup_target(conv_conn, 'baz'), None)
-        self.assertEqual(rt.lookup_source(conv_conn, 'baz'), None)
+        self.assertEqual(rt.lookup_target(conv_conn, u'baz'), None)
+        self.assertEqual(rt.lookup_source(conv_conn, u'baz'), None)

--- a/go/vumitools/conversation/tests/test_definition.py
+++ b/go/vumitools/conversation/tests/test_definition.py
@@ -49,7 +49,7 @@ class TestConversationDefinitionBase(VumiTestCase):
         dfn.update_config(self.user_api, {'endpoints': ['bar', 'baz']})
         self.assertEqual(self.conv.extra_endpoints, ['bar', 'baz'])
 
-    def test_update_config_detach_old_endpoints(self):
+    def test_update_config_detach_removed_endpoints(self):
         user_account = self.user_api.get_user_account()
         rt = user_account.routing_table
         self.conv.set_config({'endpoints': ['foo', 'bar', 'baz']})

--- a/go/vumitools/conversation/tests/test_definition.py
+++ b/go/vumitools/conversation/tests/test_definition.py
@@ -1,0 +1,31 @@
+from vumi.tests.helpers import VumiTestCase
+
+from go.vumitools.tests.helpers import VumiApiHelper
+from go.vumitools.conversation.definition import ConversationDefinitionBase
+
+
+class DummyConversationDefinition(ConversationDefinitionBase):
+    def configured_endpoints(self, config):
+        return config['endpoints']
+
+
+class TestConversationDefinitionBase(VumiTestCase):
+    def setUp(self):
+        self.vumi_helper = self.add_helper(VumiApiHelper(is_sync=True))
+        self.user_helper = self.vumi_helper.get_or_create_user()
+        self.conv = self.user_helper.create_conversation(u'jsbox')
+
+    def test_get_endpoints(self):
+        dfn = DummyConversationDefinition(self.conv)
+        self.assertEqual(
+            dfn.get_endpoints({'endpoints': ['foo', 'bar']}),
+            ['foo', 'bar'])
+
+    def test_get_endpoints_extra_endpoints(self):
+        class ConversationDefinition(DummyConversationDefinition):
+            extra_static_endpoints = ('foo', 'bar')
+
+        dfn = ConversationDefinition(self.conv)
+        self.assertEqual(
+            dfn.get_endpoints({'endpoints': ['baz', 'quux']}),
+            ['foo', 'bar', 'baz', 'quux'])

--- a/go/vumitools/conversation/tests/test_definition.py
+++ b/go/vumitools/conversation/tests/test_definition.py
@@ -13,7 +13,14 @@ class TestConversationDefinitionBase(VumiTestCase):
     def setUp(self):
         self.vumi_helper = self.add_helper(VumiApiHelper(is_sync=True))
         self.user_helper = self.vumi_helper.get_or_create_user()
+        self.user_api = self.user_helper.user_api
         self.conv = self.user_helper.create_conversation(u'jsbox')
+
+    def mk_channel(self, name):
+        self.vumi_helper.setup_tagpool(name, [name])
+        self.user_helper.add_tagpool_permission(name)
+        tag = self.user_api.acquire_tag(name)
+        return self.user_api.get_channel(tag)
 
     def test_get_endpoints(self):
         dfn = DummyConversationDefinition(self.conv)
@@ -29,3 +36,54 @@ class TestConversationDefinitionBase(VumiTestCase):
         self.assertEqual(
             dfn.get_endpoints({'endpoints': ['baz', 'quux']}),
             ['foo', 'bar', 'baz', 'quux'])
+
+    def test_update_config(self):
+        dfn = ConversationDefinitionBase(self.conv)
+        config = {'endpoints': []}
+        dfn.update_config(self.user_api, config)
+        self.assertEqual(self.conv.config, config)
+
+    def test_update_config_update_endpoints(self):
+        dfn = DummyConversationDefinition(self.conv)
+        self.conv.set_config({'endpoints': ['foo', 'bar']})
+        dfn.update_config(self.user_api, {'endpoints': ['bar', 'baz']})
+        self.assertEqual(self.conv.extra_endpoints, ['bar', 'baz'])
+
+    def test_update_config_detach_old_endpoints(self):
+        user_account = self.user_api.get_user_account()
+        rt = user_account.routing_table
+        self.conv.set_config({'endpoints': ['foo', 'bar', 'baz']})
+
+        chan1 = self.mk_channel(u'c1')
+        chan2 = self.mk_channel(u'c2')
+        chan3 = self.mk_channel(u'c3')
+        chan4 = self.mk_channel(u'c4')
+        conv_conn = self.conv.get_connector()
+
+        rt.add_entry(chan1.get_connector(), 'default', conv_conn, 'foo')
+        rt.add_entry(conv_conn, 'foo', chan2.get_connector(), 'default')
+        rt.add_entry(chan3.get_connector(), 'default', conv_conn, 'bar')
+        rt.add_entry(conv_conn, 'bar', chan4.get_connector(), 'default')
+
+        rt.validate_all_entries()
+        user_account.save()
+
+        dfn = DummyConversationDefinition(self.conv)
+        dfn.update_config(self.user_api, {'endpoints': ['bar']})
+
+        user_account = self.user_api.get_user_account()
+        rt = user_account.routing_table
+
+        self.assertEqual(rt.lookup_source(conv_conn, 'foo'), None)
+        self.assertEqual(rt.lookup_target(conv_conn, 'foo'), None)
+
+        self.assertEqual(
+            rt.lookup_source(conv_conn, 'bar'),
+            [chan3.get_connector(), 'default'])
+
+        self.assertEqual(
+            rt.lookup_target(conv_conn, 'bar'),
+            [chan4.get_connector(), 'default'])
+
+        self.assertEqual(rt.lookup_target(conv_conn, 'baz'), None)
+        self.assertEqual(rt.lookup_source(conv_conn, 'baz'), None)

--- a/go/vumitools/routing_table.py
+++ b/go/vumitools/routing_table.py
@@ -258,6 +258,14 @@ class RoutingTable(object):
 
         return old_dest
 
+    def remove_endpoint(self, conn, endpoint):
+        src = self.lookup_source(conn, endpoint)
+
+        if src is not None:
+            self.remove_entry(*src)
+
+        self.remove_entry(conn, endpoint)
+
     def remove_connector(self, conn):
         """Remove all references to the given connector.
 

--- a/go/vumitools/tests/test_routing_table.py
+++ b/go/vumitools/tests/test_routing_table.py
@@ -197,6 +197,27 @@ class TestRoutingTable(VumiTestCase):
             (self.CONV_1, "default1.2", self.CHANNEL_3, "default3"),
         ])
 
+    def test_remove_endpoint(self):
+        rt = self.make_rt({
+            self.CONV_1: {
+                "default1.1": [self.CHANNEL_2, "default2"],
+                "default1.2": [self.CHANNEL_3, "default3"]
+            },
+            self.CHANNEL_2: {
+                "default2": [self.CONV_1, "default1.1"],
+            },
+            self.CHANNEL_3: {
+                "default3": [self.CONV_2, "default"],
+            },
+        })
+
+        rt.remove_endpoint(self.CONV_1, "default1.1")
+
+        self.assert_routing_entries(rt, [
+            (self.CONV_1, 'default1.2', self.CHANNEL_3, 'default3'),
+            (self.CHANNEL_3, 'default3', self.CONV_2, 'default')
+        ])
+
     def test_remove_connector_source(self):
         rt = self.make_rt()
         rt.remove_connector(self.CONV_1)


### PR DESCRIPTION
The plan is to handle endpoints that were connected and have now been removed here by first removing the routing entries for them. This should solve #836.
