### PR TITLE
Better stripping of strange characters in tagnames when firing metrics.

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -181,7 +181,8 @@ class MetricsMiddleware(BaseMiddleware):
     """
 
     KNOWN_MODES = frozenset(['active', 'passive'])
-    TAG_SLUGIFIER_RE = re.compile(r"[^a-zA-Z0-9_-]*")
+    TAG_STRIP_RE = re.compile(r"(^[^a-zA-Z0-9_-]+)|([^a-zA-Z0-9_-]+$)")
+    TAG_DOT_RE = re.compile(r"[^a-zA-Z0-9_-]+")
 
     def validate_config(self):
         self.manager_name = self.config['manager_name']
@@ -309,7 +310,9 @@ class MetricsMiddleware(BaseMiddleware):
         return TaggingMiddleware.map_msg_to_tag(message)
 
     def slugify_tagname(self, tagname):
-        return self.TAG_SLUGIFIER_RE.sub("", tagname).lower()
+        tagname = self.TAG_STRIP_RE.sub("", tagname)
+        tagname = self.TAG_DOT_RE.sub(".", tagname)
+        return tagname.lower()
 
     def fire_response_time(self, prefix, reply_dt):
         if reply_dt:

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -590,7 +590,7 @@ class TestMetricsMiddleware(VumiTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "*123*456#"))
         yield mw.handle_inbound(msg, 'dummy_endpoint')
         self.assert_metrics(mw, {
-            'dummy_endpoint.tag.mypool.123456.inbound.counter': [1],
+            'dummy_endpoint.tag.mypool.123.456.inbound.counter': [1],
             'dummy_endpoint.inbound.counter': [1],
         })
 
@@ -606,7 +606,7 @@ class TestMetricsMiddleware(VumiTestCase):
         TaggingMiddleware.add_tag_to_msg(msg, ("mypool", "*123*567#"))
         yield mw.handle_outbound(msg, 'dummy_endpoint')
         self.assert_metrics(mw, {
-            'dummy_endpoint.tag.mypool.123567.outbound.counter': [1],
+            'dummy_endpoint.tag.mypool.123.567.outbound.counter': [1],
             'dummy_endpoint.outbound.counter': [1],
         })
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -579,6 +579,19 @@ class TestMetricsMiddleware(VumiTestCase):
         })
 
     @inlineCallbacks
+    def test_slugify_tagname(self):
+        mw = yield self.get_middleware({})
+        self.assertEqual(mw.slugify_tagname("*123"), "123")
+        self.assertEqual(mw.slugify_tagname("*#123"), "123")
+        self.assertEqual(mw.slugify_tagname("123!"), "123")
+        self.assertEqual(mw.slugify_tagname("123!+"), "123")
+        self.assertEqual(mw.slugify_tagname("1*23"), "1.23")
+        self.assertEqual(mw.slugify_tagname("1*!23"), "1.23")
+        self.assertEqual(mw.slugify_tagname("*12*3#"), "12.3")
+        self.assertEqual(
+            mw.slugify_tagname("foo@example.com"), "foo.example.com")
+
+    @inlineCallbacks
     def test_slugify_tag_on_inbound(self):
         mw = yield self.get_middleware({
             'op_mode': 'passive',


### PR DESCRIPTION
Currently we just strip out odd characters but perhaps we should replace them with `_` or `.` if they're not at the start or end of the number?
