### PR TITLE
Enable gzipped uploads during transaction archival.

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -280,7 +280,7 @@ def archive_transactions(account_id, from_date, to_date, delete=True):
         status=TransactionArchive.STATUS_ARCHIVE_CREATED)
     archive.save()
 
-    bucket.upload(filename, chunks, headers={
+    bucket.upload(filename, chunks, gzip=True, headers={
         'Content-Type': 'appliation/json; charset=utf-8',
     })
 

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
+import gzip
 import json
+import StringIO
 
 import mock
 import moto
@@ -14,6 +16,11 @@ from go.billing.django_utils import TransactionSerializer
 from go.billing.tests.helpers import (
     this_month, mk_transaction, get_message_credits,
     get_session_credits, get_line_items)
+
+
+def gunzip(data):
+    """ Gunzip data. """
+    return gzip.GzipFile(fileobj=StringIO.StringIO(data)).read()
 
 
 class TestUtilityFunctions(GoDjangoTestCase):
@@ -272,7 +279,7 @@ class TestArchiveTransactionsTask(GoDjangoTestCase):
     def assert_archive_in_s3(self, bucket, filename, transactions):
         s3_bucket = bucket.get_s3_bucket()
         key = s3_bucket.get_key(filename)
-        data = key.get_contents_as_string().split("\n")
+        data = gunzip(key.get_contents_as_string()).split("\n")
         # check for final newline
         self.assertEqual(data[-1], "")
         # construct expected JSON


### PR DESCRIPTION
#1085 adds support for gzipped s3 uploads. This ticket is to used gzipped uploads from the `archive_transactions` billing task.
