### PR TITLE
Command messages raise IgnoreMessage but only real connectors handle this.

### DIFF
--- a/go/routers/tests/helpers.py
+++ b/go/routers/tests/helpers.py
@@ -193,7 +193,7 @@ class RouterWorkerHelper(object):
     def dispatch_command(self, command, *args, **kw):
         cmd = VumiApiCommand.command(
             self._worker_name(), command, *args, **kw)
-        yield self.dispatch_raw('vumi.api', cmd)
+        yield self.ri.dispatch_raw('vumi.api', cmd)
         yield self.dispatch_commands_to_router()
 
     def get_published_metrics(self, worker):


### PR DESCRIPTION
Our command message processing appears to raise `vumi.connectors.IgnoreMessage` via `get_config_for_conversation` and `get_config_for_router` but only real connectors handle this and the custom connectors for command messages don't (so the errors escape unhandled and the consumer stops).
