### PR TITLE
Add option to abort archiving transactions if the equivalent statment has not yet been generated

### DIFF
--- a/go/billing/management/commands/go_archive_transactions.py
+++ b/go/billing/management/commands/go_archive_transactions.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from optparse import make_option
 
-from go.billing.models import Account
+from go.billing.models import Statement, Account
 from go.billing.tasks import month_range, archive_transactions
 from go.base.command_utils import BaseGoCommand, get_user_by_email
 
@@ -22,30 +22,65 @@ class Command(BaseGoCommand):
             '--delete', dest='delete', action="store_true", default=False,
             help=("Delete the transactions after uploading the archive."
                   " Default: FALSE.")),
-    )
+        make_option(
+            '--no-statement',
+            dest='no_statement', action="store_true", default=False,
+            help=("Aborts an archive if no equivalent billing statement is "
+                  "found. Default: TRUE.")))
+
+
+    def statement_exists(self, account, from_date, to_date):
+        statements = Statement.objects.filter(
+            account=account,
+            from_date=from_date,
+            to_date=to_date)
+
+        return statements.exists()
+
+    def missing_statement_months(self, account, months):
+        return [
+            m for m in months
+            if not self.statement_exists(account, *month_range(0, m))]
+
+    def archive_month_transactions(self, account, month, delete):
+        from_date, to_date = month_range(0, month)
+
+        archive = archive_transactions(
+            account.id, from_date, to_date, delete=delete)
+
+        self.stdout.write(
+            "Archiving transactions that occured in %s..."
+            % (datetime.strftime(month, '%Y-%m'),))
+
+        self.stdout.write("Archived to S3 as %s." % (archive.filename,))
+        self.stdout.write("Archive status is: %s." % (archive.status,))
+        self.stdout.write("")
+
+    def archive_transactions(self, account, months, delete):
+        for month in months:
+            self.archive_month_transactions(account, month, delete)
 
     def handle(self, *args, **opts):
         user = get_user_by_email(opts['email_address'])
         account_number = user.get_profile().user_account
         account = Account.objects.get(account_number=account_number)
 
-        delete = opts['delete']
         months = [datetime.strptime(m, '%Y-%m') for m in opts['months']]
 
-        self.stdout.write(
-            "Archiving transactions for account %s..."
-            % (opts['email_address'],))
+        if opts['no_statement']:
+            missing_months = []
+        else:
+            missing_months = self.missing_statement_months(account, months)
 
-        for month in months:
-            from_date, to_date = month_range(0, month)
+        if missing_months:
+            self.stderr.write(
+                "Aborting archiving, no statements found for the "
+                "following months:")
 
-            archive = archive_transactions(
-                account.id, from_date, to_date, delete=delete)
-
+            for m in missing_months:
+                self.stderr.write(datetime.strftime(m, '%Y-%m'))
+        else:
             self.stdout.write(
-                "Archiving transactions that occured in %s..."
-                % (datetime.strftime(month, '%Y-%m'),))
-
-            self.stdout.write("Archived to S3 as %s." % (archive.filename,))
-            self.stdout.write("Archive status is: %s." % (archive.status,))
-            self.stdout.write("")
+                "Archiving transactions for account %s..."
+                % (opts['email_address'],))
+            self.archive_transactions(account, months, opts['delete'])

--- a/go/billing/management/commands/go_archive_transactions.py
+++ b/go/billing/management/commands/go_archive_transactions.py
@@ -25,8 +25,8 @@ class Command(BaseGoCommand):
         make_option(
             '--no-statement',
             dest='no_statement', action="store_true", default=False,
-            help=("Aborts an archive if no equivalent billing statement is "
-                  "found. Default: TRUE.")))
+            help=("Allow transactions to be archived even if no equivalent "
+                  "billing statement is found. Default: FALSE.")))
 
 
     def statement_exists(self, account, from_date, to_date):

--- a/go/billing/tests/test_go_archive_transactions.py
+++ b/go/billing/tests/test_go_archive_transactions.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from go.base.tests.helpers import (
     GoDjangoTestCase, DjangoVumiApiHelper, CommandIO)
 from go.billing.models import Account, Transaction, TransactionArchive
-from go.billing.tests.helpers import mk_transaction, this_month
+from go.billing.tests.helpers import mk_statement, mk_transaction, this_month
 
 
 class TestArchiveTransactions(GoDjangoTestCase):
@@ -52,6 +52,16 @@ class TestArchiveTransactions(GoDjangoTestCase):
         bucket = self.vumi_helper.patch_s3_bucket_settings(
             'billing.archive', s3_bucket_name='billing')
         bucket.create()
+
+        mk_statement(
+            self.account,
+            from_date=datetime(2014, 11, 1),
+            to_date=datetime(2014, 11, 30))
+
+        mk_statement(
+            self.account,
+            from_date=datetime(2014, 12, 1),
+            to_date=datetime(2014, 12, 31))
 
         transactions = self.mk_monthly_transactions(
             datetime(2014, 11, 1),
@@ -104,6 +114,16 @@ class TestArchiveTransactions(GoDjangoTestCase):
             'billing.archive', s3_bucket_name='billing')
         bucket.create()
 
+        mk_statement(
+            self.account,
+            from_date=datetime(2014, 11, 1),
+            to_date=datetime(2014, 11, 30))
+
+        mk_statement(
+            self.account,
+            from_date=datetime(2014, 12, 1),
+            to_date=datetime(2014, 12, 31))
+
         self.mk_monthly_transactions(
             datetime(2014, 11, 1),
             datetime(2014, 12, 1))
@@ -149,3 +169,33 @@ class TestArchiveTransactions(GoDjangoTestCase):
 
         self.assertEqual(nov_s3_key.key, nov_archive.filename)
         self.assertEqual(dec_s3_key.key, dec_archive.filename)
+
+    @moto.mock_s3
+    def test_archive_transactions_no_statement(self):
+        bucket = self.vumi_helper.patch_s3_bucket_settings(
+            'billing.archive', s3_bucket_name='billing')
+        bucket.create()
+
+        mk_statement(
+            self.account,
+            from_date=datetime(2014, 11, 1),
+            to_date=datetime(2014, 11, 30))
+
+        transactions = self.mk_monthly_transactions(
+            datetime(2014, 10, 1),
+            datetime(2014, 11, 1),
+            datetime(2014, 12, 1))
+
+        cmd = self.run_command(
+            email_address=self.user_email,
+            months=['2014-10', '2014-11', '2014-12'],
+            delete=True)
+
+        self.assertEqual(cmd.stderr.getvalue().splitlines(), [
+            'Aborting archiving, no statements found for the following months:',
+            '2014-10',
+            '2014-12'
+        ])
+
+        self.assert_remaining_transactions(transactions)
+        self.assertEqual(list(bucket.get_s3_bucket().list()), [])


### PR DESCRIPTION
If would be useful if the management command for archiving transacations refused to archive them unless the associated statement had already been generated.

I'm also sort of wondering whether it wouldn't have been better for archiving functions to take a statement as input instead of a date range (i.e. to always require a statement). Probably we just want a helper function that does this?
