### PR TITLE
Use the same endpoint name in dialogue app and UI for send action

### DIFF
--- a/go/apps/dialogue/tests/dummy_polls.js
+++ b/go/apps/dialogue/tests/dummy_polls.js
@@ -36,37 +36,36 @@ var simple_poll = {
         entry_endpoint: {uuid: "endpoint-4"},
         exit_endpoint: {uuid: "endpoint-5"}
     },
-        {
-            uuid: "send-1",
-            name: "Message 3",
-            type: "send",
-            text: "Hello over other endpoint",
-            channel_type: "twitter",
-            entry_endpoint: {uuid: "endpoint-6"},
-            exit_endpoint: {uuid: "endpoint-7"}
-        },
-        {
-            uuid: "freetext-1",
-            name: "Message 3",
-            store_as: "message-3",
-            type: "freetext",
-            store_on_contact: true,
-            entry_endpoint: {uuid: "endpoint-8"},
-            // freetext specific
-            exit_endpoint: {uuid: "endpoint-9"},
-            text: "What is your name?"
-        },
-            {
-                uuid: "end-1",
-                name: "Ending 1",
-                store_as: "ending-1",
-                type: "end",
-                store_on_contact: true,
-                entry_endpoint: {uuid: "endpoint-10"},
-                // end specific
-                text: "Thank you for taking our survey"
-            }
-    ],
+    {
+        uuid: "send-1",
+        name: "Message 3",
+        type: "send",
+        text: "Hello over other endpoint",
+        channel_type: "twitter",
+        entry_endpoint: {uuid: "endpoint-6"},
+        exit_endpoint: {uuid: "endpoint-7"}
+    },
+    {
+        uuid: "freetext-1",
+        name: "Message 3",
+        store_as: "message-3",
+        type: "freetext",
+        store_on_contact: true,
+        entry_endpoint: {uuid: "endpoint-8"},
+        // freetext specific
+        exit_endpoint: {uuid: "endpoint-9"},
+        text: "What is your name?"
+    },
+    {
+        uuid: "end-1",
+        name: "Ending 1",
+        store_as: "ending-1",
+        type: "end",
+        store_on_contact: true,
+        entry_endpoint: {uuid: "endpoint-10"},
+        // end specific
+        text: "Thank you for taking our survey"
+    }],
     connections: [
     {
         source: {uuid: "endpoint-1"},
@@ -76,23 +75,22 @@ var simple_poll = {
         source: {uuid: "endpoint-2"},
         target: {uuid: "endpoint-10"}
     },
-        {
-            source: {uuid: "endpoint-3"},
-            target: {uuid: "endpoint-6"}
-        },
-        {
-            source: {uuid: "endpoint-5"},
-            target: {uuid: "endpoint-8"}
-        },
-            {
-                source: {uuid: "endpoint-7"},
-                target: {uuid: "endpoint-8"}
-            },
-            {
-                source: {uuid: "endpoint-9"},
-                target: {uuid: "endpoint-10"}
-            }
-    ]
+    {
+        source: {uuid: "endpoint-3"},
+        target: {uuid: "endpoint-6"}
+    },
+    {
+        source: {uuid: "endpoint-5"},
+        target: {uuid: "endpoint-8"}
+    },
+    {
+        source: {uuid: "endpoint-7"},
+        target: {uuid: "endpoint-8"}
+    },
+    {
+        source: {uuid: "endpoint-9"},
+        target: {uuid: "endpoint-10"}
+    }]
 };
 
 

--- a/go/apps/dialogue/tests/dummy_polls.js
+++ b/go/apps/dialogue/tests/dummy_polls.js
@@ -20,7 +20,7 @@ var simple_poll = {
         type: "choice", // menu of options
         entry_endpoint: null, // null for the start state
         store_on_contact: true,
-            // choice specific
+        // choice specific
         text: "What is your favourite colour?",
         choice_endpoints: [ // these are actually also the endpoints
         {value: "value-1", label: "Red", uuid: "endpoint-1"},
@@ -52,7 +52,7 @@ var simple_poll = {
             type: "freetext",
             store_on_contact: true,
             entry_endpoint: {uuid: "endpoint-8"},
-                // freetext specific
+            // freetext specific
             exit_endpoint: {uuid: "endpoint-9"},
             text: "What is your name?"
         },
@@ -63,7 +63,7 @@ var simple_poll = {
                 type: "end",
                 store_on_contact: true,
                 entry_endpoint: {uuid: "endpoint-10"},
-                    // end specific
+                // end specific
                 text: "Thank you for taking our survey"
             }
     ],
@@ -95,6 +95,6 @@ var simple_poll = {
     ]
 };
 
-// export
 
+// export
 this.simple_poll = simple_poll;

--- a/go/apps/dialogue/tests/dummy_polls.js
+++ b/go/apps/dialogue/tests/dummy_polls.js
@@ -1,10 +1,17 @@
 var simple_poll = {
-  conversation: "conversation-key",
-  start_state: {uuid: "choice-1"},
-  poll_metadata: {
-    repeatable: true,
-  },
-  states: [
+    conversation: "conversation-key",
+    start_state: {uuid: "choice-1"},
+    poll_metadata: {
+        repeatable: true,
+    },
+    channel_types: [{
+        name: 'twitter',
+        label: 'Twitter'
+    }, {
+        name: 'sms',
+        label: 'SMS'
+    }],
+    states: [
     {
         // these are common to all state types
         uuid: "choice-1", // name is unique
@@ -13,12 +20,12 @@ var simple_poll = {
         type: "choice", // menu of options
         entry_endpoint: null, // null for the start state
         store_on_contact: true,
-        // choice specific
+            // choice specific
         text: "What is your favourite colour?",
         choice_endpoints: [ // these are actually also the endpoints
-          {value: "value-1", label: "Red", uuid: "endpoint-1"},
-          {value: "value-2", label: "Blue", uuid: "endpoint-2"},
-          {value: "value-3", label: "Green", uuid: "endpoint-3"}
+        {value: "value-1", label: "Red", uuid: "endpoint-1"},
+        {value: "value-2", label: "Blue", uuid: "endpoint-2"},
+        {value: "value-3", label: "Green", uuid: "endpoint-3"}
         ]
     },
     {
@@ -29,63 +36,63 @@ var simple_poll = {
         entry_endpoint: {uuid: "endpoint-4"},
         exit_endpoint: {uuid: "endpoint-5"}
     },
+        {
+            uuid: "send-1",
+            name: "Message 3",
+            type: "send",
+            text: "Hello over other endpoint",
+            channel_type: "twitter",
+            entry_endpoint: {uuid: "endpoint-6"},
+            exit_endpoint: {uuid: "endpoint-7"}
+        },
+        {
+            uuid: "freetext-1",
+            name: "Message 3",
+            store_as: "message-3",
+            type: "freetext",
+            store_on_contact: true,
+            entry_endpoint: {uuid: "endpoint-8"},
+                // freetext specific
+            exit_endpoint: {uuid: "endpoint-9"},
+            text: "What is your name?"
+        },
+            {
+                uuid: "end-1",
+                name: "Ending 1",
+                store_as: "ending-1",
+                type: "end",
+                store_on_contact: true,
+                entry_endpoint: {uuid: "endpoint-10"},
+                    // end specific
+                text: "Thank you for taking our survey"
+            }
+    ],
+    connections: [
     {
-        uuid: "send-1",
-        name: "Message 3",
-        type: "send",
-        text: "Hello over other endpoint",
-        channel_type: "twitter_channel_type",
-        entry_endpoint: {uuid: "endpoint-6"},
-        exit_endpoint: {uuid: "endpoint-7"}
+        source: {uuid: "endpoint-1"},
+        target: {uuid: "endpoint-4"}
     },
     {
-        uuid: "freetext-1",
-        name: "Message 3",
-        store_as: "message-3",
-        type: "freetext",
-        store_on_contact: true,
-        entry_endpoint: {uuid: "endpoint-8"},
-        // freetext specific
-        exit_endpoint: {uuid: "endpoint-9"},
-        text: "What is your name?"
+        source: {uuid: "endpoint-2"},
+        target: {uuid: "endpoint-10"}
     },
-    {
-       uuid: "end-1",
-       name: "Ending 1",
-       store_as: "ending-1",
-       type: "end",
-       store_on_contact: true,
-       entry_endpoint: {uuid: "endpoint-10"},
-       // end specific
-       text: "Thank you for taking our survey"
-    }
-  ],
-  connections: [
-     {
-       source: {uuid: "endpoint-1"},
-       target: {uuid: "endpoint-4"}
-     },
-     {
-       source: {uuid: "endpoint-2"},
-       target: {uuid: "endpoint-10"}
-     },
-     {
-       source: {uuid: "endpoint-3"},
-       target: {uuid: "endpoint-6"}
-     },
-     {
-       source: {uuid: "endpoint-5"},
-       target: {uuid: "endpoint-8"}
-     },
-     {
-       source: {uuid: "endpoint-7"},
-       target: {uuid: "endpoint-8"}
-     },
-     {
-       source: {uuid: "endpoint-9"},
-       target: {uuid: "endpoint-10"}
-     }
-  ]
+        {
+            source: {uuid: "endpoint-3"},
+            target: {uuid: "endpoint-6"}
+        },
+        {
+            source: {uuid: "endpoint-5"},
+            target: {uuid: "endpoint-8"}
+        },
+            {
+                source: {uuid: "endpoint-7"},
+                target: {uuid: "endpoint-8"}
+            },
+            {
+                source: {uuid: "endpoint-9"},
+                target: {uuid: "endpoint-10"}
+            }
+    ]
 };
 
 // export

--- a/go/apps/dialogue/tests/test_utils.py
+++ b/go/apps/dialogue/tests/test_utils.py
@@ -49,7 +49,10 @@ class TestDialogueJsConfig(VumiTestCase):
         conv = self.user_helper.create_conversation(
             u'dialogue', config={'poll': poll})
         config = dialogue_js_config(conv)
-        self.assertEqual(config['endpoints'], ['SMS', 'Twitter'])
+        self.assertEqual(config['endpoints'], {
+            'SMS': {'delivery_class': 'sms'},
+            'Twitter': {'delivery_class': 'twitter'}
+        })
 
     def test_configured_endpoints(self):
         poll = simple_poll()

--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -240,7 +240,7 @@ describe("app", function() {
             it("should send a message over the given channel", function() {
                 return tester
                     .setup.config.app({
-                        endpoints: {twitter: {delivery_class: 'twitter'}}
+                        endpoints: {Twitter: {delivery_class: 'twitter'}}
                     })
                     .setup(function(api) {
                         api.contacts.add({
@@ -265,7 +265,7 @@ describe("app", function() {
             function() {
                 return tester
                     .setup.config.app({
-                        endpoints: {twitter_channel_type: {delivery_class: 'twitter'}}
+                        endpoints: {Twitter: {delivery_class: 'twitter'}}
                     })
                     .setup(function(api) {
                         api.contacts.add({

--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -240,7 +240,7 @@ describe("app", function() {
             it("should send a message over the given channel", function() {
                 return tester
                     .setup.config.app({
-                        endpoints: {twitter_channel_type: {delivery_class: 'twitter'}}
+                        endpoints: {twitter: {delivery_class: 'twitter'}}
                     })
                     .setup(function(api) {
                         api.contacts.add({

--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 
 var _ = require('lodash');
 var vumigo = require('vumigo_v02');
+var fail = vumigo.test_utils.fail;
 var AppTester = vumigo.AppTester;
 
 var app = require('../vumi_app');
@@ -278,6 +279,29 @@ describe("app", function() {
                     .check.user.state('freetext-1')
                     .check.reply('What is your name?')
                     .run();
+            });
+
+            it("should throw an error if no channel type is found", function() {
+                var state = _.find(poll.states, {uuid: 'send-1'});
+                state.channel_type = '???';
+
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27123',
+                            twitter_handle: '@me'
+                        });
+                    })
+                    .setup.user.state('choice-1')
+                    .input('3')
+                    .run()
+                    .then(fail, function(e) {
+                        assert(e instanceof Error);
+
+                        assert.equal(
+                            e.message,
+                            "No endpoint found for channel type '???'");
+                    });
             });
         });
     });

--- a/go/apps/dialogue/utils.py
+++ b/go/apps/dialogue/utils.py
@@ -1,12 +1,16 @@
-def configured_endpoints(config):
-    poll = config.get("poll", {})
-
-    names = set(
+def channel_types(poll):
+    return set(
         s['channel_type']
         for s in poll.get('states', []) if s['type'] == 'send')
 
+
+def endpoint_configs(poll):
+    names = channel_types(poll)
     types = poll.get('channel_types', [])
-    return [t['label'] for t in types if t['name'] in names]
+
+    return dict(
+        (t['label'], {'delivery_class': t['name']})
+        for t in types if t['name'] in names)
 
 
 def dialogue_js_config(conv):
@@ -14,7 +18,7 @@ def dialogue_js_config(conv):
 
     config = {
         "name": "poll-%s" % conv.key,
-        "endpoints": configured_endpoints(conv.config)
+        "endpoints": endpoint_configs(poll)
     }
 
     poll_metadata = poll.get('poll_metadata', {})
@@ -24,3 +28,10 @@ def dialogue_js_config(conv):
         config['delivery_class'] = delivery_class
 
     return config
+
+
+def configured_endpoints(config):
+    poll = config.get("poll", {})
+    names = channel_types(poll)
+    types = poll.get('channel_types', [])
+    return [t['label'] for t in types if t['name'] in names]

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -56,7 +56,7 @@ var DialogueApp = App.extend(function(self) {
 
         if (!d) {
             throw new Error(
-                "Unknown channel type: '" + channel_type + "'");
+                "No endpoint found for channel type '" + channel_type + "'");
         }
 
         return d.label;

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -51,6 +51,17 @@ var DialogueApp = App.extend(function(self) {
         });
     };
 
+    self.get_endpoint = function(channel_type) {
+        var d = _.find(self.poll.channel_types, {name: channel_type});
+
+        if (!d) {
+            throw new Error(
+                "Unknown channel type: '" + channel_type + "'");
+        }
+
+        return d.label;
+    };
+
     self.next = function(endpoint) {
         var connection = _.find(self.poll.connections, {
             source: {uuid: endpoint.uuid}
@@ -133,7 +144,7 @@ var DialogueApp = App.extend(function(self) {
             .im.outbound.send({
                 to: self.contact,
                 content: desc.text,
-                endpoint: desc.channel_type
+                endpoint: self.get_endpoint(desc.channel_type)
             })
             .then(function() {
                 return self.states.create(self.next(desc.exit_endpoint));


### PR DESCRIPTION
At the moment, the app uses the delivery class name and the UI uses its label.
