### PR TITLE
Fix message aggregate computations

### DIFF
--- a/go/base/management/commands/go_system_stats.py
+++ b/go/base/management/commands/go_system_stats.py
@@ -106,17 +106,16 @@ class Command(BaseGoCommand):
             writer.writerow(row)
 
     def _increment_msg_stats(self, conv, stats):
-        batch_key = conv.batch.key
-        mdb = conv.mdb
-        cache = mdb.cache
-        inbound_uniques = cache.count_from_addrs(batch_key)
-        outbound_uniques = cache.count_to_addrs(batch_key)
+        inbound_stats = conv.mdb.batch_inbound_stats(conv.batch.key)
+        outbound_stats = conv.mdb.batch_outbound_stats(conv.batch.key)
         stats["conversations_started"] += 1
-        stats["inbound_message_count"] += mdb.batch_inbound_count(batch_key)
-        stats["outbound_message_count"] += mdb.batch_outbound_count(batch_key)
-        stats["inbound_uniques"] += inbound_uniques
-        stats["outbound_uniques"] += outbound_uniques
-        stats["total_uniques"] += max(inbound_uniques, outbound_uniques)
+        stats["inbound_message_count"] += inbound_stats['total']
+        stats["outbound_message_count"] += outbound_stats['total']
+        stats["inbound_uniques"] += inbound_stats['unique_addresses']
+        stats["outbound_uniques"] += outbound_stats['unique_addresses']
+        stats["total_uniques"] += max(
+            inbound_stats['unique_addresses'],
+            outbound_stats['unique_addresses'])
 
     def handle_command_message_counts_by_month(self, *args, **options):
         month_stats = {}

--- a/go/base/tests/test_go_system_stats.py
+++ b/go/base/tests/test_go_system_stats.py
@@ -164,14 +164,13 @@ class TestGoSystemStatsCommand(GoDjangoTestCase):
 
         cmd = self.run_command(command=["message_counts_by_month"])
 
-        # TODO fix once we support uniques properly again
         self.assert_csv_output(cmd, [
             "date,conversations_started,"
             "inbound_message_count,outbound_message_count,"
             "inbound_uniques,outbound_uniques,total_uniques",
-            "09/01/2013,1,3,6,0,0,0",
-            "11/01/2013,3,2,2,0,0,0",
-            "12/01/2013,2,4,6,0,0,0",
+            "09/01/2013,1,3,6,1,2,2",
+            "11/01/2013,3,2,2,2,2,2",
+            "12/01/2013,2,4,6,2,6,6",
         ])
 
     def test_custom_date_format(self):

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -341,40 +341,6 @@ class TestConversationWrapper(VumiTestCase):
             (yield self.conv.get_outbound_throughput(sample_time=20)), 60)
 
     @inlineCallbacks
-    def test_get_aggregate_keys(self):
-        yield self.conv.start()
-        yield self.msg_helper.add_outbound_to_conv(
-            self.conv, 20, time_multiplier=12)
-        inbound_aggregate = yield self.conv.get_aggregate_keys('inbound')
-        self.assertEqual(inbound_aggregate, [])
-        outbound_aggregate = yield self.conv.get_aggregate_keys('outbound')
-        bucket_keys = [bucket for bucket, _ in outbound_aggregate]
-        buckets = [keys for _, keys in outbound_aggregate]
-        self.assertEqual(
-            bucket_keys,
-            [datetime.now().date() - timedelta(days=i)
-                for i in range(9, -1, -1)])
-        for bucket in buckets:
-            self.assertEqual(len(bucket), 2)
-
-    @inlineCallbacks
-    def test_get_aggregate_count(self):
-        yield self.conv.start()
-        yield self.msg_helper.add_outbound_to_conv(
-            self.conv, 20, time_multiplier=12)
-        inbound_aggregate = yield self.conv.get_aggregate_count('inbound')
-        self.assertEqual(inbound_aggregate, [])
-        outbound_aggregate = yield self.conv.get_aggregate_count('outbound')
-        bucket_keys = [bucket for bucket, _ in outbound_aggregate]
-        buckets = [keys for _, keys in outbound_aggregate]
-        self.assertEqual(
-            bucket_keys,
-            [datetime.now().date() - timedelta(days=i)
-                for i in range(9, -1, -1)])
-        for bucket in buckets:
-            self.assertEqual(bucket, 2)
-
-    @inlineCallbacks
     def test_get_groups(self):
         groups = yield self.user_helper.user_api.list_groups()
         self.assertEqual([], groups)


### PR DESCRIPTION
There are a few places where we compute aggregate statistics from the message store. Some of these were written with the now-invalid assumption that the message store cache contains all message keys for a conversation.
