### PR TITLE
Prefix billing route names

### DIFF
--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -147,7 +147,7 @@ class StatementAdmin(admin.ModelAdmin):
 
     def view_html(self, obj):
         return format_html('<a href="{0}">html</a>', urlresolvers.reverse(
-            'html_statement', kwargs={'statement_id': obj.id}))
+            'billing:html_statement', kwargs={'statement_id': obj.id}))
     view_html.short_description = "HTML"
 
 

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -24,7 +24,7 @@ class TestStatementView(GoDjangoTestCase):
     def get_statement(self, username, statement):
         client = self.vumi_helper.get_client(username=username)
         return client.get(
-            reverse('html_statement', kwargs={'statement_id': statement.id}))
+            reverse('billing:html_statement', kwargs={'statement_id': statement.id}))
 
     def check_statement_accessible_by(self, username, statement):
         response = self.get_statement(username, statement)

--- a/go/urls.py
+++ b/go/urls.py
@@ -38,7 +38,7 @@ urlpatterns = patterns(
     url(r'^contacts/', include('go.contacts.urls', namespace='contacts')),
     url(r'^account/', include('go.account.urls', namespace='account')),
     url(r'^accounts/', include('registration.backends.default.urls')),
-    url(r'^billing/', include('go.billing.urls')),
+    url(r'^billing/', include('go.billing.urls', namespace='billing')),
 
     url(r'^routing/$', 'go.routing.views.routing', name='routing'),
 


### PR DESCRIPTION
At the moment, we just refer to the route names directly, for eg, `html_statement`, as opposed to `billing:html_statement`.
