### PR TITLE
Display conversation type and attached channels in conversation dashboard

### DIFF
--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -30,6 +30,14 @@
                         <a href="{% conversation_screen conversation %}">
                             {{ conversation.name }}
                         </a>
+                        <ul class="list-unstyled">
+                          <li><span class="label label-primary">{{ conversation.conversation_type }}</span></li>
+                          {% for channel in conversation.get_channels %}
+                          <li><span class="label label-info">{{ channel.name }}</span></li>
+                          {% empty %}
+                          <li><span class="label label-danger">No channels</span></li>
+                          {% endfor %}
+                        </ul>
                     </td>
                     <td class="status {{ conversation.get_status }}">{{ conversation.get_status }}</td>
                     <td>{{ conversation.count_replies|add:conversation.count_sent_messages }} </td>

--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -31,7 +31,7 @@
                             {{ conversation.name }}
                         </a>
                         <ul class="list-unstyled">
-                          <li><span class="label label-primary">{{ conversation.conversation_type }}</span></li>
+                          <li><span class="label label-primary">{{ conversation.conversation_type_display_name }}</span></li>
                           {% for channel in conversation.get_channels %}
                           <li><span class="label label-info">{{ channel.name }}</span></li>
                           {% empty %}

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -189,6 +189,7 @@ class TestConversationsDashboardView(BaseConversationViewTestCase):
         myconv = self.user_helper.create_conversation(u'dummy', name=u'myconv')
         response = self.client.get(reverse('conversations:index'))
         self.assertContains(response, u'myconv')
+        self.assertContains(response, u'Dummy Conversation')
 
         self.assertContains(response, self.get_view_url(myconv, 'show'))
         self.assertContains(response, self.get_view_url(

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -503,3 +503,13 @@ class TestConversationWrapper(VumiTestCase):
             'conversation_type': self.conv.conversation_type,
             'conversation_key': self.conv.key,
         }})
+
+    @inlineCallbacks
+    def test_conversation_type_display_name(self):
+        conv = yield self.user_helper.create_conversation(u'static_reply')
+        self.assertEqual(
+            conv.conversation_type_display_name, 'Static Reply')
+
+    def test_conversation_type_display_name_fallback(self):
+        self.assertEqual(
+            self.conv.conversation_type_display_name, u'dummy')

--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -11,6 +11,7 @@ from vumi.persist.model import Manager
 
 from go.vumitools.opt_out import OptOutStore
 from go.vumitools.utils import MessageMetadataDictHelper, MessageMetadataHelper
+from go.config import configured_conversation_types
 
 
 class ConversationWrapper(object):
@@ -497,6 +498,11 @@ class ConversationWrapper(object):
     def worker_name(self):
         # TODO better way of working out worker_name
         return '%s_application' % (self.conversation_type,)
+
+    @property
+    def conversation_type_display_name(self):
+        conv_types = configured_conversation_types()
+        return conv_types.get(self.conversation_type, self.conversation_type)
 
     def dispatch_command(self, command, *args, **kwargs):
         """


### PR DESCRIPTION
- A lack of conversation type information makes it hard to find specific conversations (or to remember what sort of conversation is running).
- A lack of channels makes it easy to make mistakes like connecting something to the wrong channel or not connection a conversation up at all.
