### PR TITLE
Extend metrics middleware

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -336,7 +336,7 @@ class MetricsMiddleware(BaseMiddleware):
                 '%s.tagpool.%s' % (name, pool), msg, session_dt)
         if config.get('track_all_tags') or tagname in config['tags']:
             self.fire_inbound_metrics(
-                'tag.%s.%s' % (pool, tagname), msg, session_dt)
+                '%s.tag.%s.%s' % (name, pool, tagname), msg, session_dt)
 
     def fire_outbound_metrics(self, prefix, msg, session_dt):
         self.increment_counter(prefix, 'outbound')
@@ -364,7 +364,7 @@ class MetricsMiddleware(BaseMiddleware):
                 '%s.tagpool.%s' % (name, pool), msg, session_dt)
         if config.get('track_all_tags') or tagname in config['tags']:
             self.fire_outbound_metrics(
-                'tag.%s.%s' % (pool, tagname), session_dt)
+                '%s.tag.%s.%s' % (name, pool, tagname), msg, session_dt)
 
     @inlineCallbacks
     def handle_inbound(self, message, endpoint):

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -339,7 +339,7 @@ class MetricsMiddleware(BaseMiddleware):
     def fire_outbound_metrics(self, prefix, msg, session_dt):
         self.increment_counter(prefix, 'outbound')
         if session_dt is not None:
-            self.record_session_dt(prefix, session_dt)
+            self.fire_session_dt(prefix, session_dt)
 
     def fire_outbound_transport_metrics(self, name, msg, session_dt):
         self.fire_outbound_metrics(name, msg, session_dt)

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -96,7 +96,7 @@ class MetricsMiddleware(BaseMiddleware):
     network operator is not detected by the transport, consider using network
     operator detecting middleware to provide it.
 
-    Network operator metrics must be enabled by setting ``operator_metrics`` to
+    Network operator metrics must be enabled by setting ``provider_metrics`` to
     ``true``.
 
     For each selected tag or tag pool it tracks:
@@ -135,7 +135,7 @@ class MetricsMiddleware(BaseMiddleware):
         `session_billing_unit` to a number fires an additional metric whenever
         the session duration metric is fired. The new metric records the
         duration rounded up to the next `session_billing_unit`.
-    :param bool operator_metrics:
+    :param bool provider_metrics:
         Defaults to ``false``. Set to ``true`` to fire per-operator metrics.
     :param dict tagpools:
         A dictionary defining which tag pools and tags should be tracked.

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -221,6 +221,10 @@ class MetricsMiddleware(BaseMiddleware):
         metric_name = '%s.%s' % (name, self.response_time_suffix)
         return self.get_or_create_metric(metric_name, Metric)
 
+    def get_session_time_metric(self, name):
+        metric_name = '%s.%s' % (name, self.session_time_suffix)
+        return self.get_or_create_metric(metric_name, Metric)
+
     def set_response_time(self, transport_name, time):
         metric = self.get_response_time_metric(transport_name)
         metric.set(time)

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -128,8 +128,13 @@ class MetricsMiddleware(BaseMiddleware):
         timer metrics. When a session starts the current time is stored under
         the `from_addr` and when the session ends, the duration of the session
         is published.
-    :param str session_rounding:
-        Defaults to ``null``.
+    :param str session_billing_unit:
+        Defaults to ``null``. Some networks charge for sessions per unit of
+        time or part there of. This means it might be useful, for example, to
+        record the session duration rounded to the nearest 20 seconds. Setting
+        `session_billing_unit` to a number fires an additional metric whenever
+        the session duration metric is fired. The new metric records the
+        duration rounded up to the next `session_billing_unit`.
     :param bool operator_metrics:
         Defaults to ``false``. Set to ``true`` to fire per-operator metrics.
     :param dict tagpools:

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -332,8 +332,9 @@ class MetricsMiddleware(BaseMiddleware):
         if config is None:
             return
         if config.get('track_pool'):
-            self.fire_inbound_metrics('tagpool.%s' % (pool,), msg, session_dt)
-        if config.get('track_all_tags') or tagname in config.tags:
+            self.fire_inbound_metrics(
+                '%s.tagpool.%s' % (name, pool), msg, session_dt)
+        if config.get('track_all_tags') or tagname in config['tags']:
             self.fire_inbound_metrics(
                 'tag.%s.%s' % (pool, tagname), msg, session_dt)
 
@@ -358,9 +359,10 @@ class MetricsMiddleware(BaseMiddleware):
         config = self.tagpools.get(pool)
         if config is None:
             return
-        if config.get('trag_pool'):
-            self.fire_outbound_metrics('tagpool.%s', (pool,), msg, session_dt)
-        if config.get('track_all_tags') or tagname in config.tags:
+        if config.get('track_pool'):
+            self.fire_outbound_metrics(
+                '%s.tagpool.%s' % (name, pool), msg, session_dt)
+        if config.get('track_all_tags') or tagname in config['tags']:
             self.fire_outbound_metrics(
                 'tag.%s.%s' % (pool, tagname), session_dt)
 

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -350,6 +350,8 @@ class MetricsMiddleware(BaseMiddleware):
 
     def fire_outbound_metrics(self, prefix, msg, session_dt):
         self.increment_counter(prefix, 'outbound')
+        if msg['session_event'] == msg.SESSION_NEW:
+            self.increment_counter(prefix, 'sessions_started')
         if session_dt is not None:
             self.fire_session_dt(prefix, session_dt)
 
@@ -399,6 +401,9 @@ class MetricsMiddleware(BaseMiddleware):
     @inlineCallbacks
     def handle_outbound(self, message, endpoint):
         name = self.get_name(message, endpoint)
+
+        if message['session_event'] == message.SESSION_NEW:
+            yield self.set_session_start_timestamp(name, message['from_addr'])
 
         reply_dt = yield self.get_reply_dt(name, message)
 

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -86,16 +86,18 @@ class MetricsMiddleware(BaseMiddleware):
     * The number of sessions started.
     * The length of each session.
 
-    For each network it tracks:
+    For each network operator it tracks:
 
     * The number of messages sent and received.
     * The number of sessions started.
     * The length of each session.
 
-    Networks are defined in the `networks` configuration option. Each network
-    is defined as a list of MSISDN (or other address) prefixes to match
-    `from_addr` values (for inbound messages) or `to_addr` values (for outbound
-    messages) against.
+    The network operator is determined by examining each message. If the
+    network operator is not detected by the transport, consider using network
+    operator detecting middleware to provide it.
+
+    Network operator metrics must be enabled by setting ``operator_metrics`` to
+    ``true``.
 
     For each selected tag or tag pool it tracks:
 
@@ -128,16 +130,8 @@ class MetricsMiddleware(BaseMiddleware):
         is published.
     :param str session_rounding:
         Defaults to ``null``.
-    :param dict networks:
-        A dictionary mapping network names to a list of prefixes for
-        MSISDNs (or other client addresses) that should be considered part of
-        that network.
-        E.g.::
-
-            networks:
-                mtn: [0603, 0605, 0710, 0717, 0718, 0719, 073, 078, 0810, 083]
-        If this configuration option is missing or empty, no network metrics
-        are produced.
+    :param bool operator_metrics:
+        Defaults to ``false``. Set to ``true`` to fire per-operator metrics.
     :param dict tagpools:
         A dictionary defining which tag pools and tags should be tracked.
         E.g.::

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -108,6 +108,8 @@ class MetricsMiddleware(BaseMiddleware):
     :param str manager_name:
         The name of the metrics publisher, this is used for the MetricManager
         publisher and all metric names will be prefixed with it.
+    :param dict redis_manager:
+        Connection configuration details for Redis.
     :param str count_suffix:
         Defaults to 'count'. This is the suffix appended to all
         counters. If a message is received on endpoint
@@ -124,22 +126,6 @@ class MetricsMiddleware(BaseMiddleware):
         timer metrics. When a session starts the current time is stored under
         the `from_addr` and when the session ends, the duration of the session
         is published.
-    :param int max_lifetime:
-        How long to keep a timestamp for. Anything older than this is trashed.
-        Defaults to 60 seconds.
-    :param dict redis_manager:
-        Connection configuration details for Redis.
-    :param str op_mode:
-        What mode to operate in, options are `passive` or `active`.
-        Defaults to passive.
-        *passive*:  assumes the middleware endpoints are to be used as the
-                    names for metrics publishing.
-        *active*:   assumes that the individual messages are to be inspected
-                    for their `transport_name` values.
-
-        NOTE:   This does not apply for events or failures, the endpoints
-                are always used for those since those message types are not
-                guaranteed to have a `transport_name` value.
     :param dict networks:
         A dictionary mapping network names to a list of prefixes for
         MSISDNs (or other client addresses) that should be considered part of
@@ -164,6 +150,20 @@ class MetricsMiddleware(BaseMiddleware):
         This tracks `pool1` but not `pool2` and tracks the tag `tagA`
         (from `pool1`) and the tag `tagB` (from `pool2`). If this configuration
         option is missing or empty, no tag or tag pool metrics are produced.
+    :param int max_lifetime:
+        How long to keep a timestamp for. Anything older than this is trashed.
+        Defaults to 60 seconds.
+    :param str op_mode:
+        What mode to operate in, options are `passive` or `active`.
+        Defaults to passive.
+        *passive*:  assumes the middleware endpoints are to be used as the
+                    names for metrics publishing.
+        *active*:   assumes that the individual messages are to be inspected
+                    for their `transport_name` values.
+
+        NOTE:   This does not apply for events or failures, the endpoints
+                are always used for those since those message types are not
+                guaranteed to have a `transport_name` value.
     """
 
     KNOWN_MODES = frozenset(['active', 'passive'])

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -213,8 +213,8 @@ class MetricsMiddleware(BaseMiddleware):
         return self.get_or_create_metric(metric_name, Count)
 
     def increment_counter(self, transport_name, message_type):
-        metric = self.get_counter_metric('%s.%s' % (transport_name,
-            message_type))
+        metric = self.get_counter_metric(
+            '%s.%s' % (transport_name, message_type))
         metric.inc()
 
     def get_response_time_metric(self, name):

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -320,7 +320,8 @@ class MetricsMiddleware(BaseMiddleware):
 
     def fire_inbound_provider_metrics(self, name, msg, session_dt):
         provider = self.get_provider(msg)
-        self.fire_inbound_metrics('provider.%s' % (provider,), msg, session_dt)
+        self.fire_inbound_metrics(
+            '%s.provider.%s' % (name, provider), msg, session_dt)
 
     def fire_inbound_tagpool_metrics(self, name, msg, session_dt):
         tag = self.get_tag(msg)
@@ -347,7 +348,7 @@ class MetricsMiddleware(BaseMiddleware):
     def fire_outbound_provider_metrics(self, name, msg, session_dt):
         provider = self.get_provider(msg)
         self.fire_outbound_metrics(
-            'provider.%s' % (provider,), msg, session_dt)
+            '%s.provider.%s' % (name, provider), msg, session_dt)
 
     def fire_outbound_tagpool_metrics(self, name, msg, session_dt):
         tag = self.get_tag(msg)

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -126,6 +126,8 @@ class MetricsMiddleware(BaseMiddleware):
         timer metrics. When a session starts the current time is stored under
         the `from_addr` and when the session ends, the duration of the session
         is published.
+    :param str session_rounding:
+        Defaults to ``null``.
     :param dict networks:
         A dictionary mapping network names to a list of prefixes for
         MSISDNs (or other client addresses) that should be considered part of
@@ -142,13 +144,13 @@ class MetricsMiddleware(BaseMiddleware):
 
             tagpools:
                 pool1:
-                    __track_pool__: true
-                    tagA: true
+                    track_pool: true
+                    track_all_tags: true
                 pool2:
-                    tagB: true
+                    track_tags: ["tagA"]
 
-        This tracks `pool1` but not `pool2` and tracks the tag `tagA`
-        (from `pool1`) and the tag `tagB` (from `pool2`). If this configuration
+        This tracks `pool1` but not `pool2` and tracks all tags from `pool`
+        and the tag `tagB` (from `pool2`). If this configuration
         option is missing or empty, no tag or tag pool metrics are produced.
     :param int max_lifetime:
         How long to keep a timestamp for. Anything older than this is trashed.

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -427,6 +427,38 @@ class TestMetricsMiddleware(VumiTestCase):
         })
 
     @inlineCallbacks
+    def test_track_all_tags_metrics_on_inbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'tagpools': {
+                'mypool': {'track_all_tags': True},
+            },
+        })
+        msg = self.mw_helper.make_inbound("foo", provider="MYMNO")
+        TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagA"))
+        yield mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.tag.mypool.tagA.inbound.counter': [1],
+            'dummy_endpoint.inbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_track_all_tags_metrics_on_outbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'tagpools': {
+                'mypool': {'track_all_tags': True},
+            },
+        })
+        msg = self.mw_helper.make_outbound("foo")
+        TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagA"))
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.tag.mypool.tagA.outbound.counter': [1],
+            'dummy_endpoint.outbound.counter': [1],
+        })
+
+    @inlineCallbacks
     def test_ack_event(self):
         mw = yield self.get_middleware({'op_mode': 'passive'})
         event = self.mw_helper.make_ack()

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -343,6 +343,58 @@ class TestMetricsMiddleware(VumiTestCase):
         })
 
     @inlineCallbacks
+    def test_provider_metrics_on_inbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'provider_metrics': True,
+        })
+        msg = self.mw_helper.make_inbound("foo", provider="MYMNO")
+        yield mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.provider.mymno.inbound.counter': [1],
+            'dummy_endpoint.inbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_unknown_provider_metrics_on_inbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'provider_metrics': True,
+        })
+        msg = self.mw_helper.make_inbound("foo")
+        yield mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.provider.unknown.inbound.counter': [1],
+            'dummy_endpoint.inbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_provider_metrics_on_outbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'provider_metrics': True,
+        })
+        msg = self.mw_helper.make_outbound("foo", provider="MYMNO")
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.provider.mymno.outbound.counter': [1],
+            'dummy_endpoint.outbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_unknown_provider_metrics_on_outbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'provider_metrics': True,
+        })
+        msg = self.mw_helper.make_outbound("foo")
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.provider.unknown.outbound.counter': [1],
+            'dummy_endpoint.outbound.counter': [1],
+        })
+
+    @inlineCallbacks
     def test_ack_event(self):
         mw = yield self.get_middleware({'op_mode': 'passive'})
         event = self.mw_helper.make_ack()

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -332,6 +332,17 @@ class TestMetricsMiddleware(VumiTestCase):
         })
 
     @inlineCallbacks
+    def test_session_close_on_outbound(self):
+        mw = yield self.get_middleware({'op_mode': 'passive'})
+        msg = self.mw_helper.make_outbound(
+            "foo", session_event=TransportUserMessage.SESSION_CLOSE)
+        yield self.set_timestamp(mw, -10, ['dummy_endpoint', msg['from_addr']])
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.session_time': (lambda v: v > 10),
+        })
+
+    @inlineCallbacks
     def test_ack_event(self):
         mw = yield self.get_middleware({'op_mode': 'passive'})
         event = self.mw_helper.make_ack()

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -328,7 +328,7 @@ class TestMetricsMiddleware(VumiTestCase):
             "foo", session_event=TransportUserMessage.SESSION_NEW)
         yield mw.handle_inbound(msg, 'dummy_endpoint')
         yield self.assert_timestamp_exists(
-            mw, ['dummy_endpoint', msg['to_addr']], ttl=60)
+            mw, ['dummy_endpoint', msg['to_addr']], ttl=600)
 
     @inlineCallbacks
     def test_session_close_on_inbound(self):
@@ -614,7 +614,7 @@ class TestMetricsMiddleware(VumiTestCase):
 
     @inlineCallbacks
     def test_session_max_lifetime(self):
-        mw = yield self.get_middleware({'max_lifetime': 10})
+        mw = yield self.get_middleware({'max_session_time': 10})
         msg1 = self.mw_helper.make_inbound(
             'foo', session_event=TransportUserMessage.SESSION_NEW)
         yield mw.handle_inbound(msg1, 'dummy_endpoint')

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -357,6 +357,25 @@ class TestMetricsMiddleware(VumiTestCase):
         })
 
     @inlineCallbacks
+    def test_sessions_started_on_outbound(self):
+        mw = yield self.get_middleware({'op_mode': 'passive'})
+        msg = self.mw_helper.make_outbound(
+            "foo", session_event=TransportUserMessage.SESSION_NEW)
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.sessions_started.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_saving_session_start_timestamp_on_outbound(self):
+        mw = yield self.get_middleware({'op_mode': 'passive'})
+        msg = self.mw_helper.make_outbound(
+            "foo", session_event=TransportUserMessage.SESSION_NEW)
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        yield self.assert_timestamp_exists(
+            mw, ['dummy_endpoint', msg['from_addr']], ttl=600)
+
+    @inlineCallbacks
     def test_session_close_on_outbound(self):
         mw = yield self.get_middleware({'op_mode': 'passive'})
         msg = self.mw_helper.make_outbound(

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -395,6 +395,38 @@ class TestMetricsMiddleware(VumiTestCase):
         })
 
     @inlineCallbacks
+    def test_tagpool_metrics_on_inbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'tagpools': {
+                'mypool': {'track_pool': True},
+            },
+        })
+        msg = self.mw_helper.make_inbound("foo", provider="MYMNO")
+        TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagA"))
+        yield mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.tagpool.mypool.inbound.counter': [1],
+            'dummy_endpoint.inbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_tagpool_metrics_on_outbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'tagpools': {
+                'mypool': {'track_pool': True},
+            },
+        })
+        msg = self.mw_helper.make_outbound("foo")
+        TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagA"))
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.tagpool.mypool.outbound.counter': [1],
+            'dummy_endpoint.outbound.counter': [1],
+        })
+
+    @inlineCallbacks
     def test_ack_event(self):
         mw = yield self.get_middleware({'op_mode': 'passive'})
         event = self.mw_helper.make_ack()

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -478,7 +478,7 @@ class TestMetricsMiddleware(VumiTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagA"))
         yield mw.handle_inbound(msg, 'dummy_endpoint')
         self.assert_metrics(mw, {
-            'dummy_endpoint.tag.mypool.tagA.inbound.counter': [1],
+            'dummy_endpoint.tag.mypool.taga.inbound.counter': [1],
             'dummy_endpoint.inbound.counter': [1],
         })
 
@@ -494,7 +494,7 @@ class TestMetricsMiddleware(VumiTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagA"))
         yield mw.handle_outbound(msg, 'dummy_endpoint')
         self.assert_metrics(mw, {
-            'dummy_endpoint.tag.mypool.tagA.outbound.counter': [1],
+            'dummy_endpoint.tag.mypool.taga.outbound.counter': [1],
             'dummy_endpoint.outbound.counter': [1],
         })
 
@@ -510,7 +510,7 @@ class TestMetricsMiddleware(VumiTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagC"))
         yield mw.handle_inbound(msg, 'dummy_endpoint')
         self.assert_metrics(mw, {
-            'dummy_endpoint.tag.mypool.tagC.inbound.counter': [1],
+            'dummy_endpoint.tag.mypool.tagc.inbound.counter': [1],
             'dummy_endpoint.inbound.counter': [1],
         })
 
@@ -526,7 +526,39 @@ class TestMetricsMiddleware(VumiTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "tagC"))
         yield mw.handle_outbound(msg, 'dummy_endpoint')
         self.assert_metrics(mw, {
-            'dummy_endpoint.tag.mypool.tagC.outbound.counter': [1],
+            'dummy_endpoint.tag.mypool.tagc.outbound.counter': [1],
+            'dummy_endpoint.outbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_slugify_tag_on_inbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'tagpools': {
+                'mypool': {'tags': ['*123*456#']},
+            },
+        })
+        msg = self.mw_helper.make_inbound("foo", provider="MYMNO")
+        TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "*123*456#"))
+        yield mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.tag.mypool.123456.inbound.counter': [1],
+            'dummy_endpoint.inbound.counter': [1],
+        })
+
+    @inlineCallbacks
+    def test_slugify_tag_on_outbound(self):
+        mw = yield self.get_middleware({
+            'op_mode': 'passive',
+            'tagpools': {
+                'mypool': {'tags': ['*123*567#']},
+            },
+        })
+        msg = self.mw_helper.make_outbound("foo")
+        TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "*123*567#"))
+        yield mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assert_metrics(mw, {
+            'dummy_endpoint.tag.mypool.123567.outbound.counter': [1],
             'dummy_endpoint.outbound.counter': [1],
         })
 


### PR DESCRIPTION
This should allow us to track via Graphite, for each transport, network operator and tag or tagpool:
- number of sessions
- number of messages
- time taken for each session
- time taken for each session, rounded to the next `N` seconds (this is to allow very rough session costs calculations since some networks bill per `N` seconds or part there-of).

See also praekelt/vumi#856.
