### PR TITLE
Don't include billing contact details in repo

### DIFF
--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -42,9 +42,9 @@ STATEMENTS_DEFAULT_ORDER_BY = getattr(
 
 STATEMENT_CONTACT_DETAILS = getattr(
     settings, 'BILLING_STATEMENT_CONTACT_DETAILS', {
-        'tel': '27.11.482.8684',
-        'email': 'accounts@praekelt.com',
-        'website': 'www.praekeltfoundation.org',
+        'tel': '27.11.123.4567',
+        'email': 'foo@bar.com',
+        'website': 'www.foo.org',
     })
 
 ENABLE_LOW_CREDIT_NOTIFICATION = getattr(

--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -43,8 +43,8 @@ STATEMENTS_DEFAULT_ORDER_BY = getattr(
 STATEMENT_CONTACT_DETAILS = getattr(
     settings, 'BILLING_STATEMENT_CONTACT_DETAILS', {
         'tel': '27.11.123.4567',
-        'email': 'foo@bar.com',
-        'website': 'www.foo.org',
+        'email': 'foo@example.com',
+        'website': 'www.example.com',
     })
 
 ENABLE_LOW_CREDIT_NOTIFICATION = getattr(

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -37,17 +37,17 @@ class TestStatementView(GoDjangoTestCase):
 
     @mock.patch('go.billing.settings.STATEMENT_CONTACT_DETAILS', {
         'tel': '27.11.123.4567',
-        'website': 'www.foo.org',
-        'email': 'http://foo@bar.com',
+        'website': 'www.example.com',
+        'email': 'http://foo@example.com',
     })
     def test_statement_contact_details(self):
         statement = self.mk_statement()
         user = self.user_helper.get_django_user()
         response = self.get_statement(user, statement)
 
-        self.assertContains(response, '>www.foo.org<')
+        self.assertContains(response, '>www.example.com<')
         self.assertContains(response, '>27.11.123.4567<')
-        self.assertContains(response, '>http://foo@bar.com<')
+        self.assertContains(response, '>http://foo@example.com<')
 
     def test_statement_biller_title(self):
         statement = self.mk_statement(items=[{


### PR DESCRIPTION
At the moment, we include our actual contact details in the repo for generating statements, we should put dummy details in instead.
