### PR TITLE
Change LineItem credits field from an integer to a decimal field

### DIFF
--- a/go/billing/migrations/0017_auto__chg_field_lineitem_credits.py
+++ b/go/billing/migrations/0017_auto__chg_field_lineitem_credits.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'LineItem.credits'
+        db.alter_column(u'billing_lineitem', 'credits', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=20, decimal_places=6))
+
+    def backwards(self, orm):
+
+        # Changing field 'LineItem.credits'
+        db.alter_column(u'billing_lineitem', 'credits', self.gf('django.db.models.fields.IntegerField')(null=True))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'base.gouser': {
+            'Meta': {'object_name': 'GoUser'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '254'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'billing.account': {
+            'Meta': {'object_name': 'Account'},
+            'account_number': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'credit_balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '20', 'decimal_places': '6'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_topup_balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '20', 'decimal_places': '6'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['base.GoUser']"})
+        },
+        u'billing.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'billed_by': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'channel_type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '20', 'decimal_places': '6'}),
+            'credits': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '6'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'statement': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['billing.Statement']"}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '20', 'decimal_places': '6'}),
+            'units': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'billing.lowcreditnotification': {
+            'Meta': {'object_name': 'LowCreditNotification'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['billing.Account']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'credit_balance': ('django.db.models.fields.DecimalField', [], {'max_digits': '20', 'decimal_places': '6'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'success': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'threshold': ('django.db.models.fields.DecimalField', [], {'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'billing.messagecost': {
+            'Meta': {'unique_together': "[['account', 'tag_pool', 'message_direction']]", 'object_name': 'MessageCost', 'index_together': "[['account', 'tag_pool', 'message_direction']]"},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['billing.Account']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'markup_percent': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '10', 'decimal_places': '2'}),
+            'message_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '10', 'decimal_places': '3'}),
+            'message_direction': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'session_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '10', 'decimal_places': '3'}),
+            'storage_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '10', 'decimal_places': '3'}),
+            'tag_pool': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['billing.TagPool']", 'null': 'True', 'blank': 'True'})
+        },
+        u'billing.statement': {
+            'Meta': {'object_name': 'Statement'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['billing.Account']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'from_date': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to_date': ('django.db.models.fields.DateField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '40'})
+        },
+        u'billing.tagpool': {
+            'Meta': {'object_name': 'TagPool'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        u'billing.transaction': {
+            'Meta': {'object_name': 'Transaction'},
+            'account_number': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'credit_amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '20', 'decimal_places': '6'}),
+            'credit_factor': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'markup_percent': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'message_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '10', 'decimal_places': '3'}),
+            'message_credits': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '6'}),
+            'message_direction': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'message_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'session_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '10', 'decimal_places': '3'}),
+            'session_created': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'session_credits': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '6'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'Pending'", 'max_length': '20'}),
+            'storage_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '10', 'decimal_places': '3'}),
+            'storage_credits': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '6'}),
+            'tag_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'tag_pool_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        u'billing.transactionarchive': {
+            'Meta': {'object_name': 'TransactionArchive'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['billing.Account']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'from_date': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'archive_created'", 'max_length': '32'}),
+            'to_date': ('django.db.models.fields.DateField', [], {})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['billing']

--- a/go/billing/models.py
+++ b/go/billing/models.py
@@ -369,8 +369,8 @@ class LineItem(models.Model):
         default=0,
         help_text=_("Number of units associated to the item"))
 
-    credits = models.IntegerField(
-        default=0, blank=True, null=True,
+    credits = models.DecimalField(
+        max_digits=20, decimal_places=6, default=Decimal('0.0'), null=True,
         help_text=_("Total cost of the item in credits, or null if there is "
                     "no associated credit amount"))
 

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -112,7 +112,7 @@ class TestStatementView(GoDjangoTestCase):
         user = self.user_helper.get_django_user()
         response = self.get_statement(user, statement)
 
-        self.assertContains(response, '>200<')
+        self.assertContains(response, '>200.000000<')
         self.assertContains(response, '>1.235<')
         self.assertContains(response, '>6.790<')
 

--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -104,7 +104,7 @@ class TestStatementView(GoDjangoTestCase):
     @mock.patch('go.billing.settings.DOLLAR_FORMAT', '%.3f')
     def test_statement_costs(self):
         statement = self.mk_statement(items=[{
-            'credits': 200,
+            'credits': Decimal('200.0'),
             'unit_cost': Decimal('123.456'),
             'cost': Decimal('679.012'),
         }])
@@ -133,28 +133,28 @@ class TestStatementView(GoDjangoTestCase):
             'channel': 'Tag 1.1',
             'description': 'Messages Received',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 1',
             'channel_type': 'USSD',
             'channel': 'Tag 1.2',
             'description': 'Messages Received',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
             'channel': 'Tag 2.1',
             'description': 'Messages Received',
             'cost': Decimal('200.0'),
-            'credits': 250,
+            'credits': Decimal('250.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
             'channel': 'Tag 2.2',
             'description': 'Messages Received',
             'cost': Decimal('200.0'),
-            'credits': 250,
+            'credits': Decimal('250.0'),
         }])
 
         user = self.user_helper.get_django_user()
@@ -169,7 +169,7 @@ class TestStatementView(GoDjangoTestCase):
                     get_line_items(statement).filter(channel='Tag 1.1')),
                 'totals': {
                     'cost': Decimal('150.0'),
-                    'credits': 200,
+                    'credits': Decimal('200.0'),
                 }
             }, {
                 'name': u'Tag 1.2',
@@ -177,7 +177,7 @@ class TestStatementView(GoDjangoTestCase):
                     get_line_items(statement).filter(channel='Tag 1.2')),
                 'totals': {
                     'cost': Decimal('150.0'),
-                    'credits': 200,
+                    'credits': Decimal('200.0'),
                 }
             }]
         }, {
@@ -189,7 +189,7 @@ class TestStatementView(GoDjangoTestCase):
                     get_line_items(statement).filter(channel='Tag 2.1')),
                 'totals': {
                     'cost': Decimal('200.0'),
-                    'credits': 250,
+                    'credits': Decimal('250.0'),
                 }
             }, {
                 'name': u'Tag 2.2',
@@ -197,7 +197,7 @@ class TestStatementView(GoDjangoTestCase):
                     get_line_items(statement).filter(channel='Tag 2.2')),
                 'totals': {
                     'cost': Decimal('200.0 '),
-                    'credits': 250,
+                    'credits': Decimal('250.0'),
                 }
             }],
         }])
@@ -209,7 +209,7 @@ class TestStatementView(GoDjangoTestCase):
             'channel': 'Tag 1.1',
             'description': 'Messages Received',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 1',
             'channel_type': 'USSD',
@@ -223,7 +223,7 @@ class TestStatementView(GoDjangoTestCase):
             'channel': 'Tag 1.2',
             'description': 'Messages Received',
             'cost': Decimal('200.0'),
-            'credits': 250,
+            'credits': Decimal('250.0'),
         }, {
             'billed_by': 'Pool 1',
             'channel_type': 'SMS',
@@ -242,10 +242,10 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertEqual(totals, [{
             'cost': Decimal('300.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'cost': Decimal('400.0'),
-            'credits': 250,
+            'credits': Decimal('250.0'),
         }])
 
     def test_statement_section_totals_nones(self):
@@ -255,7 +255,7 @@ class TestStatementView(GoDjangoTestCase):
             'channel': 'Tag 1.1',
             'description': 'Messages Received',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
@@ -270,7 +270,7 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertEqual(response.context['totals'], {
             'cost': Decimal('350.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         })
 
     def test_statement_grand_totals(self):
@@ -280,28 +280,28 @@ class TestStatementView(GoDjangoTestCase):
             'channel': 'Tag 1.1',
             'description': 'Messages Received',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 1',
             'channel_type': 'USSD',
             'channel': 'Tag 1.1',
             'description': 'Messages Sent',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
             'channel': 'Tag 2.1',
             'description': 'Messages Received',
             'cost': Decimal('200.0'),
-            'credits': 250,
+            'credits': Decimal('250.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
             'channel': 'Tag 2.1',
             'description': 'Messages Sent',
             'cost': Decimal('200.0'),
-            'credits': 250,
+            'credits': Decimal('250.0'),
         }])
 
         user = self.user_helper.get_django_user()
@@ -309,7 +309,7 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertEqual(response.context['totals'], {
             'cost': Decimal('700.0'),
-            'credits': 900,
+            'credits': Decimal('900.0'),
         })
 
     def test_statement_grand_totals_nones(self):
@@ -319,7 +319,7 @@ class TestStatementView(GoDjangoTestCase):
             'channel': 'Tag 1.1',
             'description': 'Messages Received',
             'cost': Decimal('150.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
@@ -334,7 +334,7 @@ class TestStatementView(GoDjangoTestCase):
 
         self.assertEqual(response.context['totals'], {
             'cost': Decimal('350.0'),
-            'credits': 200,
+            'credits': Decimal('200.0'),
         })
 
     @mock.patch('go.billing.settings.SYSTEM_BILLER_NAME', 'Serenity')


### PR DESCRIPTION
Currently, all of our other credits field in the billing world are decimal field, so we need to make `LineItem.credits` a decimal field too.
