### PR TITLE
Tweak billing message chunking to reduce memory footprint

### DIFF
--- a/go/billing/django_utils.py
+++ b/go/billing/django_utils.py
@@ -11,8 +11,9 @@ class TransactionSerializer(object):
     """ Helper for serializing transaction objects to JSON. """
 
     def __init__(self):
-        self._simplifier = serializers.get_serializer("python")()
+        self._simplifier_cls = serializers.get_serializer("python")
 
     def to_json(self, transactions):
+        simplifier = self._simplifier_cls()
         return (json.dumps(t, cls=JSONEncoder)
-                for t in self._simplifier.serialize(transactions))
+                for t in simplifier.serialize(transactions))

--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -276,7 +276,7 @@ def archive_transactions(account_id, from_date, to_date, delete=True):
         created__gte=from_date,
         created__lt=(to_date + relativedelta(days=1)))
 
-    def generate_chunks(item_iter, items_per_chunk=10000, sep="\n"):
+    def generate_chunks(item_iter, items_per_chunk=1000, sep="\n"):
         data = []
         for i, item in enumerate(item_iter):
             data.append(item)


### PR DESCRIPTION
Two things are planned:
- Reduce the number of transaction objects per chunk from 10000 to 1000.
- Use a new Django serializer under the hood for each chunk to reduce the possibility of things being held in RAM.
