### PR TITLE
Change billing api to set transaction types

### DIFF
--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -89,10 +89,14 @@ class TestTransaction(BillingApiTestCase):
         return BillingApiTestCase.setUp(self)
 
     def create_api_transaction(self, account_number, message_id, tag_pool_name,
-                               tag_name, message_direction, session_created):
+                               tag_name, message_direction, session_created,
+                               transaction_type=None):
         """
         Create a transaction record via the billing API.
         """
+        if transaction_type is None:
+            transaction_type = Transaction.TRANSACTION_TYPE_MESSAGE
+
         content = {
             'account_number': account_number,
             'message_id': message_id,
@@ -100,7 +104,9 @@ class TestTransaction(BillingApiTestCase):
             'tag_name': tag_name,
             'message_direction': message_direction,
             'session_created': session_created,
+            'transaction_type': transaction_type,
         }
+
         return self.call_api('post', 'transactions', content=content)
 
     def assert_model(self, model, **kw):
@@ -281,7 +287,8 @@ class TestTransaction(BillingApiTestCase):
             tag_pool_name='pool1',
             tag_name='tag1',
             message_direction=MessageCost.DIRECTION_INBOUND,
-            session_created=False)
+            session_created=False,
+            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
         # Make sure there was a transaction created
         transaction = Transaction.objects.latest('created')
@@ -303,7 +310,8 @@ class TestTransaction(BillingApiTestCase):
             storage_credits=get_storage_credits(0.5, 10.0),
             session_credits=get_session_credits(0.3, 10.0),
             status=Transaction.STATUS_COMPLETED,
-            message_direction=MessageCost.DIRECTION_INBOUND)
+            message_direction=MessageCost.DIRECTION_INBOUND,
+            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
         # Get the account and make sure the credit balance was updated
         account = Account.objects.get(id=account.id)

--- a/go/vumitools/billing_worker.py
+++ b/go/vumitools/billing_worker.py
@@ -63,7 +63,8 @@ class BillingApi(object):
         returnValue(result)
 
     def create_transaction(self, account_number, message_id, tag_pool_name,
-                           tag_name, message_direction, session_created):
+                           tag_name, message_direction, session_created,
+                           transaction_type):
         """Create a new transaction for the given ``account_number``"""
         data = {
             'account_number': account_number,
@@ -72,6 +73,7 @@ class BillingApi(object):
             'tag_name': tag_name,
             'message_direction': message_direction,
             'session_created': session_created,
+            'transaction_type': transaction_type,
         }
         return self._call_api("/transactions", data=data, method='POST')
 
@@ -105,6 +107,8 @@ class BillingDispatcher(Dispatcher, GoWorkerMixin):
 
     MESSAGE_DIRECTION_INBOUND = "Inbound"
     MESSAGE_DIRECTION_OUTBOUND = "Outbound"
+
+    TRANSACTION_TYPE_MESSAGE = "Message"
 
     worker_name = 'billing_dispatcher'
 
@@ -150,7 +154,8 @@ class BillingDispatcher(Dispatcher, GoWorkerMixin):
             message_id=msg['message_id'],
             tag_pool_name=msg_mdh.tag[0], tag_name=msg_mdh.tag[1],
             message_direction=self.MESSAGE_DIRECTION_INBOUND,
-            session_created=session_created)
+            session_created=session_created,
+            transaction_type=self.TRANSACTION_TYPE_MESSAGE)
 
     @inlineCallbacks
     def create_transaction_for_outbound(self, msg):
@@ -163,7 +168,8 @@ class BillingDispatcher(Dispatcher, GoWorkerMixin):
             message_id=msg['message_id'],
             tag_pool_name=msg_mdh.tag[0], tag_name=msg_mdh.tag[1],
             message_direction=self.MESSAGE_DIRECTION_OUTBOUND,
-            session_created=session_created)
+            session_created=session_created,
+            transaction_type=self.TRANSACTION_TYPE_MESSAGE)
 
     @inlineCallbacks
     def process_inbound(self, config, msg, connector_name):

--- a/go/vumitools/tests/test_billing_worker.py
+++ b/go/vumitools/tests/test_billing_worker.py
@@ -47,7 +47,7 @@ class BillingApiMock(object):
             "created": "2013-10-30T10:42:51.144745+02:00",
             "last_modified": "2013-10-30T10:42:51.144745+02:00",
             "status": "Completed",
-            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE
+            "transaction_type": transaction_type
         }
 
 

--- a/go/vumitools/tests/test_billing_worker.py
+++ b/go/vumitools/tests/test_billing_worker.py
@@ -28,7 +28,8 @@ class BillingApiMock(object):
         items.append(vars)
 
     def create_transaction(self, account_number, message_id, tag_pool_name,
-                           tag_name, message_direction, session_created):
+                           tag_name, message_direction, session_created,
+                           transaction_type):
         self._record(self.transactions, locals())
         return {
             "id": 1,
@@ -45,7 +46,8 @@ class BillingApiMock(object):
             "credit_factor": decimal.Decimal('0.4'),
             "created": "2013-10-30T10:42:51.144745+02:00",
             "last_modified": "2013-10-30T10:42:51.144745+02:00",
-            "status": "Completed"
+            "status": "Completed",
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE
         }
 
 
@@ -105,6 +107,7 @@ class TestBillingApi(VumiTestCase):
             'tag_name': "1234",
             'message_direction': "Inbound",
             'session_created': False,
+            'transaction_type': BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         yield self.billing_api.create_transaction(**kwargs)
         self.assertEqual(hrm.request.uri, "%stransactions" % (self.api_url,))
@@ -127,7 +130,8 @@ class TestBillingApi(VumiTestCase):
             "credit_factor": decimal.Decimal('0.4'),
             "created": "2013-10-30T10:42:51.144745+02:00",
             "last_modified": "2013-10-30T10:42:51.144745+02:00",
-            "status": "Completed"
+            "status": "Completed",
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         response = self._mk_response(
             delivered_body=json.dumps(delivered_body, cls=JSONEncoder))
@@ -143,6 +147,7 @@ class TestBillingApi(VumiTestCase):
             'tag_name': "1234",
             'message_direction': "Inbound",
             'session_created': False,
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         result = yield self.billing_api.create_transaction(**kwargs)
         self.assertEqual(result, delivered_body)
@@ -163,6 +168,7 @@ class TestBillingApi(VumiTestCase):
             'tag_name': "1234",
             'message_direction': "Inbound",
             'session_created': False,
+            'transaction_type': BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         d = self.billing_api.create_transaction(**kwargs)
         yield self.assertFailure(d, BillingError)
@@ -183,7 +189,8 @@ class TestBillingApi(VumiTestCase):
             "credit_factor": decimal.Decimal('0.4'),
             "created": "2013-10-30T10:42:51.144745+02:00",
             "last_modified": "2013-10-30T10:42:51.144745+02:00",
-            "status": "Completed"
+            "status": "Completed",
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         response = self._mk_response(
             delivered_body=json.dumps(delivered_body, cls=JSONEncoder))
@@ -199,6 +206,7 @@ class TestBillingApi(VumiTestCase):
             'tag_name': "1234",
             'message_direction': "Inbound",
             'session_created': False,
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         result = yield self.billing_api.create_transaction(**kwargs)
         self.assertEqual(result, delivered_body)
@@ -219,6 +227,7 @@ class TestBillingApi(VumiTestCase):
             'tag_name': "1234",
             'message_direction': "Inbound",
             'session_created': False,
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }
         d = self.billing_api.create_transaction(**kwargs)
         yield self.assertFailure(d, MockNetworkError)
@@ -287,6 +296,7 @@ class TestBillingDispatcher(VumiTestCase):
             "tag_name": md.tag[1],
             "message_direction": direction,
             "session_created": session_created,
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE
         }])
 
     def assert_no_transactions(self):

--- a/go/vumitools/tests/test_billing_worker.py
+++ b/go/vumitools/tests/test_billing_worker.py
@@ -296,7 +296,7 @@ class TestBillingDispatcher(VumiTestCase):
             "tag_name": md.tag[1],
             "message_direction": direction,
             "session_created": session_created,
-            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE
+            "transaction_type": BillingDispatcher.TRANSACTION_TYPE_MESSAGE,
         }])
 
     def assert_no_transactions(self):


### PR DESCRIPTION
This will allow us to only use message transactions when generating statements.
