### PR TITLE
Billing statements split up items from the same biller into separate sections

### DIFF
--- a/go/billing/tests/test_views.py
+++ b/go/billing/tests/test_views.py
@@ -135,19 +135,19 @@ class TestStatementView(GoDjangoTestCase):
             'cost': Decimal('150.0'),
             'credits': Decimal('200.0'),
         }, {
-            'billed_by': 'Pool 1',
-            'channel_type': 'USSD',
-            'channel': 'Tag 1.2',
-            'description': 'Messages Received',
-            'cost': Decimal('150.0'),
-            'credits': Decimal('200.0'),
-        }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',
             'channel': 'Tag 2.1',
             'description': 'Messages Received',
             'cost': Decimal('200.0'),
             'credits': Decimal('250.0'),
+        }, {
+            'billed_by': 'Pool 1',
+            'channel_type': 'USSD',
+            'channel': 'Tag 1.2',
+            'description': 'Messages Received',
+            'cost': Decimal('150.0'),
+            'credits': Decimal('200.0'),
         }, {
             'billed_by': 'Pool 2',
             'channel_type': 'SMS',

--- a/go/billing/views.py
+++ b/go/billing/views.py
@@ -11,7 +11,8 @@ from go.billing.models import Statement
 
 
 def groupby(values, fn):
-    return sorted([(k, list(g)) for k, g in _groupby(values, fn)])
+    values = sorted(values, key=fn)
+    return [(k, list(g)) for k, g in _groupby(values, fn)]
 
 
 def ensure_decimal(v):


### PR DESCRIPTION
This is caused by [`groupby`](https://docs.python.org/2/library/itertools.html#itertools.groupby) being used on an unorded list of items.
