### PR TITLE
Move credits to own list item

### DIFF
--- a/go/templates/app.html
+++ b/go/templates/app.html
@@ -35,7 +35,7 @@
             {% if request.user.is_authenticated %}
             <li class="dropdown">
                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                    Account ({% credit_balance request.user %})
+                    Account
                     <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu" role="menu">
@@ -47,6 +47,7 @@
                     <li><a href="{% url 'auth_logout' %}">Logout</a></li>
                 </ul>
             </li>
+            <li><a href="{% url 'account:billing' %}">{% credit_balance request.user %}</a></li>
             {% endif %}
         </ul>
     </nav>


### PR DESCRIPTION
After a chat with @jerith (thanks!), moved `100,000,000 credits` to it's own bit.
He said that 

> Help | Account (100,000,000 credits) >

could be confusing since it looks like the drop down is for credits (rather than account). I agree. New version:

> Help | Account > | 100,000,000 credits

Looks like this: https://www.dropbox.com/s/zg3b2bm2swwoaa9/Screenshot%202014-12-09%2006.32.31.png?dl=0

Also made it a link to `/account/billing/`.

_/me edits for clarity_
