### PR TITLE
Limit concurrent HTTP API send requests

### DIFF
--- a/go/apps/http_api_nostream/resource.py
+++ b/go/apps/http_api_nostream/resource.py
@@ -164,10 +164,17 @@ class MessageResource(BaseResource):
             return
 
         in_reply_to = payload.get('in_reply_to')
-        if in_reply_to:
-            yield self.handle_PUT_in_reply_to(request, payload, in_reply_to)
-        else:
-            yield self.handle_PUT_send_to(request, payload)
+        user_account = request.getUser()
+        d = self.worker.concurrency_limiter.start(user_account)
+        try:
+            yield d  # Wait for our concurrency limiter to let us move on.
+            if in_reply_to:
+                yield self.handle_PUT_in_reply_to(
+                    request, payload, in_reply_to)
+            else:
+                yield self.handle_PUT_send_to(request, payload)
+        finally:
+            self.worker.concurrency_limiter.stop(user_account)
 
     @inlineCallbacks
     def handle_PUT_in_reply_to(self, request, payload, in_reply_to):

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -295,8 +295,6 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
             'message_id': 'evil_id',
         }
 
-        # TaggingMiddleware.add_tag_to_msg(msg, self.tag)
-
         url = '%s/%s/messages.json' % (self.url, self.conversation.key)
         response = yield http_request_full(url, json.dumps(msg),
                                            self.auth_headers, method='PUT')
@@ -337,8 +335,6 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
             'content': 'foo',
             'message_id': 'evil_id',
         }
-
-        # TaggingMiddleware.add_tag_to_msg(msg, self.tag)
 
         url = '%s/%s/messages.json' % (self.url, self.conversation.key)
         d = http_request_full(

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -14,9 +14,140 @@ from vumi.message import TransportUserMessage, TransportEvent
 from vumi.tests.utils import MockHttpServer, LogCatcher
 from vumi.tests.helpers import VumiTestCase
 
-from go.apps.http_api_nostream.vumi_app import NoStreamingHTTPWorker
+from go.apps.http_api_nostream.vumi_app import (
+    ConcurrencyLimiter, NoStreamingHTTPWorker)
 from go.apps.http_api_nostream.resource import ConversationResource
 from go.apps.tests.helpers import AppWorkerHelper
+
+
+class TestConcurrencyLimiter(VumiTestCase):
+    def test_concurrency_limiter_no_limit(self):
+        """
+        When given a negitive limit, ConcurrencyLimiter never blocks.
+        """
+        limiter = ConcurrencyLimiter(-1)
+        d1 = limiter.start("key")
+        self.assertEqual(d1.called, True)
+        d2 = limiter.start("key")
+        self.assertEqual(d2.called, True)
+
+        # Check that we aren't storing any state.
+        self.assertEqual(limiter._concurrents, {})
+        self.assertEqual(limiter._waiters, {})
+
+        # Check that stopping doesn't explode.
+        limiter.stop("key")
+
+    def test_concurrency_limiter_zero_limit(self):
+        """
+        When given a limit of zero, ConcurrencyLimiter always blocks forever.
+        """
+        limiter = ConcurrencyLimiter(0)
+        d1 = limiter.start("key")
+        self.assertEqual(d1.called, False)
+        d2 = limiter.start("key")
+        self.assertEqual(d2.called, False)
+
+        # Check that we aren't storing any state.
+        self.assertEqual(limiter._concurrents, {})
+        self.assertEqual(limiter._waiters, {})
+
+        # Check that stopping doesn't explode.
+        limiter.stop("key")
+
+    def test_concurrency_limiter_stop_without_start(self):
+        """
+        ConcurrencyLimiter raises an exception if stop() is called without
+        a prior call to start().
+        """
+        limiter = ConcurrencyLimiter(1)
+        self.assertRaises(Exception, limiter.stop)
+
+    def test_concurrency_limiter_one_limit(self):
+        """
+        ConcurrencyLimiter fires the next deferred in the queue when the stop()
+        is called.
+        """
+        limiter = ConcurrencyLimiter(1)
+        d1 = limiter.start("key")
+        self.assertEqual(d1.called, True)
+        d2 = limiter.start("key")
+        self.assertEqual(d2.called, False)
+        d3 = limiter.start("key")
+        self.assertEqual(d3.called, False)
+
+        # Stop the first concurrent and check that the second fires.
+        limiter.stop("key")
+        self.assertEqual(d2.called, True)
+        self.assertEqual(d3.called, False)
+
+        # Stop the second concurrent and check that the third fires.
+        limiter.stop("key")
+        self.assertEqual(d3.called, True)
+
+        # Stop the third concurrent and check that we don't hang on to state.
+        limiter.stop("key")
+        self.assertEqual(limiter._concurrents, {})
+        self.assertEqual(limiter._waiters, {})
+
+    def test_concurrency_limiter_two_limit(self):
+        """
+        ConcurrencyLimiter fires the next deferred in the queue when the stop()
+        is called.
+        """
+        limiter = ConcurrencyLimiter(2)
+        d1 = limiter.start("key")
+        self.assertEqual(d1.called, True)
+        d2 = limiter.start("key")
+        self.assertEqual(d2.called, True)
+        d3 = limiter.start("key")
+        self.assertEqual(d3.called, False)
+        d4 = limiter.start("key")
+        self.assertEqual(d4.called, False)
+
+        # Stop a concurrent and check that the third fires.
+        limiter.stop("key")
+        self.assertEqual(d3.called, True)
+        self.assertEqual(d4.called, False)
+
+        # Stop a concurrent and check that the fourth fires.
+        limiter.stop("key")
+        self.assertEqual(d4.called, True)
+
+        # Stop the last concurrents and check that we don't hang on to state.
+        limiter.stop("key")
+        limiter.stop("key")
+        self.assertEqual(limiter._concurrents, {})
+        self.assertEqual(limiter._waiters, {})
+
+    def test_concurrency_limiter_multiple_keys(self):
+        """
+        ConcurrencyLimiter handles different keys independently.
+        """
+        limiter = ConcurrencyLimiter(1)
+        d1a = limiter.start("key-a")
+        self.assertEqual(d1a.called, True)
+        d2a = limiter.start("key-a")
+        self.assertEqual(d2a.called, False)
+        d1b = limiter.start("key-b")
+        self.assertEqual(d1b.called, True)
+        d2b = limiter.start("key-b")
+        self.assertEqual(d2b.called, False)
+
+        # Stop "key-a" and check that the next "key-a" fires.
+        limiter.stop("key-a")
+        self.assertEqual(d2a.called, True)
+        self.assertEqual(d2b.called, False)
+
+        # Stop "key-b" and check that the next "key-b" fires.
+        limiter.stop("key-b")
+        self.assertEqual(d2b.called, True)
+
+        # Stop the last concurrents and check that we don't hang on to state.
+        limiter.stop("key-a")
+        limiter.stop("key-b")
+        self.assertEqual(limiter._concurrents, {})
+        self.assertEqual(limiter._waiters, {})
 
 
 class TestNoStreamingHTTPWorkerBase(VumiTestCase):

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -129,6 +129,8 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
         self._event_handlers = {}
         self._session_handlers = {}
 
+        self.concurrency_limiter = ConcurrencyLimiter(
+            config.worker_concurrency_limit)
         self.webserver = self.start_web_resources([
             (self.get_conversation_resource(), self.web_path),
             (httprpc.HttpRpcHealthResource(self), self.health_path),


### PR DESCRIPTION
We currently accept as many concurrent "send message" requests as we're given. This branch adds a limit to avoid overwhelming the rest of the system when a single client pushes a high volume of messages.
