### PR TITLE
Get dialogue app's endpoints to show up

### DIFF
--- a/go/api/go_api/action_dispatcher.py
+++ b/go/api/go_api/action_dispatcher.py
@@ -94,7 +94,7 @@ class ConversationActionDispatcher(ActionDispatcher):
     dispatcher_type_name = "conversation"
 
     def get_object_by_key(self, user_api, conversation_key):
-        return user_api.get_conversation(conversation_key)
+        return user_api.get_wrapped_conversation(conversation_key)
 
 
 class RouterActionDispatcher(ActionDispatcher):

--- a/go/apps/dialogue/definition.py
+++ b/go/apps/dialogue/definition.py
@@ -2,6 +2,7 @@ from go.vumitools.conversation.definition import (
     ConversationDefinitionBase, ConversationAction)
 
 from go.apps.dialogue.dialogue_api import DialogueActionDispatcher
+from go.apps.dialogue.utils import configured_endpoints
 from go.apps.jsbox.definition import SendJsboxAction
 
 
@@ -24,3 +25,6 @@ class ConversationDefinition(ConversationDefinitionBase):
     )
 
     api_dispatcher_cls = DialogueActionDispatcher
+
+    def configured_endpoints(self, config):
+        return configured_endpoints(config)

--- a/go/apps/dialogue/dialogue_api.py
+++ b/go/apps/dialogue/dialogue_api.py
@@ -1,14 +1,27 @@
 """Go API action dispatcher for dialogue conversations."""
 
+from twisted.internet.defer import inlineCallbacks, returnValue
 from go.api.go_api.action_dispatcher import ConversationActionDispatcher
+
+
+def definition(conv):
+    # to avoid problems caused by circular dependency
+    from go.apps.dialogue.definition import ConversationDefinition
+    return ConversationDefinition(conv)
 
 
 class DialogueActionDispatcher(ConversationActionDispatcher):
     def action_get_poll(self, user_api, conv):
         return {"poll": conv.config.get("poll", {})}
 
+    @inlineCallbacks
     def action_save_poll(self, user_api, conv, poll):
-        conv.config["poll"] = poll
-        d = conv.save()
-        d.addCallback(lambda r: {"saved": True})
-        return d
+        dfn = definition(conv)
+
+        config = conv.config.copy()
+        config["poll"] = poll
+
+        dfn.update_config((yield user_api.get_user_account()), config)
+        yield conv.save()
+
+        returnValue({"saved": True})

--- a/go/apps/dialogue/tests/test_definition.py
+++ b/go/apps/dialogue/tests/test_definition.py
@@ -1,0 +1,46 @@
+from vumi.tests.helpers import VumiTestCase
+
+
+from go.vumitools.tests.helpers import VumiApiHelper
+from go.apps.dialogue.definition import ConversationDefinition
+from go.apps.dialogue.tests.dummy_polls import simple_poll
+
+
+class TestConversationDefinition(VumiTestCase):
+    def setUp(self):
+        self.vumi_helper = self.add_helper(VumiApiHelper(is_sync=True))
+        self.user_helper = self.vumi_helper.get_or_create_user()
+        self.user_api = self.user_helper.user_api
+        self.conv = self.user_helper.create_conversation(u'jsbox')
+
+    def test_configured_endpoints(self):
+        poll = simple_poll()
+
+        poll['channel_types'] = [{
+            'name': 'sms',
+            'label': 'SMS'
+        }, {
+            'name': 'twitter',
+            'label': 'Twitter'
+        }]
+
+        poll['states'] = [{
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }, {
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'twitter'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }]
+
+        dfn = ConversationDefinition(self.conv)
+
+        self.assertEqual(
+            dfn.configured_endpoints({'poll': poll}),
+            ['SMS', 'Twitter'])

--- a/go/apps/dialogue/tests/test_utils.py
+++ b/go/apps/dialogue/tests/test_utils.py
@@ -1,0 +1,52 @@
+from vumi.tests.helpers import VumiTestCase
+
+from go.apps.dialogue.utils import dialogue_js_config
+from go.vumitools.tests.helpers import VumiApiHelper
+from go.apps.dialogue.tests.dummy_polls import simple_poll
+
+
+class TestDialogueJsConfig(VumiTestCase):
+    def setUp(self):
+        self.vumi_helper = self.add_helper(VumiApiHelper(is_sync=True))
+        self.user_helper = self.vumi_helper.get_or_create_user()
+
+    def test_config_delivery_class(self):
+        poll = simple_poll()
+        poll['poll_metadata']['delivery_class'] = 'twitter'
+
+        conv = self.user_helper.create_conversation(
+            u'dialogue', config={'poll': poll})
+
+        config = dialogue_js_config(conv)
+        self.assertEqual(config['delivery_class'], 'twitter')
+
+    def test_config_endpoints(self):
+        poll = simple_poll()
+
+        poll['channel_types'] = [{
+            'name': 'sms',
+            'label': 'SMS'
+        }, {
+            'name': 'twitter',
+            'label': 'Twitter'
+        }]
+
+        poll['states'] = [{
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }, {
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'twitter'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }]
+
+        conv = self.user_helper.create_conversation(
+            u'dialogue', config={'poll': poll})
+        config = dialogue_js_config(conv)
+        self.assertEqual(config['endpoints'], ['SMS', 'Twitter'])

--- a/go/apps/dialogue/tests/test_utils.py
+++ b/go/apps/dialogue/tests/test_utils.py
@@ -1,6 +1,6 @@
 from vumi.tests.helpers import VumiTestCase
 
-from go.apps.dialogue.utils import dialogue_js_config
+from go.apps.dialogue.utils import dialogue_js_config, configured_endpoints
 from go.vumitools.tests.helpers import VumiApiHelper
 from go.apps.dialogue.tests.dummy_polls import simple_poll
 
@@ -50,3 +50,33 @@ class TestDialogueJsConfig(VumiTestCase):
             u'dialogue', config={'poll': poll})
         config = dialogue_js_config(conv)
         self.assertEqual(config['endpoints'], ['SMS', 'Twitter'])
+
+    def test_configured_endpoints(self):
+        poll = simple_poll()
+
+        poll['channel_types'] = [{
+            'name': 'sms',
+            'label': 'SMS'
+        }, {
+            'name': 'twitter',
+            'label': 'Twitter'
+        }]
+
+        poll['states'] = [{
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }, {
+            'type': 'foo'
+        }, {
+            'type': 'send',
+            'channel_type': 'twitter'
+        }, {
+            'type': 'send',
+            'channel_type': 'sms'
+        }]
+
+        self.assertEqual(
+            configured_endpoints({'poll': poll}),
+            ['SMS', 'Twitter'])

--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -14,8 +14,8 @@ from vumi.application.tests.test_sandbox import (
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 
-from go.apps.dialogue.vumi_app import (
-    DialogueApplication, PollConfigResource, dialogue_js_config)
+from go.apps.dialogue.vumi_app import DialogueApplication, PollConfigResource
+from go.apps.dialogue.utils import dialogue_js_config
 from go.apps.dialogue.tests.dummy_polls import simple_poll
 from go.apps.tests.helpers import AppWorkerHelper
 
@@ -266,52 +266,3 @@ class TestPollConfigResource(ResourceTestCaseBase):
         config = json.loads(reply['value'])
 
         self.assertEqual(config, dialogue_js_config(conv))
-
-
-class TestDialogueJsConfig(VumiTestCase):
-    @inlineCallbacks
-    def setUp(self):
-        self.app_helper = self.add_helper(AppWorkerHelper(DialogueApplication))
-        self.app = yield self.app_helper.get_app_worker({})
-
-    @inlineCallbacks
-    def test_config_delivery_class(self):
-        poll = simple_poll()
-        poll['poll_metadata']['delivery_class'] = 'twitter'
-
-        conv = yield self.app_helper.create_conversation(config={'poll': poll})
-
-        config = dialogue_js_config(conv)
-        self.assertEqual(config['delivery_class'], 'twitter')
-
-    @inlineCallbacks
-    def test_config_endpoints(self):
-        poll = simple_poll()
-
-        poll['channel_types'] = [{
-            'name': 'sms',
-            'label': 'SMS'
-        }, {
-            'name': 'twitter',
-            'label': 'Twitter'
-        }]
-
-        poll['states'] = [{
-            'type': 'foo'
-        }, {
-            'type': 'send',
-            'channel_type': 'sms'
-        }, {
-            'type': 'foo'
-        }, {
-            'type': 'send',
-            'channel_type': 'twitter'
-        }, {
-            'type': 'send',
-            'channel_type': 'sms'
-        }]
-
-        conv = yield self.app_helper.create_conversation(config={'poll': poll})
-
-        config = dialogue_js_config(conv)
-        self.assertEqual(config['endpoints'], ['SMS', 'Twitter'])

--- a/go/apps/dialogue/utils.py
+++ b/go/apps/dialogue/utils.py
@@ -1,0 +1,24 @@
+def determine_endpoints(poll):
+    names = set(
+        s['channel_type']
+        for s in poll.get('states', []) if s['type'] == 'send')
+
+    types = poll.get('channel_types', [])
+    return [t['label'] for t in types if t['name'] in names]
+
+
+def dialogue_js_config(conv):
+    poll = conv.config.get("poll", {})
+
+    config = {
+        "name": "poll-%s" % conv.key,
+        "endpoints": determine_endpoints(poll)
+    }
+
+    poll_metadata = poll.get('poll_metadata', {})
+    delivery_class = poll_metadata.get('delivery_class')
+
+    if delivery_class is not None:
+        config['delivery_class'] = delivery_class
+
+    return config

--- a/go/apps/dialogue/utils.py
+++ b/go/apps/dialogue/utils.py
@@ -1,4 +1,6 @@
-def determine_endpoints(poll):
+def configured_endpoints(config):
+    poll = config.get("poll", {})
+
     names = set(
         s['channel_type']
         for s in poll.get('states', []) if s['type'] == 'send')
@@ -12,7 +14,7 @@ def dialogue_js_config(conv):
 
     config = {
         "name": "poll-%s" % conv.key,
-        "endpoints": determine_endpoints(poll)
+        "endpoints": configured_endpoints(conv.config)
     }
 
     poll_metadata = poll.get('poll_metadata', {})

--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -6,32 +6,7 @@ import json
 from vumi.application.sandbox import SandboxResource
 
 from go.apps.jsbox.vumi_app import JsBoxConfig, JsBoxApplication
-
-
-def determine_endpoints(poll):
-    names = set(
-        s['channel_type']
-        for s in poll.get('states', []) if s['type'] == 'send')
-
-    types = poll.get('channel_types', [])
-    return [t['label'] for t in types if t['name'] in names]
-
-
-def dialogue_js_config(conv):
-    poll = conv.config.get("poll", {})
-
-    config = {
-        "name": "poll-%s" % conv.key,
-        "endpoints": determine_endpoints(poll)
-    }
-
-    poll_metadata = poll.get('poll_metadata', {})
-    delivery_class = poll_metadata.get('delivery_class')
-
-    if delivery_class is not None:
-        config['delivery_class'] = delivery_class
-
-    return config
+from go.apps.dialogue.utils import dialogue_js_config
 
 
 class PollConfigResource(SandboxResource):


### PR DESCRIPTION
At the moment, we figure out which endpoints to use in a dialogue app for the vumi app side, but not the UI side. We need to get the dialogue app's conversation definition to know how to do that.
