### PR TITLE
Update low credit notification email text

### DIFF
--- a/go/billing/templates/billing/low_credit_notification_email.txt
+++ b/go/billing/templates/billing/low_credit_notification_email.txt
@@ -2,8 +2,6 @@ Hi {{user.get_full_name}}!
 
 Please note that your Vumi Go account ({{account.user.email}}) has reached {{threshold_percent}}% used of the total available credits. Your remaining balance is {{credit_balance}}.
 
-In the near future, once you have used all of your credits, your account will be capped and you will no longer be able to send any messages. Incoming messages will still be stored as usual.
-
 To top up your credits contact your Praekelt programme manager with the number of messages/sessions you want loaded.
 
 

--- a/go/billing/templates/billing/low_credit_notification_email.txt
+++ b/go/billing/templates/billing/low_credit_notification_email.txt
@@ -2,7 +2,7 @@ Hi {{user.get_full_name}}!
 
 Please note that your Vumi Go account ({{account.user.email}}) has reached {{threshold_percent}}% used of the total available credits. Your remaining balance is {{credit_balance}}.
 
-Once you have used all of your credits, your account will be capped and you will no longer be able to send any messages. Incoming messages will still be stored as usual.
+In the near future, once you have used all of your credits, your account will be capped and you will no longer be able to send any messages. Incoming messages will still be stored as usual.
 
 To top up your credits contact your Praekelt programme manager with the number of messages/sessions you want loaded.
 


### PR DESCRIPTION
Since we're not quite enabling switching off accounts with negative balances, but will be soon, we should have the low credit notification email reflect this.
