### PR TITLE
Write transport messages to message store in RTD

### DIFF
--- a/go/vumitools/routing.py
+++ b/go/vumitools/routing.py
@@ -4,7 +4,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet import reactor
 
 from vumi.dispatchers.endpoint_dispatchers import RoutingTableDispatcher
-from vumi.config import ConfigDict, ConfigText, ConfigFloat
+from vumi.config import ConfigDict, ConfigText, ConfigFloat, ConfigBool
 from vumi.message import TransportEvent
 from vumi import log
 
@@ -288,6 +288,10 @@ class AccountRoutingTableDispatcherConfig(RoutingTableDispatcher.CONFIG_CLASS,
         "TTL (in seconds) for cached routing tables. If less than or equal to"
         " zero, routing tables will not be cached.",
         static=True, default=5)
+    store_messages_to_transports = ConfigBool(
+        "If true (the default), outbound messages to transports will be"
+        " written to the message store.",
+        static=True, default=True)
 
 
 class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
@@ -688,9 +692,16 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
 
         # We skip the store code in `process_outbound()` if billing is enabled,
         # so we need to duplicate it here.
-        yield self.vumi_api.mdb.add_outbound_message(msg)
+        yield self.store_outbound_transport_message(msg)
 
         yield self.publish_outbound(msg, dst_connector_name, dst_endpoint)
+
+    def store_outbound_transport_message(self, msg):
+        """
+        Add an outbound message to the message store if configured to do so.
+        """
+        if self.get_static_config().store_messages_to_transports:
+            return self.vumi_api.mdb.add_outbound_message(msg)
 
     @inlineCallbacks
     def handle_unroutable_inbound_message(self, f, msg, connector_name):
@@ -839,7 +850,7 @@ class AccountRoutingTableDispatcher(RoutingTableDispatcher, GoWorkerMixin):
         if target_conn.ctype == target_conn.TRANSPORT_TAG:
             # This code is only reached if billing is disabled. There's a
             # separate code path for messages from billing to transports.
-            yield self.vumi_api.mdb.add_outbound_message(msg)
+            yield self.store_outbound_transport_message(msg)
 
         yield self.publish_outbound(msg, dst_connector_name, dst_endpoint)
 

--- a/go/vumitools/tests/test_routing.py
+++ b/go/vumitools/tests/test_routing.py
@@ -464,6 +464,7 @@ class RoutingTableDispatcherTestCase(VumiTestCase):
             "CONVERSATION:app1:conv1": {
                 "default": ["TRANSPORT_TAG:pool1:1234", "default"],
                 "other": ["TRANSPORT_TAG:pool1:5678", "default"],
+                "router": ["ROUTER:router:router1:OUTBOUND", "default"],
             },
             "CONVERSATION:app2:conv2": {
                 "default": ["TRANSPORT_TAG:pool1:9012", "default"],
@@ -916,6 +917,56 @@ class TestRoutingTableDispatcher(RoutingTableDispatcherTestCase):
         ])
         self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
 
+    @inlineCallbacks
+    def test_outbound_message_gets_stored_before_transport(self):
+        """
+        Outbound messages going to transports are stored.
+        """
+        yield self.get_dispatcher()
+        msg = self.with_md(
+            self.msg_helper.make_outbound("foo"), conv=('app1', 'conv1'))
+
+        mdb = self.vumi_helper.get_vumi_api().mdb
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, None)
+
+        yield self.dispatch_outbound(msg, 'app1')
+        self.assert_rkeys_used('app1.outbound', 'sphex.outbound')
+        self.with_md(msg, tag=("pool1", "1234"), hops=[
+            ['CONVERSATION:app1:conv1', 'default'],
+            ['TRANSPORT_TAG:pool1:1234', 'default'],
+        ])
+        self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
+
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, msg)
+
+    @inlineCallbacks
+    def test_outbound_message_does_not_get_stored_before_router(self):
+        """
+        Outbound messages going to routers are not stored.
+        """
+        yield self.get_dispatcher()
+        msg = self.with_md(
+            self.msg_helper.make_outbound("foo"), conv=('app1', 'conv1'),
+            endpoint="router")
+
+        mdb = self.vumi_helper.get_vumi_api().mdb
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, None)
+
+        yield self.dispatch_outbound(msg, 'app1')
+        self.assert_rkeys_used('app1.outbound', 'router_ro.outbound')
+        self.with_md(
+            msg, router=("router", "router1"), endpoint="default", hops=[
+                ['CONVERSATION:app1:conv1', 'router'],
+                ['ROUTER:router:router1:OUTBOUND', 'default'],
+            ])
+        self.assertEqual([msg], self.get_dispatched_outbound('router_ro'))
+
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, None)
+
 
 class TestRoutingTableDispatcherWithBilling(RoutingTableDispatcherTestCase):
 
@@ -1155,6 +1206,62 @@ class TestRoutingTableDispatcherWithBilling(RoutingTableDispatcherTestCase):
         yield self.dispatch_inbound(msg, 'billing_dispatcher_ro')
         self.assert_unroutable_reply(
             'billing_dispatcher_ro', msg, "Eep!", tag=("pool1", "unowned-tag"))
+
+    @inlineCallbacks
+    def test_outbound_message_gets_stored_before_transport(self):
+        """
+        Outbound messages going to transports are stored.
+        """
+        yield self.get_dispatcher()
+        msg = self.with_md(
+            self.msg_helper.make_outbound("foo"), tag=("pool1", "1234"),
+            conv=('app1', 'conv1'), is_paid=True)
+
+        mdb = self.vumi_helper.get_vumi_api().mdb
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, None)
+
+        yield self.dispatch_outbound(msg, 'billing_dispatcher_ri')
+        self.assert_rkeys_used(
+            'billing_dispatcher_ri.outbound', 'sphex.outbound')
+
+        hops = [
+            ['BILLING:INBOUND', 'default'],
+            ['TRANSPORT_TAG:pool1:1234', 'default']
+        ]
+        self.with_md(msg, hops=hops)
+        self.assertEqual([msg], self.get_dispatched_outbound('sphex'))
+
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, msg)
+
+    @inlineCallbacks
+    def test_outbound_message_does_not_get_stored_before_billing(self):
+        """
+        Outbound messages going to billing are not stored.
+        """
+        yield self.get_dispatcher()
+        msg = self.with_md(
+            self.msg_helper.make_outbound("foo"), conv=('app1', 'conv1'))
+
+        mdb = self.vumi_helper.get_vumi_api().mdb
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, None)
+
+        yield self.dispatch_outbound(msg, 'app1')
+        self.assert_rkeys_used(
+            'app1.outbound', 'billing_dispatcher_ro.outbound')
+
+        hops = [
+            ['CONVERSATION:app1:conv1', 'default'],
+            ['BILLING:OUTBOUND', 'default'],
+        ]
+        self.with_md(msg, tag=("pool1", "1234"), hops=hops)
+        self.assertEqual(
+            [msg], self.get_dispatched_outbound('billing_dispatcher_ro'))
+
+        stored_msg = yield mdb.get_outbound_message(msg["message_id"])
+        self.assertEqual(stored_msg, None)
 
 
 class TestUnroutableSessionResponse(RoutingTableDispatcherTestCase):


### PR DESCRIPTION
The routing table dispatcher relies on stored outbound messages containing full routing information for its ability to route events back along the same path the outbound messages took. We currently rely on middleware to store these messages, but that's inefficient if the middleware is on the dispatchers (because we're storing messages unnecessarily) and a latency and reliability risk if the middleware is on the transport (because we lose the concurrency from the number of RTD workers and it's easy to misconfigure individual transports).

Given this, it seems reasonable for the routing table dispatcher to write each message to the message store before publishing it to a transport. (We probably also need a config option to disable the write in case we need to switch back to middleware for some reason.)

We can't do a similar write for messages to conversations and routers because the RTD doesn't load those objects and therefore can't include batch information.
