### PR TITLE
Add approximate total unique user counts to go_system_stats.

### DIFF
--- a/go/base/management/commands/go_system_stats.py
+++ b/go/base/management/commands/go_system_stats.py
@@ -109,11 +109,14 @@ class Command(BaseGoCommand):
         batch_key = conv.batch.key
         mdb = conv.mdb
         cache = mdb.cache
+        inbound_uniques = cache.count_from_addrs(batch_key)
+        outbound_uniques = cache.count_to_addrs(batch_key)
         stats["conversations_started"] += 1
         stats["inbound_message_count"] += mdb.batch_inbound_count(batch_key)
         stats["outbound_message_count"] += mdb.batch_outbound_count(batch_key)
-        stats["inbound_uniques"] += cache.count_from_addrs(batch_key)
-        stats["outbound_uniques"] += cache.count_to_addrs(batch_key)
+        stats["inbound_uniques"] += inbound_uniques
+        stats["outbound_uniques"] += outbound_uniques
+        stats["total_uniques"] += max(inbound_uniques, outbound_uniques)
 
     def handle_command_message_counts_by_month(self, *args, **options):
         month_stats = {}
@@ -129,7 +132,7 @@ class Command(BaseGoCommand):
         fields = ([
             "date", "conversations_started",
             "inbound_message_count", "outbound_message_count",
-            "inbound_uniques", "outbound_uniques",
+            "inbound_uniques", "outbound_uniques", "total_uniques",
         ])
         writer = StatsWriter(self.stdout, fields)
         writer.writeheader()

--- a/go/base/tests/test_go_system_stats.py
+++ b/go/base/tests/test_go_system_stats.py
@@ -6,7 +6,6 @@ from django.core.management.base import CommandError
 from django.core.management import call_command
 
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
-from go.base.management.commands import go_system_stats
 from go.vumitools.tests.helpers import GoMessageHelper
 
 
@@ -147,7 +146,7 @@ class TestGoSystemStatsCommand(GoDjangoTestCase):
         self.assert_csv_output(cmd, [
             "date,conversations_started,"
             "inbound_message_count,outbound_message_count,"
-            "inbound_uniques,outbound_uniques",
+            "inbound_uniques,outbound_uniques,total_uniques",
         ])
 
     def test_message_counts_by_month(self):
@@ -173,10 +172,10 @@ class TestGoSystemStatsCommand(GoDjangoTestCase):
         self.assert_csv_output(cmd, [
             "date,conversations_started,"
             "inbound_message_count,outbound_message_count,"
-            "inbound_uniques,outbound_uniques",
-            "09/01/2013,1,3,6,1,2",
-            "11/01/2013,3,2,2,2,2",
-            "12/01/2013,2,4,6,2,6",
+            "inbound_uniques,outbound_uniques,total_uniques",
+            "09/01/2013,1,3,6,1,2,2",
+            "11/01/2013,3,2,2,2,2,2",
+            "12/01/2013,2,4,6,2,6,6",
         ])
 
     def test_custom_date_format(self):


### PR DESCRIPTION
Currently the stats only include total inbound and outbound uniques and don't provide anything that gives a reasonable estimate of total uniques. The idea here is to assume that inbound and outbound addresses that interact with a conversation overlap significantly and maintain a total of `max(inbound_uniques, outbound_uniqes)`.
