### PR TITLE
Update version of requests we depend on.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'django-registration==1.0',
         'lesscpy==0.9h',
         'xlrd==0.8.0',
-        'requests==0.14.2',
+        'requests',
         'mock==1.0.1',
         'raven>=2.0,<3.0',
         'django-debug-toolbar==0.9.4',


### PR DESCRIPTION
We currently depend on requests 0.14.2. Since the current version on PyPI is 2.4.3, we should consider updating.

What triggered this is the Travis failure https://travis-ci.org/praekelt/vumi-go/jobs/41489295 from #868 which is caused by a bug in older versions of requests that overwrote `six.moves` with its own module.
