### PR TITLE
Update requests usage to match later requests.

### DIFF
--- a/go/api/go_api/tests/utils.py
+++ b/go/api/go_api/tests/utils.py
@@ -24,27 +24,27 @@ class MockRpc(object):
         return self.response
 
     @staticmethod
-    def make_response_data(result={}, id=None):
-        return {
+    def make_response_json_func(result={}, id=None, error=None):
+        response_data = {
             'id': id,
             'jsonrpc': '2.0',
             'result': result,
         }
+        if error is not None:
+            response_data["error"] = error
+        return (lambda: response_data)
 
     def set_response(self, result={}, id=None):
         response = Mock()
         response.status_code = 200
-        response.json = self.make_response_data(result, id)
+        response.json = self.make_response_json_func(result, id)
         self.response = response
 
     def set_rpc_error_response(self, error, id=None):
         response = Mock()
         response.status_code = 200
-
-        data = self.make_response_data(result=None, id=id)
-        data.error = error
-        response.json = data
-
+        response.json = self.make_response_json_func(
+            result=None, id=id, error=error)
         self.response = response
 
     def set_error_response(self, code, text):

--- a/go/apps/dialogue/view_definition.py
+++ b/go/apps/dialogue/view_definition.py
@@ -37,7 +37,7 @@ class DialogueEditView(ConversationTemplateView):
             'label': d['label']
         } for d_name, d in DELIVERY_CLASSES.iteritems()]
 
-        model_data = r.json['result']['poll']
+        model_data = r.json()['result']['poll']
         model_data.update({
             'campaign_id': request.user_api.user_account_key,
             'conversation_key': conversation.key,

--- a/go/routing/views.py
+++ b/go/routing/views.py
@@ -20,7 +20,7 @@ def routing(request):
             " (%r) %r." % (r.status_code, r.text))
 
     model_data = {'campaign_id': request.user_api.user_account_key}
-    model_data.update(r.json['result'])
+    model_data.update(r.json()['result'])
 
     return render(request, 'routing.html', {
         'session_id': request.session.session_key,


### PR DESCRIPTION
```
File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/django/views/generic/base.py", line 86, in dispatch
    return handler(request, *args, **kwargs)

  File "/var/praekelt/vumi-go/go/apps/dialogue/view_definition.py", line 40, in get
    model_data = r.json['result']['poll']

TypeError: 'instancemethod' object has no attribute '__getitem__'
```
