### PR TITLE
Configurable message length limit for HTTP API

### DIFF
--- a/go/apps/http_api/tests/test_views.py
+++ b/go/apps/http_api/tests/test_views.py
@@ -46,7 +46,7 @@ class TestHttpApiViews(GoDjangoTestCase):
                 'metric_store': 'foo_metric_store',
                 'ignore_events': False,
                 'ignore_messages': False,
-
+                'content_length_limit': None,
             }
         })
 
@@ -70,7 +70,7 @@ class TestHttpApiViews(GoDjangoTestCase):
                 'metric_store': 'foo_metric_store',
                 'ignore_events': False,
                 'ignore_messages': False,
-
+                'content_length_limit': None,
             }
         })
         self.assertEqual(conversation.config, {})
@@ -99,10 +99,62 @@ class TestHttpApiViews(GoDjangoTestCase):
                 'metric_store': 'foo_metric_store',
                 'ignore_events': False,
                 'ignore_messages': False,
-
+                'content_length_limit': None,
             }
         })
         self.assertEqual(conversation.config, {})
         response = self.client.get(conv_helper.get_view_url('edit'))
         self.assertContains(response, 'foo_metric_store')
         self.assertEqual(response.status_code, 200)
+
+    def test_edit_view_content_length_limit(self):
+        conv_helper = self.app_helper.create_conversation_helper()
+        conversation = conv_helper.get_conversation()
+        self.assertEqual(conversation.config, {})
+        response = self.client.post(conv_helper.get_view_url('edit'), {
+            'http_api-api_tokens': 'token',
+            'http_api-push_message_url': 'http://messages/',
+            'http_api-push_event_url': 'http://events/',
+            'http_api-metric_store': 'foo_metric_store',
+            'http_api-content_length_limit': '160',
+        })
+        self.assertRedirects(response, conv_helper.get_view_url('show'))
+
+        reloaded_conv = conv_helper.get_conversation()
+        self.assertEqual(reloaded_conv.config, {
+            'http_api': {
+                'push_event_url': 'http://events/',
+                'push_message_url': 'http://messages/',
+                'api_tokens': ['token'],
+                'metric_store': 'foo_metric_store',
+                'ignore_events': False,
+                'ignore_messages': False,
+                'content_length_limit': 160,
+            }
+        })
+
+        # Now unset the limit
+        response = self.client.get(conv_helper.get_view_url('edit'))
+        self.assertContains(response, '160')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.post(conv_helper.get_view_url('edit'), {
+            'http_api-api_tokens': 'token',
+            'http_api-push_message_url': 'http://messages/',
+            'http_api-push_event_url': 'http://events/',
+            'http_api-metric_store': 'foo_metric_store',
+            'http_api-content_length_limit': '',
+        })
+        self.assertRedirects(response, conv_helper.get_view_url('show'))
+
+        reloaded_conv = conv_helper.get_conversation()
+        self.assertEqual(reloaded_conv.config, {
+            'http_api': {
+                'push_event_url': 'http://events/',
+                'push_message_url': 'http://messages/',
+                'api_tokens': ['token'],
+                'metric_store': 'foo_metric_store',
+                'ignore_events': False,
+                'ignore_messages': False,
+                'content_length_limit': None,
+            }
+        })

--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -277,7 +277,60 @@ class TestStreamingHTTPWorker(VumiTestCase):
         self.assertEqual(sent_msg['from_addr'], None)
 
     @inlineCallbacks
-    def test_in_send_to_with_evil_content(self):
+    def test_send_to_within_content_length_limit(self):
+        self.conversation.config['http_api'].update({
+            'content_length_limit': 182,
+        })
+        yield self.conversation.save()
+
+        msg = {
+            'content': 'foo',
+            'to_addr': '+1234',
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(url, json.dumps(msg),
+                                           self.auth_headers, method='PUT')
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
+        put_msg = json.loads(response.delivered_body)
+        self.assertEqual(response.code, http.OK)
+
+        [sent_msg] = self.app_helper.get_dispatched_outbound()
+        self.assertEqual(sent_msg['to_addr'], put_msg['to_addr'])
+        self.assertEqual(sent_msg['helper_metadata'], {
+            'go': {
+                'conversation_key': self.conversation.key,
+                'conversation_type': 'http_api',
+                'user_account': self.conversation.user_account.key,
+            },
+        })
+        self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
+        self.assertEqual(sent_msg['session_event'], None)
+        self.assertEqual(sent_msg['to_addr'], '+1234')
+        self.assertEqual(sent_msg['from_addr'], None)
+
+    @inlineCallbacks
+    def test_send_to_content_too_long(self):
+        self.conversation.config['http_api'].update({
+            'content_length_limit': 10,
+        })
+        yield self.conversation.save()
+
+        msg = {
+            'content': "This message is longer than 10 characters.",
+            'to_addr': '+1234',
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(
+            url, json.dumps(msg), self.auth_headers, method='PUT')
+        self.assert_bad_request(
+            response, "Payload content too long: 42 > 10")
+
+    @inlineCallbacks
+    def test_send_to_with_evil_content(self):
         msg = {
             'content': 0xBAD,
             'to_addr': '+1234',
@@ -290,7 +343,7 @@ class TestStreamingHTTPWorker(VumiTestCase):
             response, "Invalid or missing value for payload key 'content'")
 
     @inlineCallbacks
-    def test_in_send_to_with_evil_to_addr(self):
+    def test_send_to_with_evil_to_addr(self):
         msg = {
             'content': 'good',
             'to_addr': 1234,
@@ -335,6 +388,65 @@ class TestStreamingHTTPWorker(VumiTestCase):
         self.assertEqual(sent_msg['session_event'], None)
         self.assertEqual(sent_msg['to_addr'], inbound_msg['from_addr'])
         self.assertEqual(sent_msg['from_addr'], '9292')
+
+    @inlineCallbacks
+    def test_in_reply_to_within_content_length_limit(self):
+        self.conversation.config['http_api'].update({
+            'content_length_limit': 182,
+        })
+        yield self.conversation.save()
+
+        inbound_msg = yield self.app_helper.make_stored_inbound(
+            self.conversation, 'in 1', message_id='1')
+
+        msg = {
+            'content': 'foo',
+            'in_reply_to': inbound_msg['message_id'],
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(url, json.dumps(msg),
+                                           self.auth_headers, method='PUT')
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
+        put_msg = json.loads(response.delivered_body)
+        self.assertEqual(response.code, http.OK)
+
+        [sent_msg] = self.app_helper.get_dispatched_outbound()
+        self.assertEqual(sent_msg['to_addr'], put_msg['to_addr'])
+        self.assertEqual(sent_msg['helper_metadata'], {
+            'go': {
+                'conversation_key': self.conversation.key,
+                'conversation_type': 'http_api',
+                'user_account': self.conversation.user_account.key,
+            },
+        })
+        self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
+        self.assertEqual(sent_msg['session_event'], None)
+        self.assertEqual(sent_msg['to_addr'], inbound_msg['from_addr'])
+        self.assertEqual(sent_msg['from_addr'], '9292')
+
+    @inlineCallbacks
+    def test_in_reply_to_content_too_long(self):
+        self.conversation.config['http_api'].update({
+            'content_length_limit': 10,
+        })
+        yield self.conversation.save()
+
+        inbound_msg = yield self.app_helper.make_stored_inbound(
+            self.conversation, 'in 1', message_id='1')
+
+        msg = {
+            'content': "This message is longer than 10 characters.",
+            'in_reply_to': inbound_msg['message_id'],
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(
+            url, json.dumps(msg), self.auth_headers, method='PUT')
+        self.assert_bad_request(
+            response, "Payload content too long: 42 > 10")
 
     @inlineCallbacks
     def test_in_reply_to_with_evil_content(self):

--- a/go/apps/http_api/view_definition.py
+++ b/go/apps/http_api/view_definition.py
@@ -24,6 +24,10 @@ class TokenForm(forms.Form):
     metric_store = forms.CharField(
         help_text='Which store to publish metrics to.',
         required=False)
+    content_length_limit = forms.IntegerField(
+        help_text=('Optional content length limit. If set, messages with'
+                   ' content longer than this will be rejected.'),
+        required=False)
 
     @staticmethod
     def initial_from_config(data):
@@ -34,6 +38,7 @@ class TokenForm(forms.Form):
             'push_message_url': data.get('push_message_url', None),
             'push_event_url': data.get('push_event_url', None),
             'metric_store': data.get('metric_store', DEFAULT_METRIC_STORE),
+            'content_length_limit': data.get('content_length_limit', None),
         }
 
     def to_config(self):
@@ -43,6 +48,7 @@ class TokenForm(forms.Form):
             'push_message_url': data['push_message_url'] or None,
             'push_event_url': data['push_event_url'] or None,
             'metric_store': data.get('metric_store') or DEFAULT_METRIC_STORE,
+            'content_length_limit': data.get('content_length_limit', None),
             # The worker code checks these, but we don't provide config UI for
             # them. They should always be False.
             'ignore_events': False,

--- a/go/apps/http_api/vumi_app.py
+++ b/go/apps/http_api/vumi_app.py
@@ -72,8 +72,8 @@ class StreamingHTTPWorker(NoStreamingHTTPWorker):
     def get_conversation_resource(self):
         return AuthorizedResource(self, StreamingConversationResource)
 
-    def get_api_config(self, conversation, key, default=None):
-        return conversation.config.get('http_api', {}).get(key, default)
+    def get_all_api_config(self, conversation):
+        return conversation.config.get('http_api', {})
 
     def stream(self, stream_class, conversation_key, message):
         # Publish the message by manually specifying the routing key

--- a/go/apps/http_api_nostream/resource.py
+++ b/go/apps/http_api_nostream/resource.py
@@ -124,7 +124,7 @@ class MsgCheckHelpers(object):
         Check that the message content is within the configured length limit.
         """
         length_limit = api_config.get("content_length_limit")
-        if length_limit is not None:
+        if (length_limit is not None) and (payload["content"] is not None):
             content_length = len(payload["content"])
             if content_length > length_limit:
                 return "Payload content too long: %s > %s" % (

--- a/go/apps/http_api_nostream/resource.py
+++ b/go/apps/http_api_nostream/resource.py
@@ -127,7 +127,7 @@ class MsgCheckHelpers(object):
         if length_limit is not None:
             content_length = len(payload["content"])
             if content_length > length_limit:
-                return"Payload content too long: %s > %s" % (
+                return "Payload content too long: %s > %s" % (
                     content_length, length_limit)
         return None
 

--- a/go/apps/http_api_nostream/resource.py
+++ b/go/apps/http_api_nostream/resource.py
@@ -75,8 +75,9 @@ class MsgOptions(object):
     """Helper for sanitizing msg options from clients."""
 
     WHITELIST = {}
+    VALIDATION = ()
 
-    def __init__(self, payload):
+    def __init__(self, payload, api_config):
         self.errors = []
         for key, checker in sorted(self.WHITELIST.iteritems()):
             value = payload.get(key)
@@ -85,6 +86,11 @@ class MsgOptions(object):
                     "Invalid or missing value for payload key %r" % (key,))
             else:
                 setattr(self, key, value)
+
+        for checker in self.VALIDATION:
+            error = checker(payload, api_config)
+            if error is not None:
+                self.errors.append(error)
 
     @property
     def is_valid(self):
@@ -109,6 +115,22 @@ class MsgCheckHelpers(object):
     def is_session_event(value):
         return value in TransportUserMessage.SESSION_EVENTS
 
+    # The following checkers perform more complex validation based on the
+    # entire payload and the API config.
+
+    @staticmethod
+    def is_within_content_length_limit(payload, api_config):
+        """
+        Check that the message content is within the configured length limit.
+        """
+        length_limit = api_config.get("content_length_limit")
+        if length_limit is not None:
+            content_length = len(payload["content"])
+            if content_length > length_limit:
+                return"Payload content too long: %s > %s" % (
+                    content_length, length_limit)
+        return None
+
 
 class SendToOptions(MsgOptions):
     """Payload options for messages sent with `.send_to(...)`."""
@@ -118,6 +140,10 @@ class SendToOptions(MsgOptions):
         'to_addr': MsgCheckHelpers.is_unicode_or_none,
     }
 
+    VALIDATION = (
+        MsgCheckHelpers.is_within_content_length_limit,
+    )
+
 
 class ReplyToOptions(MsgOptions):
     """Payload options for messages sent with `.reply_to(...)`."""
@@ -126,6 +152,10 @@ class ReplyToOptions(MsgOptions):
         'content': MsgCheckHelpers.is_unicode_or_none,
         'session_event': MsgCheckHelpers.is_session_event,
     }
+
+    VALIDATION = (
+        MsgCheckHelpers.is_within_content_length_limit,
+    )
 
 
 class MessageResource(BaseResource):
@@ -197,7 +227,8 @@ class MessageResource(BaseResource):
             self.client_error_response(request, 'Invalid in_reply_to value')
             return
 
-        msg_options = ReplyToOptions(payload)
+        msg_options = ReplyToOptions(
+            payload, self.worker.get_all_api_config(conversation))
         if not msg_options.is_valid:
             self.client_error_response(request, msg_options.error_msg)
             return
@@ -218,7 +249,8 @@ class MessageResource(BaseResource):
         user_account = request.getUser()
         conversation = yield self.get_conversation(user_account)
 
-        msg_options = SendToOptions(payload)
+        msg_options = SendToOptions(
+            payload, self.worker.get_all_api_config(conversation))
         if not msg_options.is_valid:
             self.client_error_response(request, msg_options.error_msg)
             return

--- a/go/apps/http_api_nostream/tests/test_resource.py
+++ b/go/apps/http_api_nostream/tests/test_resource.py
@@ -1,6 +1,7 @@
 from twisted.trial.unittest import TestCase
 
-from go.apps.http_api_nostream.resource import MsgOptions
+from go.apps.http_api_nostream.resource import (
+    MsgOptions, SendToOptions, ReplyToOptions)
 
 
 def validate_even_not_multiple_of_odd(payload, api_config):
@@ -78,3 +79,75 @@ class TestMsgOptions(TestCase):
         )
         self.assert_no_attribute(opts, "even")
         self.assert_no_attribute(opts, "odd")
+
+
+class TestSendToOptions(TestCase):
+
+    def assert_no_attribute(self, obj, attr):
+        self.assertRaises(AttributeError, getattr, obj, attr)
+
+    def test_content_whitelist(self):
+        self.assertTrue(SendToOptions({"content": None}, {}).is_valid)
+        self.assertTrue(SendToOptions({"content": u"nicode"}, {}).is_valid)
+        self.assertFalse(SendToOptions({"content": "str"}, {}).is_valid)
+        self.assertFalse(SendToOptions({"content": 123}, {}).is_valid)
+
+    def test_to_addr_whitelist(self):
+        self.assertTrue(SendToOptions({"to_addr": None}, {}).is_valid)
+        self.assertTrue(SendToOptions({"to_addr": u"nicode"}, {}).is_valid)
+        self.assertFalse(SendToOptions({"to_addr": "str"}, {}).is_valid)
+        self.assertFalse(SendToOptions({"to_addr": 123}, {}).is_valid)
+
+    def test_white_listing(self):
+        opts = SendToOptions({"bad": 5}, {})
+        self.assertTrue(opts.is_valid)
+        self.assert_no_attribute(opts, "bad")
+
+    def test_content_length_validation(self):
+        self.assertTrue(SendToOptions({"content": None}, {}).is_valid)
+        self.assertTrue(SendToOptions({"content": u"12345"}, {}).is_valid)
+
+        opts = SendToOptions({"content": None}, {"content_length_limit": 5})
+        self.assertTrue(opts.is_valid)
+
+        opts = SendToOptions({"content": u"1234"}, {"content_length_limit": 4})
+        self.assertTrue(opts.is_valid)
+
+        opts = SendToOptions({"content": u"1234"}, {"content_length_limit": 3})
+        self.assertFalse(opts.is_valid)
+
+
+class TestReplyToOptions(TestCase):
+
+    def assert_no_attribute(self, obj, attr):
+        self.assertRaises(AttributeError, getattr, obj, attr)
+
+    def test_content_whitelist(self):
+        self.assertTrue(ReplyToOptions({"content": None}, {}).is_valid)
+        self.assertTrue(ReplyToOptions({"content": u"nicode"}, {}).is_valid)
+        self.assertFalse(ReplyToOptions({"content": "str"}, {}).is_valid)
+        self.assertFalse(ReplyToOptions({"content": 123}, {}).is_valid)
+
+    def test_session_event_whitelist(self):
+        self.assertTrue(ReplyToOptions({"session_event": None}, {}).is_valid)
+        self.assertTrue(ReplyToOptions({"session_event": "new"}, {}).is_valid)
+        self.assertFalse(ReplyToOptions({"session_event": "bar"}, {}).is_valid)
+        self.assertFalse(ReplyToOptions({"session_event": 123}, {}).is_valid)
+
+    def test_white_listing(self):
+        opts = ReplyToOptions({"bad": 5}, {})
+        self.assertTrue(opts.is_valid)
+        self.assert_no_attribute(opts, "bad")
+
+    def test_content_length_validation(self):
+        self.assertTrue(ReplyToOptions({"content": None}, {}).is_valid)
+        self.assertTrue(ReplyToOptions({"content": u"12345"}, {}).is_valid)
+
+        opts = ReplyToOptions({"content": None}, {"content_length_limit": 5})
+        self.assertTrue(opts.is_valid)
+
+        opts = ReplyToOptions({"content": u"123"}, {"content_length_limit": 3})
+        self.assertTrue(opts.is_valid)
+
+        opts = ReplyToOptions({"content": u"123"}, {"content_length_limit": 2})
+        self.assertFalse(opts.is_valid)

--- a/go/apps/http_api_nostream/tests/test_resource.py
+++ b/go/apps/http_api_nostream/tests/test_resource.py
@@ -3,11 +3,23 @@ from twisted.trial.unittest import TestCase
 from go.apps.http_api_nostream.resource import MsgOptions
 
 
+def validate_even_not_multiple_of_odd(payload, api_config):
+    factor = api_config.get("factor")
+    if factor is not None:
+        if payload["even"] == factor * payload["odd"]:
+            return "even == %s * odd" % (factor,)
+    return None
+
+
 class ToyMsgOptions(MsgOptions):
     WHITELIST = {
         "even": (lambda v: v is None or bool((v % 2) == 0)),
         "odd": (lambda v: v is None or bool((v % 2) == 1)),
     }
+
+    VALIDATION = (
+        validate_even_not_multiple_of_odd,
+    )
 
 
 class TestMsgOptions(TestCase):
@@ -16,7 +28,7 @@ class TestMsgOptions(TestCase):
         self.assertRaises(AttributeError, getattr, obj, attr)
 
     def test_no_errors(self):
-        opts = ToyMsgOptions({"even": 4, "odd": 5})
+        opts = ToyMsgOptions({"even": 4, "odd": 5}, {})
         self.assertTrue(opts.is_valid)
         self.assertEqual(opts.errors, [])
         self.assertEqual(opts.error_msg, None)
@@ -24,12 +36,22 @@ class TestMsgOptions(TestCase):
         self.assertEqual(opts.odd, 5)
 
     def test_white_listing(self):
-        opts = ToyMsgOptions({"bad": 5})
+        opts = ToyMsgOptions({"bad": 5}, {})
         self.assertTrue(opts.is_valid)
         self.assert_no_attribute(opts, "bad")
 
+    def test_validation_pass(self):
+        opts = ToyMsgOptions({"even": 4, "odd": 3}, {"factor": 2})
+        self.assertTrue(opts.is_valid)
+
+    def test_validation_fail(self):
+        opts = ToyMsgOptions({"even": 6, "odd": 3}, {"factor": 2})
+        self.assertFalse(opts.is_valid)
+        self.assertEqual(opts.errors, ["even == 2 * odd"])
+        self.assertEqual(opts.error_msg, "even == 2 * odd")
+
     def test_single_error(self):
-        opts = ToyMsgOptions({"even": 5, "odd": 7})
+        opts = ToyMsgOptions({"even": 5, "odd": 7}, {})
         self.assertFalse(opts.is_valid)
         self.assertEqual(opts.errors, [
             "Invalid or missing value for payload key 'even'",
@@ -42,7 +64,7 @@ class TestMsgOptions(TestCase):
         self.assertEqual(opts.odd, 7)
 
     def test_many_errors(self):
-        opts = ToyMsgOptions({"even": 3, "odd": 4})
+        opts = ToyMsgOptions({"even": 3, "odd": 4}, {})
         self.assertFalse(opts.is_valid)
         self.assertEqual(opts.errors, [
             "Invalid or missing value for payload key 'even'",

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -64,8 +64,8 @@ class TestConcurrencyLimitManager(VumiTestCase):
 
     def test_concurrency_limiter_one_limit(self):
         """
-        ConcurrencyLimitManager fires the next deferred in the queue when stop()
-        is called.
+        ConcurrencyLimitManager fires the next deferred in the queue when
+        stop() is called.
         """
         limiter = ConcurrencyLimitManager(1)
         d1 = limiter.start("key")
@@ -90,8 +90,8 @@ class TestConcurrencyLimitManager(VumiTestCase):
 
     def test_concurrency_limiter_two_limit(self):
         """
-        ConcurrencyLimitManager fires the next deferred in the queue when stop()
-        is called.
+        ConcurrencyLimitManager fires the next deferred in the queue when
+        stop() is called.
         """
         limiter = ConcurrencyLimitManager(2)
         d1 = limiter.start("key")
@@ -340,7 +340,62 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
         yield self.assertFailure(d, HttpTimeoutError)
 
     @inlineCallbacks
-    def test_in_send_to_with_evil_content(self):
+    def test_send_to_within_content_length_limit(self):
+        yield self.start_app_worker()
+        self.conversation.config['http_api_nostream'].update({
+            'content_length_limit': 182,
+        })
+        yield self.conversation.save()
+
+        msg = {
+            'content': 'foo',
+            'to_addr': '+1234',
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(url, json.dumps(msg),
+                                           self.auth_headers, method='PUT')
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
+        put_msg = json.loads(response.delivered_body)
+        self.assertEqual(response.code, http.OK)
+
+        [sent_msg] = self.app_helper.get_dispatched_outbound()
+        self.assertEqual(sent_msg['to_addr'], put_msg['to_addr'])
+        self.assertEqual(sent_msg['helper_metadata'], {
+            'go': {
+                'conversation_key': self.conversation.key,
+                'conversation_type': 'http_api_nostream',
+                'user_account': self.conversation.user_account.key,
+            },
+        })
+        self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
+        self.assertEqual(sent_msg['session_event'], None)
+        self.assertEqual(sent_msg['to_addr'], '+1234')
+        self.assertEqual(sent_msg['from_addr'], None)
+
+    @inlineCallbacks
+    def test_send_to_content_too_long(self):
+        yield self.start_app_worker()
+        self.conversation.config['http_api_nostream'].update({
+            'content_length_limit': 10,
+        })
+        yield self.conversation.save()
+
+        msg = {
+            'content': "This message is longer than 10 characters.",
+            'to_addr': '+1234',
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(
+            url, json.dumps(msg), self.auth_headers, method='PUT')
+        self.assert_bad_request(
+            response, "Payload content too long: 42 > 10")
+
+    @inlineCallbacks
+    def test_send_to_with_evil_content(self):
         yield self.start_app_worker()
         msg = {
             'content': 0xBAD,
@@ -354,7 +409,7 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
             response, "Invalid or missing value for payload key 'content'")
 
     @inlineCallbacks
-    def test_in_send_to_with_evil_to_addr(self):
+    def test_send_to_with_evil_to_addr(self):
         yield self.start_app_worker()
         msg = {
             'content': 'good',
@@ -400,6 +455,67 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
         self.assertEqual(sent_msg['session_event'], None)
         self.assertEqual(sent_msg['to_addr'], inbound_msg['from_addr'])
         self.assertEqual(sent_msg['from_addr'], '9292')
+
+    @inlineCallbacks
+    def test_in_reply_to_within_content_length_limit(self):
+        yield self.start_app_worker()
+        self.conversation.config['http_api_nostream'].update({
+            'content_length_limit': 182,
+        })
+        yield self.conversation.save()
+
+        inbound_msg = yield self.app_helper.make_stored_inbound(
+            self.conversation, 'in 1', message_id='1')
+
+        msg = {
+            'content': 'foo',
+            'in_reply_to': inbound_msg['message_id'],
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(url, json.dumps(msg),
+                                           self.auth_headers, method='PUT')
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
+        put_msg = json.loads(response.delivered_body)
+        self.assertEqual(response.code, http.OK)
+
+        [sent_msg] = self.app_helper.get_dispatched_outbound()
+        self.assertEqual(sent_msg['to_addr'], put_msg['to_addr'])
+        self.assertEqual(sent_msg['helper_metadata'], {
+            'go': {
+                'conversation_key': self.conversation.key,
+                'conversation_type': 'http_api_nostream',
+                'user_account': self.conversation.user_account.key,
+            },
+        })
+        self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
+        self.assertEqual(sent_msg['session_event'], None)
+        self.assertEqual(sent_msg['to_addr'], inbound_msg['from_addr'])
+        self.assertEqual(sent_msg['from_addr'], '9292')
+
+    @inlineCallbacks
+    def test_in_reply_to_content_too_long(self):
+        yield self.start_app_worker()
+        self.conversation.config['http_api_nostream'].update({
+            'content_length_limit': 10,
+        })
+        yield self.conversation.save()
+
+        inbound_msg = yield self.app_helper.make_stored_inbound(
+            self.conversation, 'in 1', message_id='1')
+
+        msg = {
+            'content': "This message is longer than 10 characters.",
+            'in_reply_to': inbound_msg['message_id'],
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation.key)
+        response = yield http_request_full(
+            url, json.dumps(msg), self.auth_headers, method='PUT')
+        self.assert_bad_request(
+            response, "Payload content too long: 42 > 10")
 
     @inlineCallbacks
     def test_in_reply_to_with_evil_content(self):

--- a/go/apps/http_api_nostream/view_definition.py
+++ b/go/apps/http_api_nostream/view_definition.py
@@ -25,6 +25,10 @@ class TokenForm(forms.Form):
     metric_store = forms.CharField(
         help_text='Which store to publish metrics to.',
         required=False)
+    content_length_limit = forms.IntegerField(
+        help_text=('Optional content length limit. If set, messages with'
+                   ' content longer than this will be rejected.'),
+        required=False)
 
     def clean(self):
         cleaned_data = super(TokenForm, self).clean()
@@ -54,6 +58,7 @@ class TokenForm(forms.Form):
             'metric_store': data.get('metric_store', DEFAULT_METRIC_STORE),
             'ignore_events': data.get('ignore_events', False),
             'ignore_messages': data.get('ignore_messages', False),
+            'content_length_limit': data.get('content_length_limit', None),
         }
 
     def to_config(self):
@@ -65,6 +70,7 @@ class TokenForm(forms.Form):
             'metric_store': data.get('metric_store') or DEFAULT_METRIC_STORE,
             'ignore_events': data.get('ignore_events', False),
             'ignore_messages': data.get('ignore_messages', False),
+            'content_length_limit': data.get('content_length_limit', None),
         }
 
 

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -228,9 +228,11 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
         yield super(NoStreamingHTTPWorker, self).teardown_application()
         yield self.webserver.loseConnection()
 
+    def get_all_api_config(self, conversation):
+        return conversation.config.get('http_api_nostream', {})
+
     def get_api_config(self, conversation, key, default=None):
-        return conversation.config.get(
-            'http_api_nostream', {}).get(key, default)
+        return self.get_all_api_config(conversation).get(key, default)
 
     @inlineCallbacks
     def consume_user_message(self, message):


### PR DESCRIPTION
We currently accept all (valid) outbound messages in the HTTP API. Ideally, we'd like to reject messages that can't be sent for some reason. Since we don't (currently) have any way to get capability information from channels, the easiest thing to do here is add conversation config, starting with the length limit.
