### PR TITLE
HTTP API needs to respond with correct Content-Type in all cases

### DIFF
--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -122,6 +122,9 @@ class TestStreamingHTTPWorker(VumiTestCase):
 
     def assert_bad_request(self, response, reason):
         self.assertEqual(response.code, http.BAD_REQUEST)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         data = json.loads(response.delivered_body)
         self.assertEqual(data, {
             "success": False,
@@ -252,6 +255,9 @@ class TestStreamingHTTPWorker(VumiTestCase):
         response = yield http_request_full(url, json.dumps(msg),
                                            self.auth_headers, method='PUT')
 
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         self.assertEqual(response.code, http.OK)
         put_msg = json.loads(response.delivered_body)
 
@@ -310,6 +316,9 @@ class TestStreamingHTTPWorker(VumiTestCase):
         response = yield http_request_full(url, json.dumps(msg),
                                            self.auth_headers, method='PUT')
 
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         put_msg = json.loads(response.delivered_body)
         self.assertEqual(response.code, http.OK)
 
@@ -413,6 +422,9 @@ class TestStreamingHTTPWorker(VumiTestCase):
                                            self.auth_headers, method='PUT')
 
         self.assertEqual(response.code, http.OK)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         put_msg = json.loads(response.delivered_body)
         [sent_msg] = self.app_helper.get_dispatched_outbound()
 
@@ -435,6 +447,9 @@ class TestStreamingHTTPWorker(VumiTestCase):
             url, json.dumps(metric_data), self.auth_headers, method='PUT')
 
         self.assertEqual(response.code, http.OK)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
 
         prefix = "go.campaigns.test-0-user.stores.metric_store"
 

--- a/go/apps/http_api_nostream/resource.py
+++ b/go/apps/http_api_nostream/resource.py
@@ -44,6 +44,7 @@ class BaseResource(resource.Resource):
         return user_api.get_wrapped_conversation(conversation_key)
 
     def finish_response(self, request, body, code, status=None):
+        request.setHeader('Content-Type', 'application/json; charset=utf-8')
         request.setResponseCode(code, status)
         request.write(body)
         request.finish()

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -108,6 +108,9 @@ class TestNoStreamingHTTPWorkerBase(VumiTestCase):
 
     def assert_bad_request(self, response, reason):
         self.assertEqual(response.code, http.BAD_REQUEST)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         data = json.loads(response.delivered_body)
         self.assertEqual(data, {
             "success": False,
@@ -163,6 +166,9 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
                                            self.auth_headers, method='PUT')
 
         self.assertEqual(response.code, http.OK)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         put_msg = json.loads(response.delivered_body)
 
         [sent_msg] = self.app_helper.get_dispatched_outbound()
@@ -219,7 +225,9 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
         url = '%s/%s/messages.json' % (self.url, self.conversation.key)
         response = yield http_request_full(url, json.dumps(msg),
                                            self.auth_headers, method='PUT')
-
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         put_msg = json.loads(response.delivered_body)
         self.assertEqual(response.code, http.OK)
 
@@ -322,6 +330,9 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
         response = yield http_request_full(url, json.dumps(msg),
                                            self.auth_headers, method='PUT')
 
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
         self.assertEqual(response.code, http.OK)
         put_msg = json.loads(response.delivered_body)
         [sent_msg] = self.app_helper.get_dispatched_outbound()
@@ -345,6 +356,9 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
             url, json.dumps(metric_data), self.auth_headers, method='PUT')
 
         self.assertEqual(response.code, http.OK)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
 
         prefix = "go.campaigns.test-0-user.stores.metric_store"
 


### PR DESCRIPTION
Apparently there are still places where it uses `text/html` instead of `application/json`.
