### PR TITLE
Format numbers on billing numbers in the UI

### DIFF
--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -8,8 +8,8 @@ from go.config import billing_quantization_exponent
 SYSTEM_BILLER_NAME = getattr(
     settings, 'BILLING_SYSTEM_BILLER_NAME', 'Vumi')
 
-DOLLAR_FORMAT = getattr(
-    settings, 'BILLING_DOLLAR_FORMAT', '%.3f')
+DOLLAR_DECIMAL_PLACES = getattr(
+    settings, 'BILLING_DOLLAR_DECIMAL_PLACES', 3)
 
 # 10 credits = 1 US cent
 CREDIT_CONVERSION_FACTOR = getattr(

--- a/go/billing/templates/billing/invoice.html
+++ b/go/billing/templates/billing/invoice.html
@@ -62,8 +62,8 @@
                             <td>{% if item.description != None %}{{ item.description }}{% endif %}</th>
                             <td>{{ item.units }}</th>
                             <td>{% if item.credits != None %}{{ item.credits }}{% endif %}</th>
-                            <td>{{ item.unit_cost|dollars }}</th>
-                            <td>{{ item.cost|dollars }}
+                            <td>{{ item.unit_cost|format_cents }}</th>
+                            <td>{{ item.cost|format_cents }}
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -73,7 +73,7 @@
                             <td></td>
                             <td>{{ section.totals.credits }}</td>
                             <td></td>
-                            <td>{{ section.totals.cost|dollars }}</td>
+                            <td>{{ section.totals.cost|format_cents }}</td>
                         </tr>
                     </tfoot>
                 </table>
@@ -95,7 +95,7 @@
                         <td></td>
                         <td>{{ totals.credits }}</td>
                         <td></td>
-                        <td>{{ totals.cost|dollars }}</td>
+                        <td>{{ totals.cost|format_cents }}</td>
                     </tfoot>
                 </table>
             </div>

--- a/go/billing/templates/billing/invoice.html
+++ b/go/billing/templates/billing/invoice.html
@@ -61,7 +61,7 @@
                         <tr>
                             <td>{% if item.description != None %}{{ item.description }}{% endif %}</th>
                             <td>{{ item.units }}</th>
-                            <td>{% if item.credits != None %}{{ item.credits }}{% endif %}</th>
+                            <td>{% if item.credits != None %}{{ item.credits|format_credits }}{% endif %}</th>
                             <td>{{ item.unit_cost|format_cents }}</th>
                             <td>{{ item.cost|format_cents }}
                         </tr>
@@ -71,7 +71,7 @@
                         <tr>
                             <td>Total</td>
                             <td></td>
-                            <td>{{ section.totals.credits }}</td>
+                            <td>{{ section.totals.credits|format_credits }}</td>
                             <td></td>
                             <td>{{ section.totals.cost|format_cents }}</td>
                         </tr>
@@ -93,7 +93,7 @@
                     <tfoot>
                         <td>Grand Total</td>
                         <td></td>
-                        <td>{{ totals.credits }}</td>
+                        <td>{{ totals.credits|format_credits }}</td>
                         <td></td>
                         <td>{{ totals.cost|format_cents }}</td>
                     </tfoot>

--- a/go/billing/templatetags/billing_tags.py
+++ b/go/billing/templatetags/billing_tags.py
@@ -3,9 +3,29 @@ from decimal import Decimal
 from django import template
 from django.utils.translation import ungettext
 
+from go.base.utils import format_currency
 from go.billing import settings
 
 register = template.Library()
+
+
+@register.filter
+def format_cents(v):
+    """returns a formatted string representation of a number in dollars from a
+    decimal cents value (cents are the billing system's internal representation
+    for monetary amounts).
+    """
+    v = v / Decimal('100.0')
+    return format_currency(v, places=settings.DOLLAR_DECIMAL_PLACES)
+
+
+@register.filter
+def format_credits(v):
+    """Returns a formatted string representation of a number in dollars from a
+    decimal cents value (cents are the billing system's internal representation
+    for monetary amounts).
+    """
+    return format_currency(v)
 
 
 @register.simple_tag
@@ -14,21 +34,9 @@ def credit_balance(user):
 
     If the user has multiple accounts, the first one's balance is returned.
     """
-    try:
-        account = user.account_set.all()[0]
-        credit_balance = account.credit_balance
-    except IndexError:
-        credit_balance = 0
+    account = user.account_set.get()
+    credits = account.credit_balance
 
-    return ungettext(
-        "%(credit_balance)d credit",
-        "%(credit_balance)d credits",
-        credit_balance) % {'credit_balance': credit_balance}
-
-
-@register.filter
-def dollars(v):
-    """Returns a formatted dollar value from a decimal cents value (cents are
-    the billing system's internal representation for monetary amounts).
-    """
-    return settings.DOLLAR_FORMAT % (v / Decimal('100.0'),)
+    return "%s %s" % (
+        format_credits(credits),
+        ungettext("credit", "credits", credits))

--- a/go/billing/templatetags/billing_tags.py
+++ b/go/billing/templatetags/billing_tags.py
@@ -11,7 +11,7 @@ register = template.Library()
 
 @register.filter
 def format_cents(v):
-    """returns a formatted string representation of a number in dollars from a
+    """Returns a formatted string representation of a number in dollars from a
     decimal cents value (cents are the billing system's internal representation
     for monetary amounts).
     """
@@ -21,9 +21,8 @@ def format_cents(v):
 
 @register.filter
 def format_credits(v):
-    """Returns a formatted string representation of a number in dollars from a
-    decimal or float cents value (cents are the billing system's
-    internal representation for monetary amounts).
+    """Returns a formatted string representation of a number in credits from a
+    decimal credits value.
     """
     return format_currency(v)
 

--- a/go/billing/templatetags/billing_tags.py
+++ b/go/billing/templatetags/billing_tags.py
@@ -22,10 +22,12 @@ def format_cents(v):
 @register.filter
 def format_credits(v):
     """Returns a formatted string representation of a number in dollars from a
-    decimal cents value (cents are the billing system's internal representation
-    for monetary amounts).
+    decimal or float cents value (cents are the billing system's
+    internal representation for monetary amounts).
     """
-    return format_currency(v)
+    if not isinstance(v, Decimal):
+        v = Decimal(str(v))
+    return format_currency(Decimal(str(v)))
 
 
 @register.simple_tag

--- a/go/billing/templatetags/billing_tags.py
+++ b/go/billing/templatetags/billing_tags.py
@@ -25,9 +25,7 @@ def format_credits(v):
     decimal or float cents value (cents are the billing system's
     internal representation for monetary amounts).
     """
-    if not isinstance(v, Decimal):
-        v = Decimal(str(v))
-    return format_currency(Decimal(str(v)))
+    return format_currency(v)
 
 
 @register.simple_tag

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -21,7 +21,7 @@ class TestFormatCents(GoDjangoTestCase):
 
 class TestFormatCredits(GoDjangoTestCase):
     def test_format_credits(self):
-        self.assertEqual(format_credits(2), '2.00')
+        self.assertEqual(format_credits(Decimal('2.00'), '2.00')
         self.assertEqual(format_credits(Decimal('0.23')), '0.23')
         self.assertEqual(format_credits(Decimal('0.028')), '0.02')
 

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import mock
+>>>>>>> feature/issue-1152-change-lineitem-credits-field-from-an-integer-to-a-decimal-field
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
 from go.billing.templatetags.billing_tags import (
     format_cents, format_credits, credit_balance)
@@ -21,7 +22,7 @@ class TestFormatCents(GoDjangoTestCase):
 
 class TestFormatCredits(GoDjangoTestCase):
     def test_format_credits(self):
-        self.assertEqual(format_credits(Decimal('2.00'), '2.00')
+        self.assertEqual(format_credits(Decimal('2.00'), '2.00'))
         self.assertEqual(format_credits(Decimal('0.23')), '0.23')
         self.assertEqual(format_credits(Decimal('0.028')), '0.02')
 

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -29,10 +29,6 @@ class TestFormatCredits(GoDjangoTestCase):
             format_credits(Decimal('123456789.9876')),
             '123,456,789.98')
 
-    def test_float_values(self):
-        self.assertEqual(format_credits(0.23), '0.23')
-        self.assertEqual(format_credits(0.028), '0.02')
-
 
 class TestCreditBalance(GoDjangoTestCase):
     def setUp(self):

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -19,15 +19,19 @@ class TestFormatCents(GoDjangoTestCase):
             '1,234,567.899')
 
 
-class TestCredits(GoDjangoTestCase):
-    def test_credits(self):
-        self.assertEqual(format_credits(Decimal('2')), '2.00')
+class TestFormatCredits(GoDjangoTestCase):
+    def test_format_credits(self):
+        self.assertEqual(format_credits(2), '2.00')
         self.assertEqual(format_credits(Decimal('0.23')), '0.23')
         self.assertEqual(format_credits(Decimal('0.028')), '0.02')
 
         self.assertEqual(
             format_credits(Decimal('123456789.9876')),
             '123,456,789.98')
+
+    def test_float_values(self):
+        self.assertEqual(format_credits(0.23), '0.23')
+        self.assertEqual(format_credits(0.028), '0.02')
 
 
 class TestCreditBalance(GoDjangoTestCase):

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 
 import mock
->>>>>>> feature/issue-1152-change-lineitem-credits-field-from-an-integer-to-a-decimal-field
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
 from go.billing.templatetags.billing_tags import (
     format_cents, format_credits, credit_balance)
@@ -22,7 +21,7 @@ class TestFormatCents(GoDjangoTestCase):
 
 class TestFormatCredits(GoDjangoTestCase):
     def test_format_credits(self):
-        self.assertEqual(format_credits(Decimal('2.00'), '2.00'))
+        self.assertEqual(format_credits(Decimal('2.00')), '2.00')
         self.assertEqual(format_credits(Decimal('0.23')), '0.23')
         self.assertEqual(format_credits(Decimal('0.028')), '0.02')
 

--- a/go/billing/tests/test_template_tags.py
+++ b/go/billing/tests/test_template_tags.py
@@ -1,14 +1,55 @@
 from decimal import Decimal
 
 import mock
-from go.billing.templatetags.billing_tags import dollars
-from go.base.tests.helpers import GoDjangoTestCase
+from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
+from go.billing.templatetags.billing_tags import (
+    format_cents, format_credits, credit_balance)
 
 
-class TestDollars(GoDjangoTestCase):
-    @mock.patch('go.billing.settings.DOLLAR_FORMAT', '%.3f')
-    def test_dollars(self):
-        self.assertEqual(dollars(Decimal('2')), '0.020')
-        self.assertEqual(dollars(Decimal('23')), '0.230')
-        self.assertEqual(dollars(Decimal('0.1')), '0.001')
-        self.assertEqual(dollars(Decimal('0.2')), '0.002')
+class TestFormatCents(GoDjangoTestCase):
+    @mock.patch('go.billing.settings.DOLLAR_DECIMAL_PLACES', 3)
+    def test_format_cents(self):
+        self.assertEqual(format_cents(Decimal('2')), '0.020')
+        self.assertEqual(format_cents(Decimal('23')), '0.230')
+        self.assertEqual(format_cents(Decimal('0.1')), '0.001')
+        self.assertEqual(format_cents(Decimal('0.2')), '0.002')
+
+        self.assertEqual(
+            format_cents(Decimal('123456789.9876')),
+            '1,234,567.899')
+
+
+class TestCredits(GoDjangoTestCase):
+    def test_credits(self):
+        self.assertEqual(format_credits(Decimal('2')), '2.00')
+        self.assertEqual(format_credits(Decimal('0.23')), '0.23')
+        self.assertEqual(format_credits(Decimal('0.028')), '0.02')
+
+        self.assertEqual(
+            format_credits(Decimal('123456789.9876')),
+            '123,456,789.98')
+
+
+class TestCreditBalance(GoDjangoTestCase):
+    def setUp(self):
+        self.vumi_helper = self.add_helper(DjangoVumiApiHelper())
+
+    def mk_user(self, balance):
+        self.user_helper = self.vumi_helper.make_django_user()
+        user = self.user_helper.get_django_user()
+        account = user.account_set.get()
+        account.credit_balance = balance
+        account.save()
+        return user
+
+    def test_zero(self):
+        user = self.mk_user(Decimal('0.0'))
+        self.assertEqual(credit_balance(user), '0.00 credits')
+
+    def test_singular(self):
+        user = self.mk_user(Decimal('1.0'))
+        self.assertEqual(credit_balance(user), '1.00 credit')
+
+    def test_plural(self):
+        user = self.mk_user(Decimal('123456789.9876'))
+        self.assertEqual(credit_balance(user), '123,456,789.98 credits')

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -112,7 +112,7 @@ class TestStatementView(GoDjangoTestCase):
         user = self.user_helper.get_django_user()
         response = self.get_statement(user, statement)
 
-        self.assertContains(response, '>200<')
+        self.assertContains(response, '>200.00<')
         self.assertContains(response, '>1.234<')
         self.assertContains(response, '>6.790<')
 

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -101,7 +101,7 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertNotContains(response, '>None<')
 
-    @mock.patch('go.billing.settings.DOLLAR_FORMAT', '%.3f')
+    @mock.patch('go.billing.settings.DOLLAR_DECIMAL_PLACES', 3)
     def test_statement_costs(self):
         statement = self.mk_statement(items=[{
             'credits': 200,
@@ -113,7 +113,7 @@ class TestStatementView(GoDjangoTestCase):
         response = self.get_statement(user, statement)
 
         self.assertContains(response, '>200<')
-        self.assertContains(response, '>1.235<')
+        self.assertContains(response, '>1.234<')
         self.assertContains(response, '>6.790<')
 
     def test_statement_cost_nones(self):

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -334,7 +334,7 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertEqual(response.context['totals'], {
             'cost': Decimal('350.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         })
 
     @mock.patch('go.billing.settings.SYSTEM_BILLER_NAME', 'Serenity')

--- a/go/billing/views.py
+++ b/go/billing/views.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from itertools import groupby as _groupby
 
 from django.contrib.auth.decorators import login_required
@@ -13,15 +14,21 @@ def groupby(values, fn):
     return sorted([(k, list(g)) for k, g in _groupby(values, fn)])
 
 
-def ensure_int(v):
-    return v if v is not None else 0
+def ensure_decimal(v):
+    return v if v is not None else Decimal('0.0')
 
 
 def totals_from_items(items):
-    return {
-        'cost': sum(ensure_int(item.cost) for item in items),
-        'credits': sum(ensure_int(item.credits) for item in items),
-    }
+    if not items:
+        return {
+            'cost': Decimal('0.0'),
+            'credits': Decimal('0.0')
+        }
+    else:
+        return {
+            'cost': sum(ensure_decimal(item.cost) for item in items),
+            'credits': sum(ensure_decimal(item.credits) for item in items),
+        }
 
 
 def sections_from_items(all_items):


### PR DESCRIPTION
We have a function to format numbers better, we should use it for statements and the credit amount shown in the top-right hand corner.
