### PR TITLE
Handle non-existent tagpools when generating statements

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -73,7 +73,10 @@ def get_session_transactions(account, from_date, to_date):
 
 
 def get_provider_name(transaction, tagpools):
-    return tagpools.display_name(transaction['tag_pool_name'])
+    if transaction['tag_pool_name'] not in tagpools.pools():
+        return transaction['tag_pool_name']
+    else:
+        return tagpools.display_name(transaction['tag_pool_name'])
 
 
 def get_channel_name(transaction, tagpools):
@@ -117,8 +120,11 @@ def get_session_credits(transaction):
 
 
 def get_channel_type(transaction, tagpools):
-    delivery_class = tagpools.delivery_class(transaction['tag_pool_name'])
-    return tagpools.delivery_class_name(delivery_class)
+    if transaction['tag_pool_name'] not in tagpools.pools():
+        return None
+    else:
+        delivery_class = tagpools.delivery_class(transaction['tag_pool_name'])
+        return tagpools.delivery_class_name(delivery_class)
 
 
 def get_message_description(transaction):

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -119,6 +119,20 @@ class TestMonthlyStatementTask(GoDjangoTestCase):
         self.assertEqual(item.unit_cost, 100)
         self.assertEqual(item.cost, 200)
 
+    def test_generate_monthly_statement_unknown_tagpool(self):
+        mk_transaction(
+            self.account,
+            tag_name=u'unknown-tag',
+            tag_pool_name=u'unknown-tagpool',
+            message_direction=MessageCost.DIRECTION_INBOUND)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        [item] = get_line_items(statement).filter(billed_by='unknown-tagpool')
+        self.assertEqual(item.channel, 'unknown-tag')
+        self.assertEqual(item.channel_type, None)
+
     def test_generate_monthly_statement_outbound_messages(self):
         mk_transaction(
             self.account,


### PR DESCRIPTION
At the moment, statement generation breaks when transactions with now non-existent tagpools are encountered. The plan is to default to the tag pool name for the display name, and use 'unknown' as the channel type name.
