### PR TITLE
update transaction cost calculations

### DIFF
--- a/go/billing/models.py
+++ b/go/billing/models.py
@@ -151,7 +151,7 @@ class MessageCost(models.Model):
             base_cost += session_cost
         if session_length and session_unit_length and session_unit_cost:
             units = (
-                Decimal(session_length)/Decimal(session_unit_length)
+                session_length / session_unit_length
                 ).to_integral_exact(rounding=ROUND_CEILING)
             base_cost += units * session_unit_cost
         return cls.apply_markup_and_convert_to_credits(

--- a/go/billing/models.py
+++ b/go/billing/models.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, ROUND_CEILING
 
 from django.db import models
 from django.db.models.signals import post_save
@@ -138,8 +138,10 @@ class MessageCost(models.Model):
             session_length_cost, markup_percent, context=context)
 
     @classmethod
-    def calculate_credit_cost(cls, message_cost, storage_cost, markup_percent,
-                              session_cost, session_created, context=None):
+    def calculate_credit_cost(
+            cls, message_cost, storage_cost, markup_percent, session_cost,
+            session_created, session_unit_cost=None, session_unit_length=None,
+            session_length=None, context=None):
         """
         Return the total cost for both the message and the session, if any,
         in credits.
@@ -147,6 +149,11 @@ class MessageCost(models.Model):
         base_cost = message_cost + storage_cost
         if session_created:
             base_cost += session_cost
+        if session_length and session_unit_length and session_unit_cost:
+            units = (
+                Decimal(session_length)/Decimal(session_unit_length)
+                ).to_integral_exact(rounding=ROUND_CEILING)
+            base_cost += units * session_unit_cost
         return cls.apply_markup_and_convert_to_credits(
             base_cost, markup_percent, context=context)
 

--- a/go/billing/tests/test_models.py
+++ b/go/billing/tests/test_models.py
@@ -179,6 +179,19 @@ class TestMessageCost(GoDjangoTestCase):
         self.assertEqual(context.flags[Inexact], 1)
         self.assertEqual(context.flags[Rounded], 1)
 
+    def test_calculate_credit_cost_with_session_length(self):
+        self.assertEqual(
+            MessageCost.calculate_credit_cost(
+                message_cost=Decimal('1.0'),
+                storage_cost=Decimal('3.0'),
+                session_cost=Decimal('2.0'),
+                session_unit_cost=Decimal('2.0'),
+                markup_percent=Decimal('10.0'),
+                session_created=True,
+                session_length=Decimal('25.0'),
+                session_unit_length=Decimal('20.0')),
+            Decimal('110.0'))
+
     def test_message_credit_cost(self):
         mc = self.mk_msg_cost(
             message_cost=Decimal('5.0'),


### PR DESCRIPTION
Update the transaction cost calculations to include calculating the cost of the time length of a session.
