### PR TITLE
Change email testing backend to celery

### DIFF
--- a/go/testsettings.py
+++ b/go/testsettings.py
@@ -55,7 +55,8 @@ del VUMIGO_TEST_DB
 # test client was logged in as will suddenly not exist).
 CELERY_DB_REUSE_MAX = 100
 
-EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+CELERY_EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
 STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'


### PR DESCRIPTION
The current mail backend for testing is the django in-memory mail backend. This should be changed to use the celery mail backend, and the celery mail backend should be set to the django in-memory mail backend (for tests).
