### PR TITLE
Fix failing unique index tests.

### DIFF
--- a/go/account/tests.py
+++ b/go/account/tests.py
@@ -229,10 +229,13 @@ class TestEmail(GoDjangoTestCase):
         self.assertTrue('number of messages received: 5' in email.body)
         self.assertTrue('Group Message' in email.body)
         self.assertTrue('Test Conversation' in email.body)
-        self.assertTrue('Sent: 5 to 5 uniques.' in email.body)
-        self.assertTrue('Received: 5 from 5 uniques.' in email.body)
         self.assertTrue('"Group Message" Sent: 5' in email.body)
         self.assertTrue('"Group Message" Received: 5' in email.body)
+
+        # TODO fix once we support uniques properly again
+        self.assertTrue('Sent: 5 to 0 uniques.' in email.body)
+        self.assertTrue('Received: 5 from 0 uniques.' in email.body)
+
 
     def test_send_scheduled_account_summary_task(self):
         user_account = self.user_helper.get_user_account()

--- a/go/apps/jsbox/tests/test_message_store.py
+++ b/go/apps/jsbox/tests/test_message_store.py
@@ -85,13 +85,15 @@ class TestMessageStoreResource(ResourceTestCaseBase):
     def test_handle_count_inbound_uniques(self):
         reply = yield self.dispatch_command('count_inbound_uniques')
         self.assertTrue(reply['success'])
-        self.assertEqual(reply['count'], 1)
+        # TODO fix once we support uniques properly again
+        self.assertEqual(reply['count'], 0)
 
     @inlineCallbacks
     def test_handle_count_outbound_uniques(self):
         reply = yield self.dispatch_command('count_outbound_uniques')
         self.assertTrue(reply['success'])
-        self.assertEqual(reply['count'], 1)
+        # TODO fix once we support uniques properly again
+        self.assertEqual(reply['count'], 0)
 
     @inlineCallbacks
     def test_handle_inbound_throughput(self):

--- a/go/base/tests/test_go_system_stats.py
+++ b/go/base/tests/test_go_system_stats.py
@@ -163,13 +163,15 @@ class TestGoSystemStatsCommand(GoDjangoTestCase):
         )
 
         cmd = self.run_command(command=["message_counts_by_month"])
+
+        # TODO fix once we support uniques properly again
         self.assert_csv_output(cmd, [
             "date,conversations_started,"
             "inbound_message_count,outbound_message_count,"
             "inbound_uniques,outbound_uniques,total_uniques",
-            "09/01/2013,1,3,6,1,2,2",
-            "11/01/2013,3,2,2,2,2,2",
-            "12/01/2013,2,4,6,2,6,6",
+            "09/01/2013,1,3,6,0,0,0",
+            "11/01/2013,3,2,2,0,0,0",
+            "12/01/2013,2,4,6,0,0,0",
         ])
 
     def test_custom_date_format(self):

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -720,8 +720,8 @@ class TestConversationViews(BaseConversationViewTestCase):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
         msgs = self.msg_helper.add_inbound_to_conv(conv, 10)
         response = self.client.get(self.get_view_url(conv, 'message_list'))
-        self.assertContains(
-            response, 'Messages from 10 unique people')
+        # TODO fix once we support uniques properly again
+        self.assertContains(response, 'Messages from 0 unique people')
 
     def test_message_list_inbound_download_links_display(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
@@ -743,8 +743,8 @@ class TestConversationViews(BaseConversationViewTestCase):
             self.get_view_url(conv, 'message_list'), {
                 'direction': 'outbound'
             })
-        self.assertContains(
-            response, 'Messages to 10 unique people')
+        # TODO fix once we support uniques properly again
+        self.assertContains(response, 'Messages to 0 unique people')
 
     def test_message_list_outbound_download_links_display(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -82,23 +82,25 @@ class TestConversationWrapper(VumiTestCase):
 
     @inlineCallbacks
     def test_count_inbound_uniques(self):
+        # TODO fix once we support uniques properly again
         yield self.conv.start()
         yield self.msg_helper.add_inbound_to_conv(self.conv, 3)
-        self.assertEqual((yield self.conv.count_inbound_uniques()), 3)
+        self.assertEqual((yield self.conv.count_inbound_uniques()), 0)
         yield self.msg_helper.add_inbound_to_conv(self.conv, 4)
-        self.assertEqual((yield self.conv.count_inbound_uniques()), 4)
+        self.assertEqual((yield self.conv.count_inbound_uniques()), 0)
         yield self.msg_helper.add_inbound_to_conv(self.conv, 2)
-        self.assertEqual((yield self.conv.count_inbound_uniques()), 4)
+        self.assertEqual((yield self.conv.count_inbound_uniques()), 0)
 
     @inlineCallbacks
     def test_count_outbound_uniques(self):
+        # TODO fix once we support uniques properly again
         yield self.conv.start()
         yield self.msg_helper.add_outbound_to_conv(self.conv, 3)
-        self.assertEqual((yield self.conv.count_outbound_uniques()), 3)
+        self.assertEqual((yield self.conv.count_outbound_uniques()), 0)
         yield self.msg_helper.add_outbound_to_conv(self.conv, 4)
-        self.assertEqual((yield self.conv.count_outbound_uniques()), 4)
+        self.assertEqual((yield self.conv.count_outbound_uniques()), 0)
         yield self.msg_helper.add_outbound_to_conv(self.conv, 2)
-        self.assertEqual((yield self.conv.count_outbound_uniques()), 4)
+        self.assertEqual((yield self.conv.count_outbound_uniques()), 0)
 
     @inlineCallbacks
     def test_received_messages(self):


### PR DESCRIPTION
The disabling of the unique message counts in Vumi's message store is causing a selection of Vumi Go tests to fail. This wasn't picked up in Travis builds until the latest Vumi release.

See, e.g. https://travis-ci.org/praekelt/vumi-go/jobs/45937989
