### PR TITLE
Fix permissions for viewing billing statement PDFs.

### DIFF
--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -15,12 +15,53 @@ class TestStatementView(GoDjangoTestCase):
         self.account = Account.objects.get(
             user=self.user_helper.get_django_user())
 
-    def test_statement_accessable(self):
-        mk_transaction(self.account)
-        statement = mk_statement(self.account)
-        client = self.vumi_helper.get_client()
-        client.login()
-        response = client.get(
-            reverse('pdf_statement', kwargs={'statement_id': statement.id}))
+    def mk_statement(self, transactions=2):
+        for _i in range(transactions):
+            mk_transaction(self.account)
+        return mk_statement(self.account)
+
+    def assert_is_pdf(self, response):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/pdf')
+        self.assertTrue(response.content.startswith('%PDF-'))
+
+    def get_statement_pdf(self, username, statement):
+        client = self.vumi_helper.get_client(username=username)
+        return client.get(
+            reverse('pdf_statement', kwargs={'statement_id': statement.id}))
+
+    def check_statement_accessible_by(self, username, statement):
+        response = self.get_statement_pdf(username, statement)
+        self.assert_is_pdf(response)
+
+    def check_statement_not_accessible_by(self, username, statement):
+        response = self.get_statement_pdf(username, statement)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response['Content-Type'].split(';')[0], 'text/html')
+
+    def test_statement_accessable_by_owner(self):
+        statement = statement = self.mk_statement()
+        self.check_statement_accessible_by(
+            self.user_helper.get_django_user(), statement)
+
+    def test_statement_accessable_by_superuser(self):
+        statement = self.mk_statement()
+        self.vumi_helper.make_django_user(
+            email='super@example.com', superuser=True)
+        self.check_statement_accessible_by('super@example.com', statement)
+
+    def test_statement_accessable_by_staff(self):
+        statement = self.mk_statement()
+        user_helper = self.vumi_helper.make_django_user(
+            email='staff@example.com')
+        user = user_helper.get_django_user()
+        user.is_staff = True
+        user.save()
+        self.check_statement_accessible_by('staff@example.com', statement)
+
+    def test_statement_hidden_when_not_accessible(self):
+        statement = self.mk_statement()
+        self.vumi_helper.make_django_user(
+            email='other.user@example.com')
+        self.check_statement_not_accessible_by(
+            'other.user@example.com', statement)

--- a/go/billing/views.py
+++ b/go/billing/views.py
@@ -2,7 +2,7 @@ import os
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.template import RequestContext, loader
 from xhtml2pdf import pisa
@@ -16,8 +16,11 @@ def statement_view(request, statement_id=None):
     """Send a PDF version of the statement with the given
        ``statement_id`` to the user's browser.
     """
-    statement = get_object_or_404(
-        Statement, pk=statement_id, account__user=request.user)
+    statement = get_object_or_404(Statement, pk=statement_id)
+
+    if not (request.user.is_staff or
+            statement.account.user == request.user):
+        raise Http404
 
     response = HttpResponse(mimetype='application/pdf')
     filename = "%s (%s).pdf" % (statement.title,


### PR DESCRIPTION
Currently admins can't see other people's statements (which makes the link in the admin interface not particularly useful).
