### PR TITLE
jsbox unicode stuff

### DIFF
--- a/go/apps/jsbox/log.py
+++ b/go/apps/jsbox/log.py
@@ -79,9 +79,10 @@ class GoLoggingResource(LoggingResource):
         campaign_key = conv.user_account.key
         conversation_key = conv.key
 
-        internal_msg = "[Account: %s, Conversation: %s] %s" % (
+        # The keys may be unicode, so make everything unicode and then encode.
+        internal_msg = u"[Account: %s, Conversation: %s] %r" % (
             campaign_key, conversation_key, msg)
-        log.msg(internal_msg, logLevel=level)
+        log.msg(internal_msg.encode("ascii"), logLevel=level)
 
         yield self.log_manager.add_log(campaign_key, conversation_key,
                                        msg, level)

--- a/go/apps/jsbox/tests/test_log.py
+++ b/go/apps/jsbox/tests/test_log.py
@@ -152,6 +152,11 @@ class TestGoLoggingResource(ResourceTestCaseBase, LogCheckerMixin):
         ])
 
     @inlineCallbacks
+    def test_handle_info_failure(self):
+        yield self.assert_bad_command(
+            'info', u'Value expected for msg')
+
+    @inlineCallbacks
     def test_handle_unicode(self):
         with LogCatcher(log_level=logging.INFO) as lc:
             reply = yield self.dispatch_command('info', msg=u'Zoë message')


### PR DESCRIPTION
We're seeing a lot of unicode-related errors being logged from jsbox apps, which seems to indicate implicit bytes<->unicode conversions somewhere.
