### PR TITLE
Display statement costs in dollars

### DIFF
--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -8,6 +8,9 @@ from go.config import billing_quantization_exponent
 SYSTEM_BILLER_NAME = getattr(
     settings, 'BILLING_SYSTEM_BILLER_NAME', 'Vumi')
 
+DOLLAR_FORMAT = getattr(
+    settings, 'BILLING_DOLLAR_FORMAT', '%.3f')
+
 # 10 credits = 1 US cent
 CREDIT_CONVERSION_FACTOR = getattr(
     settings, 'BILLING_CREDIT_CONVERSION_FACTOR', Decimal('10.00'))

--- a/go/billing/templates/billing/invoice.html
+++ b/go/billing/templates/billing/invoice.html
@@ -1,4 +1,5 @@
 {% load compressed %}
+{% load billing_tags %}
 
 <!DOCTYPE html>
 <html>
@@ -61,8 +62,8 @@
                             <td>{% if item.description != None %}{{ item.description }}{% endif %}</th>
                             <td>{{ item.units }}</th>
                             <td>{% if item.credits != None %}{{ item.credits }}{% endif %}</th>
-                            <td>{{ item.unit_cost|floatformat:2 }}</th>
-                            <td>{{ item.cost|floatformat:2 }}
+                            <td>{{ item.unit_cost|dollars }}</th>
+                            <td>{{ item.cost|dollars }}
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -72,7 +73,7 @@
                             <td></td>
                             <td>{{ section.totals.credits }}</td>
                             <td></td>
-                            <td>{{ section.totals.cost|floatformat:2 }}</td>
+                            <td>{{ section.totals.cost|dollars }}</td>
                         </tr>
                     </tfoot>
                 </table>
@@ -94,7 +95,7 @@
                         <td></td>
                         <td>{{ totals.credits }}</td>
                         <td></td>
-                        <td>{{ totals.cost|floatformat:2 }}</td>
+                        <td>{{ totals.cost|dollars }}</td>
                     </tfoot>
                 </table>
             </div>

--- a/go/billing/templatetags/billing_tags.py
+++ b/go/billing/templatetags/billing_tags.py
@@ -1,5 +1,9 @@
+from decimal import Decimal
+
 from django import template
 from django.utils.translation import ungettext
+
+from go.billing import settings
 
 register = template.Library()
 
@@ -20,3 +24,11 @@ def credit_balance(user):
         "%(credit_balance)d credit",
         "%(credit_balance)d credits",
         credit_balance) % {'credit_balance': credit_balance}
+
+
+@register.filter
+def dollars(v):
+    """Returns a formatted dollar value from a decimal cents value (cents are
+    the billing system's internal representation for monetary amounts).
+    """
+    return settings.DOLLAR_FORMAT % (v / Decimal('100.0'),)

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -1,0 +1,14 @@
+from decimal import Decimal
+
+import mock
+from go.billing.templatetags.billing_tags import dollars
+from go.base.tests.helpers import GoDjangoTestCase
+
+
+class TestDollars(GoDjangoTestCase):
+    @mock.patch('go.billing.settings.DOLLAR_FORMAT', '%.3f')
+    def test_dollars(self):
+        self.assertEqual(dollars(Decimal('2')), '0.020')
+        self.assertEqual(dollars(Decimal('23')), '0.230')
+        self.assertEqual(dollars(Decimal('0.1')), '0.001')
+        self.assertEqual(dollars(Decimal('0.2')), '0.002')

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -101,6 +101,7 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertNotContains(response, '>None<')
 
+    @mock.patch('go.billing.settings.DOLLAR_FORMAT', '%.3f')
     def test_statement_costs(self):
         statement = self.mk_statement(items=[{
             'credits': 200,
@@ -112,8 +113,8 @@ class TestStatementView(GoDjangoTestCase):
         response = self.get_statement(user, statement)
 
         self.assertContains(response, '>200<')
-        self.assertContains(response, '>123.46<')
-        self.assertContains(response, '>679.01<')
+        self.assertContains(response, '>1.235<')
+        self.assertContains(response, '>6.790<')
 
     def test_statement_cost_nones(self):
         statement = self.mk_statement(items=[{


### PR DESCRIPTION
At the moment, we display statement costs in cents, but the titles suggest the amounts are in dollars.
