### PR TITLE
Fix dialogue UI js test timeout

### DIFF
--- a/go/base/static/js/test/apps/dialogue/states/send.test.js
+++ b/go/base/static/js/test/apps/dialogue/states/send.test.js
@@ -1,5 +1,5 @@
 describe("go.apps.dialogue.states.send", function() {
-  var dialogue = go.apps.dialogue;
+ var dialogue = go.apps.dialogue;
 
   var setUp = dialogue.testHelpers.setUp,
       tearDown = dialogue.testHelpers.tearDown,
@@ -13,23 +13,24 @@ describe("go.apps.dialogue.states.send", function() {
 
     diagram = newDialogueDiagram();
     
-    diagram.model.set('channel_types', [{
+    diagram.model.set({
+      channel_types: [{
         name: 'sms',
         label: 'SMS'
-    }, {
+      }, {
         name: 'ussd',
         label: 'USSD'
-    }]);
-
-    diagram.model.set('states', [{
-      uuid: 'foo',
-      name: 'Foo',
-      type: 'send',
-      channel_type: 'sms',
-      entry_endpoint: {uuid: 'endpoint-a'},
-      exit_endpoint: {uuid: 'endpoint-b'},
-      text: 'Hello over SMS'
-    }]);
+      }],
+      states: [{
+        uuid: 'foo',
+        name: 'Foo',
+        type: 'send',
+        channel_type: 'sms',
+        entry_endpoint: {uuid: 'endpoint-a'},
+        exit_endpoint: {uuid: 'endpoint-b'},
+        text: 'Hello over SMS'
+      }]
+    }, {silent: true})
 
     state = diagram.states.get('foo');
   });


### PR DESCRIPTION
[This particular `.set`](https://github.com/praekelt/vumi-go/blob/develop/go/base/static/js/test/apps/dialogue/states/send.test.js#L24-L32) causes its enclosing `beforeEach` to take quite long, often timing out tests. This is because clearing the old states and adding a new state causes the relevant views listening to the model to update, resulting in quite a few DOM updates, which takes a while. Since these view updates are unnecessary for the purpose of the `beforeEach`, we can make the `.set` silent.

In chrome, this was taking ~150ms. In phantomjs, this was taking ~500ms, so this is more an issue in tests than it is in the UI, though it still a significant amount of time. Such a drastic change isn't really likely with the way the UI is used I don't think, that particular `.set` causes an 'all at once' remove of all current states and create of a new state, each remove requiring unhooking and removing of views for connections and states, and the relevant DOM changes for each. After making the `.set` silent, this took ~50ms in chrome and ~100ms in phantomjs (still longer than it should be, but much quicker, enough to avoid test timeouts). I suspect the remaining delay is because of backbone-relational managing all the removed connection and state models, also something unlikely to be done in the UI all at once, I think.
