### PR TITLE
Change dialogue jsbox app to record multiple answers in a single extras field

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -84,14 +84,19 @@ describe("app", function() {
 
             it("should store the user's answer", function() {
                 return tester
-                    .setup.user.state('choice-1')
-                    .input('1')
+                    .inputs(
+                        null, '1', 'foo',
+                        null, '2', 'bar',
+                        null, '1', 'baz',
+                        null, '2', 'quux')
                     .check(function(api) {
                         var contact = _.find(api.contacts.store, {
                             msisdn: '+27123'
                         });
 
-                        assert.equal(contact.extra['message-1'], 'value-1');
+                        assert.equal(
+                            contact.extra['message-1-answers'],
+                            'value-1;value-2;value-1;value-2');
                     })
                     .run();
             });
@@ -135,14 +140,21 @@ describe("app", function() {
 
             it("should store the user's answer", function() {
                 return tester
-                    .setup.user.state('freetext-1')
-                    .input('foo')
+                    .inputs(
+                        null, '1', 'foo',
+                        null, '1', 'bar',
+                        null, '1', 'baz',
+                        null, '1', 'quux')
                     .check(function(api) {
                         var contact = _.find(api.contacts.store, {
                             msisdn: '+27123'
                         });
 
-                        assert.equal(contact.extra['message-3'], 'foo');
+                        assert.equal(contact.extra['message-3'], 'quux');
+
+                        assert.equal(
+                            contact.extra['message-3-answers'],
+                            'foo;bar;baz;quux');
                     })
                     .run();
             });


### PR DESCRIPTION
Similar to #1075, except using a single extras field for all answers. We might end up wanting to do this, but the change is quick enough to make that it is worth making a PR in the meantime.
