### PR TITLE
Support managing opt outs for accounts

### DIFF
--- a/go/vumitools/opt_out/tests/test_utils.py
+++ b/go/vumitools/opt_out/tests/test_utils.py
@@ -135,6 +135,22 @@ class TestOptOutHelper(VumiTestCase):
         self.assertEqual(msg['helper_metadata']['optout'], {'optout': False})
 
     @inlineCallbacks
+    def test_process_message_disabled_by_account(self):
+        """
+        If the message is being sent using a tag in a tagpool with global opt
+        outs disabled, it should process the message as a non-opt out.
+        """
+        optouts = OptOutHelper(self.vumi_api, {'keywords': ['stop']})
+
+        msg = self.msg_helper.make_inbound('stop')
+        md = MessageMetadataHelper(self.vumi_api, msg)
+        md.set_tag((u'pool1', u'tag1'))
+
+        self.account.disable_optouts = True
+        yield optouts.process_message(self.account, msg)
+        self.assertEqual(msg['helper_metadata']['optout'], {'optout': False})
+
+    @inlineCallbacks
     def test_process_message_already_processed(self):
         """
         If the message has already been processed as an opt out or non-opt out,

--- a/go/vumitools/opt_out/utils.py
+++ b/go/vumitools/opt_out/utils.py
@@ -36,7 +36,9 @@ class OptOutHelper(object):
     def _optout_disabled(self, account, message):
         msg_mdh = MessageMetadataHelper(self.vumi_api, message)
 
-        if msg_mdh.tag is not None:
+        if account.disable_optouts:
+            returnValue(True)
+        elif msg_mdh.tag is not None:
             tagpool_metadata = yield msg_mdh.get_tagpool_metadata()
             returnValue(tagpool_metadata.get('disable_global_opt_out', False))
         else:


### PR DESCRIPTION
Currently, we support managing opt outs at the tagpool level, but we need to be able to do this at the account level.
