### PR TITLE
Statement tasks only look at tagpools with unused tags

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -52,7 +52,7 @@ def get_session_transactions(account, from_date, to_date):
 
 
 def get_tagpools(account):
-    return vumi_api().get_user_api(account.account_number).tagpools()
+    return vumi_api().get_user_api(account.account_number).known_tagpools()
 
 
 def get_provider_name(transaction, tagpools):

--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -51,10 +51,6 @@ def get_session_transactions(account, from_date, to_date):
     return transactions
 
 
-def get_tagpools(account):
-    return vumi_api().get_user_api(account.account_number).known_tagpools()
-
-
 def get_provider_name(transaction, tagpools):
     return tagpools.display_name(transaction['tag_pool_name'])
 
@@ -172,7 +168,7 @@ def generate_monthly_statement(account_id, from_date, to_date):
        between the given ``from_date`` and ``to_date``.
     """
     account = Account.objects.get(id=account_id)
-    tagpools = get_tagpools(account)
+    tagpools = vumi_api().known_tagpools()
 
     statement = Statement(
         account=account,

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -222,3 +222,19 @@ class TestMonthlyStatementTask(GoDjangoTestCase):
         self.assertEqual(item1.credits, get_session_credits(100, 10))
         self.assertEqual(item2.credits, get_session_credits(100, 20))
         self.assertEqual(item3.credits, get_session_credits(100, 30))
+
+    def test_generate_monthly_statement_unaccessible_tags(self):
+        self.vumi_helper.setup_tagpool(u'pool2', [u'tag2.1'], {
+            'display_name': 'Pool 2'
+        })
+
+        mk_transaction(
+            self.account,
+            tag_pool_name=u'pool2',
+            tag_name=u'tag2.1')
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        [item] = get_line_items(statement).filter(channel=u'tag2.1')
+        self.assertEqual(item.billed_by, 'Pool 2')

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -214,13 +214,6 @@ class VumiUserApi(object):
         returnValue(channels)
 
     @Manager.calls_manager
-    def _tagpool_set(self, pools):
-        pool_data = dict([
-            (pool, (yield self.api.tpm.get_metadata(pool)))
-            for pool in pools])
-        returnValue(TagpoolSet(pool_data))
-
-    @Manager.calls_manager
     def tagpools(self):
         user_account = yield self.get_user_account()
 
@@ -244,12 +237,7 @@ class VumiUserApi(object):
             if free_tags:
                 available_pools.append(pool)
 
-        returnValue((yield self._tagpool_set(available_pools)))
-
-    @Manager.calls_manager
-    def known_tagpools(self):
-        pools = yield self.api.tpm.list_pools()
-        returnValue((yield self._tagpool_set(pools)))
+        returnValue((yield self.api.tagpool_set(available_pools)))
 
     @Manager.calls_manager
     def applications(self):
@@ -602,6 +590,18 @@ class VumiApi(object):
         if self.metric_publisher is None:
             raise VumiError("No metric publisher available.")
         return MetricManager(prefix, publisher=self.metric_publisher)
+
+    @Manager.calls_manager
+    def tagpool_set(self, pools):
+        pool_data = dict([
+            (pool, (yield self.tpm.get_metadata(pool)))
+            for pool in pools])
+        returnValue(TagpoolSet(pool_data))
+
+    @Manager.calls_manager
+    def known_tagpools(self):
+        pools = yield self.tpm.list_pools()
+        returnValue((yield self.tagpool_set(pools)))
 
 
 class SyncMessageSender(object):

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -214,6 +214,13 @@ class VumiUserApi(object):
         returnValue(channels)
 
     @Manager.calls_manager
+    def _tagpool_set(self, pools):
+        pool_data = dict([
+            (pool, (yield self.api.tpm.get_metadata(pool)))
+            for pool in pools])
+        returnValue(TagpoolSet(pool_data))
+
+    @Manager.calls_manager
     def tagpools(self):
         user_account = yield self.get_user_account()
 
@@ -237,9 +244,12 @@ class VumiUserApi(object):
             if free_tags:
                 available_pools.append(pool)
 
-        pool_data = dict([(pool, (yield self.api.tpm.get_metadata(pool)))
-                          for pool in available_pools])
-        returnValue(TagpoolSet(pool_data))
+        returnValue((yield self._tagpool_set(available_pools)))
+
+    @Manager.calls_manager
+    def known_tagpools(self):
+        pools = yield self.api.tpm.list_pools()
+        returnValue((yield self._tagpool_set(pools)))
 
     @Manager.calls_manager
     def applications(self):

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -11,10 +11,11 @@ from vumi.errors import VumiError
 
 from go.vumitools.opt_out import OptOutStore
 from go.vumitools.contact import ContactStore
-from go.vumitools.api import VumiUserApi, VumiApiCommand, VumiApiEvent
 from go.vumitools.account.old_models import AccountStoreVNone, AccountStoreV1
 from go.vumitools.routing_table import GoConnector, RoutingTable
 from go.vumitools.tests.helpers import VumiApiHelper
+from go.vumitools.api import (
+    VumiUserApi, VumiApiCommand, VumiApiEvent, TagpoolSet)
 
 
 class TestTxVumiApi(VumiTestCase):
@@ -364,6 +365,54 @@ class TestTxVumiUserApi(VumiTestCase):
                 'namespace': 'bulk_message',
             }})
 
+    @inlineCallbacks
+    def test_tagpools(self):
+        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'])
+        yield self.vumi_helper.setup_tagpool(u'pool2', [u'2.1'])
+        yield self.user_helper.add_tagpool_permission(u'pool1')
+        yield self.user_helper.add_tagpool_permission(u'pool2')
+
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(sorted(pools.pools()), [u'pool1', u'pool2'])
+
+    @inlineCallbacks
+    def test_tagpools_max_keys(self):
+        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1', u'1.2'])
+        yield self.user_helper.add_tagpool_permission(u'pool1', max_keys=2)
+
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(sorted(pools.pools()), [u'pool1'])
+
+        yield self.user_api.acquire_specific_tag((u'pool1', u'1.1'))
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(sorted(pools.pools()), [u'pool1'])
+
+        yield self.user_api.acquire_specific_tag((u'pool1', u'1.2'))
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(pools.pools(), [])
+
+    @inlineCallbacks
+    def test_tagpools_available(self):
+        user2_helper = yield self.vumi_helper.make_user(u'User 2')
+        user2_api = user2_helper.user_api
+        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1', u'1.2'])
+        yield self.user_helper.add_tagpool_permission(u'pool1')
+        yield user2_helper.add_tagpool_permission(u'pool1')
+
+        yield user2_api.acquire_specific_tag((u'pool1', u'1.1'))
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(sorted(pools.pools()), [u'pool1'])
+
+        yield user2_api.acquire_specific_tag((u'pool1', u'1.2'))
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(pools.pools(), [])
+
+    @inlineCallbacks
+    def test_tagpools_accessible(self):
+        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'])
+        pools = yield self.user_api.tagpools()
+        self.assertEqual(pools.pools(), [])
+
 
 class TestVumiUserApi(TestTxVumiUserApi):
     sync_persistence = True
@@ -511,3 +560,107 @@ class TestVumiApiEvent(VumiTestCase):
         self.assertEqual(event['conversation_key'], 'my_conv')
         self.assertEqual(event['event_type'], 'my_event')
         self.assertEqual(event['content'], {"foo": "bar"})
+
+
+class TestTagpoolSet(VumiTestCase):
+    def test_pools(self):
+        pools = TagpoolSet({
+            'pool1': {},
+            'pool2': {}
+        })
+
+        self.assertEqual(sorted(pools.pools()), ['pool1', 'pool2'])
+
+    def test_display_name(self):
+        pools = TagpoolSet({
+            'pool1': {'display_name': 'Pool 1'},
+            'pool2': {'display_name': 'Pool 2'}
+        })
+
+        self.assertEqual(pools.display_name('pool1'), 'Pool 1')
+        self.assertEqual(pools.display_name('pool2'), 'Pool 2')
+
+    def test_display_name_fallback(self):
+        pools = TagpoolSet({
+            'pool1': {'display_name': 'Pool 1'},
+            'pool2': {}
+        })
+
+        self.assertEqual(pools.display_name('pool1'), 'Pool 1')
+        self.assertEqual(pools.display_name('pool2'), 'pool2')
+
+    def test_country_name(self):
+        pools = TagpoolSet({
+            'pool1': {'country_name': 'Foo'},
+            'pool2': {'country_name': 'Bar'}
+        })
+
+        self.assertEqual(pools.country_name('pool1', None), 'Foo')
+        self.assertEqual(pools.country_name('pool2', None), 'Bar')
+
+    def test_country_name_default(self):
+        pools = TagpoolSet({
+            'pool1': {'country_name': 'Foo'},
+            'pool2': {}
+        })
+
+        self.assertEqual(pools.country_name('pool1', 'Baz'), 'Foo')
+        self.assertEqual(pools.country_name('pool2', 'Bar'), 'Bar')
+
+    def test_user_selects_tag(self):
+        pools = TagpoolSet({
+            'pool1': {'user_selects_tag': True},
+            'pool2': {'user_selects_tag': False}
+        })
+
+        self.assertTrue(pools.user_selects_tag('pool1'))
+        self.assertFalse(pools.user_selects_tag('pool2'))
+
+    def test_user_selects_tag_fallback(self):
+        pools = TagpoolSet({
+            'pool1': {'user_selects_tag': True},
+            'pool2': {}
+        })
+
+        self.assertTrue(pools.user_selects_tag('pool1'))
+        self.assertFalse(pools.user_selects_tag('pool2'))
+
+    def test_delivery_class(self):
+        pools = TagpoolSet({
+            'pool1': {'delivery_class': 'sms'},
+            'pool2': {'delivery_class': 'ussd'}
+        })
+
+        self.assertEqual(pools.delivery_class('pool1'), 'sms')
+        self.assertEqual(pools.delivery_class('pool2'), 'ussd')
+
+    def test_delivery_class_fallback(self):
+        pools = TagpoolSet({
+            'pool1': {'delivery_class': 'sms'},
+            'pool2': {}
+        })
+
+        self.assertEqual(pools.delivery_class('pool1'), 'sms')
+        self.assertEqual(pools.delivery_class('pool2'), None)
+
+    def test_delivery_classes(self):
+        pools = TagpoolSet({
+            'pool1': {'delivery_class': 'sms'},
+            'pool2': {'delivery_class': 'ussd'},
+        })
+
+        self.assertEqual(pools.delivery_classes(), ['sms', 'ussd'])
+
+    def test_delivery_classes_unspecifieds(self):
+        pools = TagpoolSet({
+            'pool1': {'delivery_class': 'sms'},
+            'pool2': {},
+        })
+
+        self.assertEqual(pools.delivery_classes(), ['sms'])
+
+    def test_delivery_class_name(self):
+        pools = TagpoolSet({})
+        self.assertEqual(pools.delivery_class_name('sms'), 'SMS')
+        self.assertEqual(pools.delivery_class_name('ussd'), 'USSD')
+        self.assertEqual(pools.delivery_class_name('gtalk'), 'Gtalk')

--- a/go/vumitools/tests/test_api.py
+++ b/go/vumitools/tests/test_api.py
@@ -46,6 +46,28 @@ class TestTxVumiApi(VumiTestCase):
         self.assertEqual(cmd1.payload['kwargs']['to_addr'], '+12')
         self.assertEqual(cmd2.payload['kwargs']['to_addr'], '+34')
 
+    @inlineCallbacks
+    def test_tagpool_set(self):
+        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'], {
+            'display_name': 'Pool 1'
+        })
+
+        yield self.vumi_helper.setup_tagpool(u'pool2', [u'1.1'], {
+            'display_name': 'Pool 2'
+        })
+
+        pools = yield self.vumi_api.tagpool_set([u'pool1', u'pool2'])
+        self.assertEqual(sorted(pools.pools()), [u'pool1', u'pool2'])
+        self.assertEqual(pools.display_name('pool1'), 'Pool 1')
+        self.assertEqual(pools.display_name('pool2'), 'Pool 2')
+
+    @inlineCallbacks
+    def test_known_tagpools(self):
+        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'])
+        yield self.vumi_helper.setup_tagpool(u'pool2', [u'2.1'])
+        pools = yield self.vumi_api.known_tagpools()
+        self.assertEqual(sorted(pools.pools()), [u'pool1', u'pool2'])
+
 
 class TestVumiApi(TestTxVumiApi):
     is_sync = True
@@ -412,54 +434,6 @@ class TestTxVumiUserApi(VumiTestCase):
         yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'])
         pools = yield self.user_api.tagpools()
         self.assertEqual(pools.pools(), [])
-
-    @inlineCallbacks
-    def test_known_tagpools(self):
-        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'])
-        yield self.vumi_helper.setup_tagpool(u'pool2', [u'2.1'])
-        yield self.user_helper.add_tagpool_permission(u'pool1')
-        yield self.user_helper.add_tagpool_permission(u'pool2')
-
-        pools = yield self.user_api.known_tagpools()
-        self.assertEqual(sorted(pools.pools()), [u'pool1', u'pool2'])
-
-    @inlineCallbacks
-    def test_known_tagpools_max_keys(self):
-        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1', u'1.2'])
-        yield self.user_helper.add_tagpool_permission(u'pool1', max_keys=2)
-
-        pools = yield self.user_api.known_tagpools()
-        self.assertEqual(sorted(pools.pools()), [u'pool1'])
-
-        yield self.user_api.acquire_specific_tag((u'pool1', u'1.1'))
-        pools = yield self.user_api.known_tagpools()
-        self.assertEqual(sorted(pools.pools()), [u'pool1'])
-
-        pools = yield self.user_api.known_tagpools()
-        yield self.user_api.acquire_specific_tag((u'pool1', u'1.2'))
-        self.assertEqual(sorted(pools.pools()), [u'pool1'])
-
-    @inlineCallbacks
-    def test_known_tagpools_available(self):
-        user2_helper = yield self.vumi_helper.make_user(u'User 2')
-        user2_api = user2_helper.user_api
-        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1', u'1.2'])
-        yield self.user_helper.add_tagpool_permission(u'pool1')
-        yield user2_helper.add_tagpool_permission(u'pool1')
-
-        yield user2_api.acquire_specific_tag((u'pool1', u'1.1'))
-        pools = yield self.user_api.known_tagpools()
-        self.assertEqual(sorted(pools.pools()), [u'pool1'])
-
-        yield user2_api.acquire_specific_tag((u'pool1', u'1.2'))
-        pools = yield self.user_api.known_tagpools()
-        self.assertEqual(sorted(pools.pools()), [u'pool1'])
-
-    @inlineCallbacks
-    def test_known_tagpools_accessible(self):
-        yield self.vumi_helper.setup_tagpool(u'pool1', [u'1.1'])
-        pools = yield self.user_api.known_tagpools()
-        self.assertEqual(pools.pools(), [u'pool1'])
 
 
 class TestVumiUserApi(TestTxVumiUserApi):


### PR DESCRIPTION
The task should look at all known tagpools.
