### PR TITLE
Handle 'None' costs and markups when generating statements

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -89,11 +89,13 @@ def get_channel_name(transaction, tagpools):
 
 
 def get_message_cost(transaction):
-    return transaction['total_message_cost']
+    cost = transaction['total_message_cost']
+    return cost if cost is not None else 0
 
 
 def get_session_cost(transaction):
-    return transaction['total_session_cost']
+    cost = transaction['total_session_cost']
+    return cost if cost is not None else 0
 
 
 def get_count(transaction):
@@ -113,14 +115,18 @@ def get_session_unit_cost(transaction):
 
 
 def get_message_credits(transaction):
-    cost = get_message_cost(transaction)
+    cost = transaction['total_message_cost']
     markup = transaction['markup_percent']
+    if cost is None or markup is None:
+        return None
     return MessageCost.calculate_message_credit_cost(cost, markup)
 
 
 def get_session_credits(transaction):
-    cost = get_session_cost(transaction)
+    cost = transaction['total_session_cost']
     markup = transaction['markup_percent']
+    if cost is None or markup is None:
+        return None
     return MessageCost.calculate_session_credit_cost(cost, markup)
 
 

--- a/go/billing/tests/helpers.py
+++ b/go/billing/tests/helpers.py
@@ -30,6 +30,10 @@ def this_month(day=None):
     return [start_of_month(day), end_of_month(day)]
 
 
+def maybe_decimal(v):
+    return Decimal(str(v)) if v is not None else None
+
+
 def get_billing_account(user_account):
     return Account.objects.get(user=user_account)
 
@@ -37,7 +41,7 @@ def get_billing_account(user_account):
 def mk_transaction(account, tag_pool_name='pool1',
                    tag_name="tag1",
                    message_direction=MessageCost.DIRECTION_INBOUND,
-                   message_cost=100, markup_percent=10.0,
+                   message_cost=100, session_cost=0, markup_percent=10.0,
                    credit_factor=0.25, credit_amount=28,
                    status=Transaction.STATUS_COMPLETED,
                    created=None, **kwargs):
@@ -46,9 +50,10 @@ def mk_transaction(account, tag_pool_name='pool1',
         tag_pool_name=tag_pool_name,
         tag_name=tag_name,
         message_direction=message_direction,
-        message_cost=message_cost,
-        markup_percent=Decimal(str(markup_percent)),
-        credit_factor=Decimal(str(credit_factor)),
+        message_cost=maybe_decimal(message_cost),
+        session_cost=maybe_decimal(session_cost),
+        markup_percent=maybe_decimal(markup_percent),
+        credit_factor=maybe_decimal(credit_factor),
         credit_amount=credit_amount,
         status=status, **kwargs)
 

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -284,6 +284,70 @@ class TestMonthlyStatementTask(GoDjangoTestCase):
         [item] = get_line_items(statement).filter(channel=u'tag2.1')
         self.assertEqual(item.billed_by, 'Pool 2')
 
+    def test_generate_monthly_statement_messages_none_message_cost(self):
+        mk_transaction(
+            self.account,
+            message_cost=None)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        [item] = get_line_items(statement).filter(
+            description='Messages received')
+
+        self.assertEqual(item.credits, None)
+        self.assertEqual(item.unit_cost, 0)
+        self.assertEqual(item.cost, 0)
+
+    def test_generate_monthly_statement_messages_none_markup(self):
+        mk_transaction(
+            self.account,
+            message_cost=100,
+            markup_percent=None)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        [item] = get_line_items(statement).filter(
+            description='Messages received')
+
+        self.assertEqual(item.credits, None)
+        self.assertEqual(item.unit_cost, 100)
+        self.assertEqual(item.cost, 100)
+
+    def test_generate_monthly_statement_sessions_none_session_cost(self):
+        mk_transaction(
+            self.account,
+            session_cost=None,
+            session_created=True)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        [item] = get_line_items(statement).filter(
+            description='Sessions')
+
+        self.assertEqual(item.credits, None)
+        self.assertEqual(item.unit_cost, 0)
+        self.assertEqual(item.cost, 0)
+
+    def test_generate_monthly_statement_sessions_none_markup(self):
+        mk_transaction(
+            self.account,
+            session_cost=100,
+            markup_percent=None,
+            session_created=True)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        [item] = get_line_items(statement).filter(
+            description='Sessions')
+
+        self.assertEqual(item.credits, None)
+        self.assertEqual(item.unit_cost, 100)
+        self.assertEqual(item.cost, 100)
+
 
 class TestArchiveTransactionsTask(GoDjangoTestCase):
 
@@ -445,7 +509,7 @@ class TestLowCreditNotificationTask(GoDjangoTestCase):
                                  + 'EmailBackend')
         self.user_helper = self.vumi_helper.make_django_user()
 
-    def mk_notification(self,  percent, balance):
+    def mk_notification(self, percent, balance):
         self.django_user = self.user_helper.get_django_user()
         self.acc = Account.objects.get(user=self.django_user)
         return tasks.create_low_credit_notification(


### PR DESCRIPTION
Transaction costs and markups can be `None`, we need to handle this when generating statements.
