### PR TITLE
Disable fallback search for contact lookup

### DIFF
--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -158,7 +158,7 @@ class ContactStore(PerAccountStore):
     # but will result in false negatives if there are matching contacts that
     # have not yet been migrated to version 2.
     FIND_BY_INDEX = True
-    FIND_BY_INDEX_SEARCH_FALLBACK = True
+    FIND_BY_INDEX_SEARCH_FALLBACK = False
 
     def setup_proxies(self):
         self.contacts = self.manager.proxy(Contact)

--- a/go/vumitools/contact/tests/test_models.py
+++ b/go/vumitools/contact/tests/test_models.py
@@ -202,11 +202,10 @@ class TestContactStore(VumiTestCase):
 
     @inlineCallbacks
     def test_contact_for_addr_unindexed(self):
-        contact = yield self.make_unindexed_contact(
-            name=u'name', msisdn=u'+27831234567')
-        found_contact = yield self.contact_store.contact_for_addr(
+        yield self.make_unindexed_contact(name=u'name', msisdn=u'+27831234567')
+        contact_d = self.contact_store.contact_for_addr(
             'sms', u'+27831234567', create=False)
-        self.assertEqual(contact.key, found_contact.key)
+        yield self.assertFailure(contact_d, ContactNotFoundError)
 
     @inlineCallbacks
     def test_contact_for_addr_unindexed_index_disabled(self):
@@ -227,12 +226,13 @@ class TestContactStore(VumiTestCase):
         self.assertEqual(contact.key, found_contact.key)
 
     @inlineCallbacks
-    def test_contact_for_addr_unindexed_fallback_disabled(self):
-        yield self.make_unindexed_contact(name=u'name', msisdn=u'+27831234567')
-        self.contact_store.FIND_BY_INDEX_SEARCH_FALLBACK = False
-        contact_d = self.contact_store.contact_for_addr(
+    def test_contact_for_addr_unindexed_fallback_enabled(self):
+        contact = yield self.make_unindexed_contact(
+            name=u'name', msisdn=u'+27831234567')
+        self.contact_store.FIND_BY_INDEX_SEARCH_FALLBACK = True
+        found_contact = yield self.contact_store.contact_for_addr(
             'sms', u'+27831234567', create=False)
-        yield self.assertFailure(contact_d, ContactNotFoundError)
+        self.assertEqual(contact.key, found_contact.key)
 
     @inlineCallbacks
     def test_contact_for_addr_indexed_fallback_disabled(self):


### PR DESCRIPTION
We still have a contact-for-address fallback mechanism that uses search, for ancient and decrepit contacts that predate the appropriate indexes (which were added six months ago).

I'm reasonably sure we've migrated all the contacts since then, and the additional expense of a search feeding into a mapreduce every time we look for a contact for a new address is way more than we can manage at high load.
