### PR TITLE
Remove old hack in sequential send that falls back to batch ids

### DIFF
--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -199,29 +199,6 @@ class TestSequentialSendApplication(VumiTestCase):
                          sorted([conv1.key, conv2.key]))
 
     @inlineCallbacks
-    def test_get_conversations_batch_key(self):
-        """
-        Test get_conversation using the batch key fallback.
-        """
-
-        conv1 = yield self.app_helper.create_conversation(
-            config={'schedule': {'recurring': 'daily', 'time': '00:01:40'}})
-        yield self.app_helper.start_conversation(conv1)
-
-        conv2 = yield self.app_helper.create_conversation(
-            config={'schedule': {'recurring': 'daily', 'time': '00:02:30'}})
-        yield self.app_helper.start_conversation(conv2)
-
-        yield self.app_helper.create_conversation(
-            config={'schedule': {'recurring': 'daily', 'time': '00:02:30'}})
-
-        convs = yield self.app.get_conversations(
-            [[conv1.batch.key, conv1.key], [conv2.batch.key, conv2.key]])
-
-        self.assertEqual(sorted([c.key for c in convs]),
-                         sorted([conv1.key, conv2.key]))
-
-    @inlineCallbacks
     def test_get_conversations_missing_conv(self):
         """
         Test get_conversation when it's expecting a conversation that doesn't
@@ -233,7 +210,7 @@ class TestSequentialSendApplication(VumiTestCase):
 
         with LogCatcher(message='Conversation .* not found.') as lc:
             convs = yield self.app.get_conversations(
-                [[conv.batch.key, conv.key], ['badaccount', 'badkey']])
+                [[conv.user_account.key, conv.key], ['badaccount', 'badkey']])
             self.assertEqual(
                 lc.messages(),
                 ['Conversation badkey for account badaccount not found.'])


### PR DESCRIPTION
Our logs indicate that this case hasn't been encountered recently.
