### PR TITLE
Add management command for archiving transactions

### DIFF
--- a/go/base/tests/helpers.py
+++ b/go/base/tests/helpers.py
@@ -159,6 +159,18 @@ class DjangoVumiApiHelper(object):
         user_api = base_utils.vumi_api_for_user(user)
         return self.get_user_helper(user_api.user_account_key)
 
+    @proxyable
+    def patch_s3_bucket_settings(self, config_name, defaults=None, **kw):
+        from go.base.s3utils import Bucket
+        defaults = defaults if defaults is not None else {
+            "aws_access_key_id": "AWS-DUMMY-ID",
+            "aws_secret_access_key": "AWS-DUMMY-SECRET",
+        }
+        go_s3_buckets = {config_name: defaults}
+        go_s3_buckets[config_name].update(kw)
+        self.patch_settings(GO_S3_BUCKETS=go_s3_buckets)
+        return Bucket(config_name)
+
     def create_user_profile(self, sender, instance, created, **kwargs):
         if not created:
             return

--- a/go/billing/management/commands/go_archive_transactions.py
+++ b/go/billing/management/commands/go_archive_transactions.py
@@ -34,17 +34,14 @@ class Command(BaseGoCommand):
         account_number = user.get_profile().user_account
         account = Account.objects.get(account_number=account_number)
 
-        from_date = parse_date(opts['from_date'], default_timezone=None)
-        to_date = parse_date(opts['to_date'], default_timezone=None)
+        from_date = parse_date(opts['from_date']).date()
+        to_date = parse_date(opts['to_date']).date()
         delete = opts['delete']
 
         archive = archive_transactions(
             account.id, from_date, to_date, delete=delete)
 
         self.stdout.write(
-            "Transactions archived for account %s from %s to %s"
-            % (opts['email_address'], archive.from_date, archive.to_date))
-        self.stdout.write(
-            "Archived to S3 as %s." % (archive.filename,))
-        self.stdout.write(
-            "Archive status is: %s." % (archive.status,))
+            "Transactions archived for account %s." % (opts['email_address'],))
+        self.stdout.write("Archived to S3 as %s." % (archive.filename,))
+        self.stdout.write("Archive status is: %s." % (archive.status,))

--- a/go/billing/management/commands/go_archive_transactions.py
+++ b/go/billing/management/commands/go_archive_transactions.py
@@ -1,0 +1,50 @@
+from iso8601 import parse_date
+from optparse import make_option
+
+from go.billing.models import Account
+from go.billing.tasks import archive_transactions
+from go.base.command_utils import BaseGoCommand, get_user_by_email
+
+
+class Command(BaseGoCommand):
+    help = (
+        "Archive transactions for an account over a "
+        "specified time range to S3.")
+
+    option_list = BaseGoCommand.option_list + (
+        make_option(
+            '--email-address', dest='email_address',
+            help="Email address of the account to archive transactions for."),
+        make_option(
+            '--from', dest='from_date',
+            help=("Date to start archiving transactions from in iso8601"
+                  " format. E.g. 2014-03-01.")),
+        make_option(
+            '--to', dest='to_date',
+            help=("Date to stop archiving transactions at in iso8601"
+                  " format. E.g. 2014-03-30.")),
+        make_option(
+            '--delete', dest='delete', action="store_true", default=False,
+            help=("Delete the transactions after uploading the archive."
+                  " Default: FALSE.")),
+    )
+
+    def handle(self, *args, **opts):
+        user = get_user_by_email(opts['email_address'])
+        account_number = user.get_profile().user_account
+        account = Account.objects.get(account_number=account_number)
+
+        from_date = parse_date(opts['from_date'], default_timezone=None)
+        to_date = parse_date(opts['to_date'], default_timezone=None)
+        delete = opts['delete']
+
+        archive = archive_transactions(
+            account.id, from_date, to_date, delete=delete)
+
+        self.stdout.write(
+            "Transactions archived for account %s from %s to %s"
+            % (opts['email_address'], archive.from_date, archive.to_date))
+        self.stdout.write(
+            "Archived to S3 as %s." % (archive.filename,))
+        self.stdout.write(
+            "Archive status is: %s." % (archive.status,))

--- a/go/billing/tests/helpers.py
+++ b/go/billing/tests/helpers.py
@@ -34,7 +34,8 @@ def mk_transaction(account, tag_pool_name='pool1',
                    message_direction=MessageCost.DIRECTION_INBOUND,
                    message_cost=100, markup_percent=10.0,
                    credit_factor=0.25, credit_amount=28,
-                   status=Transaction.STATUS_COMPLETED, **kwargs):
+                   status=Transaction.STATUS_COMPLETED,
+                   created=None, **kwargs):
     transaction = Transaction(
         account_number=account.account_number,
         tag_pool_name=tag_pool_name,
@@ -47,6 +48,11 @@ def mk_transaction(account, tag_pool_name='pool1',
         status=status, **kwargs)
 
     transaction.save()
+    if created is not None:
+        # a double-save is needed here because auto_now_add overrides created
+        # when the transaction is first saved.
+        transaction.created = created
+        transaction.save()
     return transaction
 
 

--- a/go/billing/tests/test_go_archive_transactions.py
+++ b/go/billing/tests/test_go_archive_transactions.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+import moto
+
+from django.core.management import call_command
+
+from go.base.tests.helpers import (
+    GoDjangoTestCase, DjangoVumiApiHelper, CommandIO)
+from go.billing.models import Account, Transaction, TransactionArchive
+from go.billing.tests.helpers import mk_transaction, this_month
+
+
+class TestArchiveTransactions(GoDjangoTestCase):
+    def setUp(self):
+        self.vumi_helper = self.add_helper(DjangoVumiApiHelper())
+        self.user_helper = self.vumi_helper.make_django_user()
+
+        user = self.user_helper.get_django_user()
+        self.user_email = user.email
+
+        account_number = user.get_profile().user_account
+        self.account = Account.objects.get(account_number=account_number)
+
+    def run_command(self, **kw):
+        cmd = CommandIO()
+        call_command(
+            'go_archive_transactions',
+            stdout=cmd.stdout,
+            stderr=cmd.stderr,
+            **kw)
+        return cmd
+
+    def assert_remaining_transactions(self, transactions):
+        self.assertEqual(
+            set(Transaction.objects.all()), set(transactions))
+
+    @moto.mock_s3
+    def test_archive_transactions_without_deletion(self):
+        bucket = self.vumi_helper.patch_s3_bucket_settings(
+            'billing.archive', s3_bucket_name='billing')
+        bucket.create()
+
+        from_time = datetime(2014, 12, 1)
+        from_date, to_date = this_month(from_time.date())
+        transaction_1 = mk_transaction(self.account, created=from_date)
+        transaction_2 = mk_transaction(self.account, created=to_date)
+
+        cmd = self.run_command(
+            email_address=self.user_email,
+            from_date='2014-12-01',
+            to_date='2014-12-31')
+
+        self.assertEqual(cmd.stderr.getvalue(), "")
+        self.assertEqual(cmd.stdout.getvalue().splitlines(), [
+            'Transactions archived for account user@domain.com'
+            ' from 2014-12-01 00:00:00 to 2014-12-31 00:00:00',
+            'Archived to S3 as'
+            ' transactions-test-0-user-2014-12-01 00:00:00'
+            '-to-2014-12-31 00:00:00.json.',
+            'Archive status is: transactions_uploaded.'
+        ])
+
+        self.assert_remaining_transactions([transaction_1, transaction_2])
+
+        archive = TransactionArchive.objects.get(account=self.account)
+        self.assertEqual(
+            archive.status, TransactionArchive.STATUS_TRANSACTIONS_UPLOADED)
+        self.assertEqual(archive.from_date, from_date)
+        self.assertEqual(archive.to_date, to_date)
+
+        s3_bucket = bucket.get_s3_bucket()
+        [s3_key] = list(s3_bucket.list())
+        self.assertEqual(s3_key.key, archive.filename)
+
+    @moto.mock_s3
+    def test_archive_transactions_with_deletion(self):
+        bucket = self.vumi_helper.patch_s3_bucket_settings(
+            'billing.archive', s3_bucket_name='billing')
+        bucket.create()
+
+        from_time = datetime(2014, 12, 1)
+        from_date, to_date = this_month(from_time.date())
+        mk_transaction(self.account, created=from_date)
+        mk_transaction(self.account, created=to_date)
+
+        cmd = self.run_command(
+            email_address=self.user_email,
+            from_date='2014-12-01',
+            to_date='2014-12-31',
+            delete=True)
+
+        self.assertEqual(cmd.stderr.getvalue(), "")
+        self.assertEqual(cmd.stdout.getvalue().splitlines(), [
+            'Transactions archived for account user@domain.com'
+            ' from 2014-12-01 00:00:00 to 2014-12-31 00:00:00',
+            'Archived to S3 as'
+            ' transactions-test-0-user-2014-12-01 00:00:00'
+            '-to-2014-12-31 00:00:00.json.',
+            'Archive status is: archive_completed.'
+        ])
+
+        self.assert_remaining_transactions([])
+
+        archive = TransactionArchive.objects.get(account=self.account)
+        self.assertEqual(
+            archive.status, TransactionArchive.STATUS_ARCHIVE_COMPLETED)
+        self.assertEqual(archive.from_date, from_date)
+        self.assertEqual(archive.to_date, to_date)
+
+        s3_bucket = bucket.get_s3_bucket()
+        [s3_key] = list(s3_bucket.list())
+        self.assertEqual(s3_key.key, archive.filename)

--- a/go/billing/tests/test_go_archive_transactions.py
+++ b/go/billing/tests/test_go_archive_transactions.py
@@ -54,11 +54,9 @@ class TestArchiveTransactions(GoDjangoTestCase):
 
         self.assertEqual(cmd.stderr.getvalue(), "")
         self.assertEqual(cmd.stdout.getvalue().splitlines(), [
-            'Transactions archived for account user@domain.com'
-            ' from 2014-12-01 00:00:00 to 2014-12-31 00:00:00',
+            'Transactions archived for account user@domain.com.',
             'Archived to S3 as'
-            ' transactions-test-0-user-2014-12-01 00:00:00'
-            '-to-2014-12-31 00:00:00.json.',
+            ' transactions-test-0-user-2014-12-01-to-2014-12-31.json.',
             'Archive status is: transactions_uploaded.'
         ])
 
@@ -93,11 +91,9 @@ class TestArchiveTransactions(GoDjangoTestCase):
 
         self.assertEqual(cmd.stderr.getvalue(), "")
         self.assertEqual(cmd.stdout.getvalue().splitlines(), [
-            'Transactions archived for account user@domain.com'
-            ' from 2014-12-01 00:00:00 to 2014-12-31 00:00:00',
+            'Transactions archived for account user@domain.com.',
             'Archived to S3 as'
-            ' transactions-test-0-user-2014-12-01 00:00:00'
-            '-to-2014-12-31 00:00:00.json.',
+            ' transactions-test-0-user-2014-12-01-to-2014-12-31.json.',
             'Archive status is: archive_completed.'
         ])
 

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -326,9 +326,7 @@ class TestArchiveTransactionsTask(GoDjangoTestCase):
         from_time = datetime(2013, 11, 1)
         from_date, to_date = this_month(from_time.date())
 
-        transaction = mk_transaction(self.account)
-        transaction.created = from_time
-        transaction.save()
+        transaction = mk_transaction(self.account, created=from_time)
 
         result = tasks.archive_transactions(
             self.account.id, from_date, to_date)
@@ -359,9 +357,7 @@ class TestArchiveTransactionsTask(GoDjangoTestCase):
         def mk_transaction_set(n, created):
             transaction_set = set()
             for i in range(5):
-                transaction = mk_transaction(self.account)
-                transaction.created = created
-                transaction.save()
+                transaction = mk_transaction(self.account, created=created)
                 transaction_set.add(transaction)
             return transaction_set
 


### PR DESCRIPTION
Similar to the one in #1083 that handles statement generation.

This should support archiving to S3 but not deleting the transactions (for carefully trying things out in production).
