### PR TITLE
Cache conversation objects in app workers

### DIFF
--- a/go/apps/http_api/tests/test_vumi_app.py
+++ b/go/apps/http_api/tests/test_vumi_app.py
@@ -30,6 +30,7 @@ class TestStreamingHTTPWorker(VumiTestCase):
             'web_path': '/foo',
             'web_port': 0,
             'metrics_prefix': 'metrics_prefix.',
+            'conversation_cache_ttl': 0,
         }
         self.app = yield self.app_helper.get_app_worker(self.config)
         self.addr = self.app.webserver.getHost()

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -159,6 +159,7 @@ class TestNoStreamingHTTPWorkerBase(VumiTestCase):
             'web_path': '/foo',
             'web_port': 0,
             'metrics_prefix': 'metrics_prefix.',
+            'conversation_cache_ttl': 0,
         }
         self.config.update(config_overrides)
         self.app = yield self.app_helper.get_app_worker(self.config)

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -198,7 +198,8 @@ class GoWorkerMixin(object):
             If the key count difference between the message_store and
             the cache is bigger than the delta a reconciliation is initiated.
         """
-        conv = yield user_api.get_wrapped_conversation(conversation_key)
+        conv = yield self.get_conversation(
+            user_api.user_account_key, conversation_key)
         if conv is None:
             log.error('Conversation does not exist: %s' % (conversation_key,))
             return
@@ -223,12 +224,10 @@ class GoWorkerMixin(object):
             delivery_class, message.user(), create=create)
         returnValue(contact)
 
-    @inlineCallbacks
     def get_conversation(self, user_account_key, conversation_key):
         user_api = self.get_user_api(user_account_key)
-        conv = yield self._conversation_cache.get_model(
-            user_api.get_conversation, conversation_key)
-        returnValue(user_api.wrap_conversation(conv))
+        return self._conversation_cache.get_model(
+            user_api.get_wrapped_conversation, conversation_key)
 
     def get_router(self, user_account_key, router_key):
         user_api = self.get_user_api(user_account_key)

--- a/go/vumitools/app_worker.py
+++ b/go/vumitools/app_worker.py
@@ -1,4 +1,5 @@
 from zope.interface import implements
+from twisted.internet import reactor
 from twisted.internet.defer import (
     inlineCallbacks, returnValue, maybeDeferred, gatherResults)
 
@@ -6,7 +7,8 @@ from vumi import log
 from vumi.worker import BaseWorker
 from vumi.application import ApplicationWorker
 from vumi.blinkenlights.metrics import MetricPublisher, Metric
-from vumi.config import IConfigData, ConfigText, ConfigDict, ConfigField
+from vumi.config import (
+    IConfigData, ConfigText, ConfigDict, ConfigField, ConfigFloat)
 from vumi.connectors import IgnoreMessage
 
 from go.config import get_conversation_definition
@@ -15,6 +17,7 @@ from go.vumitools.api import (
     ApiEventPublisher)
 from go.vumitools.metrics import (
     get_account_metric_prefix, get_conversation_metric_prefix)
+from go.vumitools.model_object_cache import ModelObjectCache
 from go.vumitools.utils import MessageMetadataHelper
 
 
@@ -52,6 +55,10 @@ class GoWorkerConfigMixin(object):
         "Name of this worker.", required=True, static=True)
     riak_manager = ConfigDict("Riak config.", static=True)
     redis_manager = ConfigDict("Redis config.", static=True)
+    conversation_cache_ttl = ConfigFloat(
+        "TTL (in seconds) for cached conversations. If less than or equal to"
+        " zero, conversations will not be cached.",
+        static=True, default=5)
 
 
 class GoWorkerMixin(object):
@@ -96,6 +103,11 @@ class GoWorkerMixin(object):
         if config.worker_name is not None:
             self.worker_name = config.worker_name
 
+        # Not all workers need this, but it's cheap if unused and easier to put
+        # here than a bunch of more specific places.
+        self._conversation_cache = ModelObjectCache(
+            reactor, config.conversation_cache_ttl)
+
         self.metric_publisher = yield self.start_publisher(MetricPublisher)
 
         yield self._go_setup_command_publisher(config)
@@ -105,6 +117,7 @@ class GoWorkerMixin(object):
 
     @inlineCallbacks
     def _go_teardown_worker(self):
+        yield self._conversation_cache.cleanup()
         # Sometimes something else closes our Redis connection.
         if self.redis is not None:
             yield self.redis.close_manager()
@@ -210,16 +223,20 @@ class GoWorkerMixin(object):
             delivery_class, message.user(), create=create)
         returnValue(contact)
 
+    @inlineCallbacks
     def get_conversation(self, user_account_key, conversation_key):
         user_api = self.get_user_api(user_account_key)
-        return user_api.get_wrapped_conversation(conversation_key)
+        conv = yield self._conversation_cache.get_model(
+            user_api.get_conversation, conversation_key)
+        returnValue(user_api.wrap_conversation(conv))
 
     def get_router(self, user_account_key, router_key):
         user_api = self.get_user_api(user_account_key)
         return user_api.get_router(router_key)
 
     def get_metadata_helper(self, msg):
-        return MessageMetadataHelper(self.vumi_api, msg)
+        return MessageMetadataHelper(
+            self.vumi_api, msg, conversation_cache=self._conversation_cache)
 
     @inlineCallbacks
     def find_outboundmessage_for_event(self, event):

--- a/go/vumitools/model_object_cache.py
+++ b/go/vumitools/model_object_cache.py
@@ -1,0 +1,64 @@
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+
+class ModelObjectCache(object):
+    """
+    Low-TTL cache for model data to avoid hitting Riak too much.
+    """
+    def __init__(self, reactor, ttl):
+        self._reactor = reactor
+        self._ttl = ttl
+        self._models = {}
+        self._evictors = {}
+
+    def evict_model_entry(self, key):
+        """
+        Remove an model from the cache.
+        """
+        del self._models[key]
+        del self._evictors[key]
+
+    def schedule_eviction(self, key):
+        """
+        Schedule the eviction of a cached model.
+        """
+        if key in self._evictors:
+            # We already have an evictor for this model, so we don't
+            # need a new one.
+            return
+        delayed_call = self._reactor.callLater(
+            self._ttl, self.evict_model_entry, key)
+        self._evictors[key] = delayed_call
+
+    def cleanup(self):
+        """
+        Clean up all remaining state.
+        """
+        # We use .items() instead of .iteritems() here because we modify
+        # self._evictors in the loop.
+        for key, delayed_call in self._evictors.items():
+            delayed_call.cancel()
+            self.evict_model_entry(key)
+
+    @inlineCallbacks
+    def get_model(self, model_getter, key):
+        """
+        Return the model using the provided getter function and key.
+
+        If the model is not cached, it will be fetched from Riak. If
+        caching is not disabled, it will also be added to the cache and
+        eviction scheduled.
+        """
+        if key not in self._models:
+            # Fetching the model returns control to the reactor and
+            # gives other things the opportunity to cache the model
+            # behind our back. If this happens, we replace the cached model
+            # (the one we fetched may be newer) and let schedule_eviction()
+            # worry about the existing evictor.
+            model = yield model_getter(key)
+            if self._ttl <= 0:
+                # Special case for disabled cache.
+                returnValue(model)
+            self._models[key] = model
+            self.schedule_eviction(key)
+        returnValue(self._models[key])

--- a/go/vumitools/tests/test_app_worker.py
+++ b/go/vumitools/tests/test_app_worker.py
@@ -70,6 +70,19 @@ class TestGoApplicationWorker(VumiTestCase):
         self.conv = yield self.app_helper.create_conversation()
 
     @inlineCallbacks
+    def test_conversation_cache_ttl_config(self):
+        """
+        The conversation_cache_ttl config option is passed to the cache.
+        """
+        # When the config isn't provided, we use the default.
+        self.assertEqual(self.app._conversation_cache._ttl, 5)
+
+        app_helper2 = self.add_helper(AppWorkerHelper(DummyApplication))
+        app2 = yield app_helper2.get_app_worker(
+            {"conversation_cache_ttl": 0})
+        self.assertEqual(app2._conversation_cache._ttl, 0)
+
+    @inlineCallbacks
     def test_message_not_processed_while_stopped(self):
         self.assertFalse(self.conv.running())
         self.assertEqual([], self.app.msgs)

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -796,6 +796,18 @@ class TestConversationStoringMiddleware(VumiTestCase):
         self.assertEqual(sorted(ids), sorted(m['message_id'] for m in msgs))
 
     @inlineCallbacks
+    def test_conversation_cache_ttl_config(self):
+        """
+        The conversation_cache_ttl config option is passed to the cache.
+        """
+        # When the config isn't provided, we use the default.
+        mw = yield self.mw_helper.create_middleware()
+        self.assertEqual(mw._conversation_cache._ttl, 5)
+        mw2 = yield self.mw_helper.create_middleware(
+            {"conversation_cache_ttl": 0})
+        self.assertEqual(mw2._conversation_cache._ttl, 0)
+
+    @inlineCallbacks
     def test_inbound_message(self):
         mw = yield self.mw_helper.create_middleware()
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -847,6 +847,32 @@ class TestConversationStoringMiddleware(VumiTestCase):
         yield mw.handle_publish_outbound(msg2, 'default')
         yield self.assert_stored_outbound([msg2])
 
+    @inlineCallbacks
+    def test_conversation_cached_for_inbound_message(self):
+        """
+        When we process an inbound message, the conversation lookup is cached.
+        """
+        mw = yield self.mw_helper.create_middleware()
+        cache = mw._conversation_cache
+
+        self.assertEqual(cache._models.keys(), [])
+        msg1 = self.mw_helper.make_inbound("inbound", conv=self.conv)
+        yield mw.handle_consume_inbound(msg1, 'default')
+        self.assertEqual(cache._models.keys(), [self.conv.key])
+
+    @inlineCallbacks
+    def test_conversation_cached_for_outbound_message(self):
+        """
+        When we process an outbound message, the conversation lookup is cached.
+        """
+        mw = yield self.mw_helper.create_middleware()
+        cache = mw._conversation_cache
+
+        self.assertEqual(cache._models.keys(), [])
+        msg1 = self.mw_helper.make_outbound("outbound", conv=self.conv)
+        yield mw.handle_consume_outbound(msg1, 'default')
+        self.assertEqual(cache._models.keys(), [self.conv.key])
+
 
 class TestRouterStoringMiddleware(VumiTestCase):
 

--- a/go/vumitools/tests/test_model_object_cache.py
+++ b/go/vumitools/tests/test_model_object_cache.py
@@ -1,0 +1,234 @@
+from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.task import Clock
+
+from vumi.tests.helpers import VumiTestCase
+
+from go.vumitools.model_object_cache import ModelObjectCache
+from go.vumitools.tests.helpers import VumiApiHelper
+
+
+class FakeModelObject(object):
+    """
+    A stand-in for a model object fetched from Riak.
+    """
+
+    def __init__(self, key):
+        self.key = key
+
+
+class TestModelObjectCache(VumiTestCase):
+    def setUp(self):
+        self.clock = Clock()
+
+    def make_object_getter(self, missing_keys=(), delay=0):
+        """
+        Build a function that returns a fake model object after a suitable
+        delay for any key not in the missing keys list.
+        """
+        def object_getter(key):
+            d = Deferred()
+            obj = None if key in missing_keys else FakeModelObject(key)
+            if delay > 0:
+                self.clock.callLater(delay, d.callback, obj)
+            else:
+                d.callback(obj)
+            return d
+
+        return object_getter
+
+    @inlineCallbacks
+    def test_get_model_not_cached(self):
+        """
+        When fetching an uncached model, we cache it.
+        """
+        cache = ModelObjectCache(self.clock, 5)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+        getter = self.make_object_getter()
+        model = yield cache.get_model(getter, "LisaFonssagrives")
+        self.assertEqual(model.key, "LisaFonssagrives")
+        self.assertEqual(cache._models, {"LisaFonssagrives": model})
+        self.assertEqual(cache._evictors.keys(), ["LisaFonssagrives"])
+
+        # Clean up remaining state.
+        cache.cleanup()
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    @inlineCallbacks
+    def test_cache_eviction(self):
+        """
+        When the TTL is reached, the model is removed from the cache.
+        """
+        cache = ModelObjectCache(self.clock, 5)
+        getter = self.make_object_getter()
+        model = yield cache.get_model(getter, "LisaFonssagrives")
+        self.assertEqual(model.key, "LisaFonssagrives")
+        self.assertEqual(cache._models, {"LisaFonssagrives": model})
+        self.assertEqual(cache._evictors.keys(), ["LisaFonssagrives"])
+
+        self.clock.advance(4.9)
+        self.assertNotEqual(cache._models, {})
+        self.assertNotEqual(cache._evictors, {})
+
+        self.clock.advance(0.5)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    @inlineCallbacks
+    def test_multiple_cache_eviction(self):
+        """
+        Each model has its own TTL.
+        """
+        cache = ModelObjectCache(self.clock, 5)
+        getter = self.make_object_getter()
+        model = yield cache.get_model(getter, "LisaFonssagrives")
+        self.assertEqual(cache._models, {"LisaFonssagrives": model})
+        self.assertEqual(cache._evictors.keys(), ["LisaFonssagrives"])
+
+        self.clock.advance(3)
+        model2 = yield cache.get_model(getter, "JinxFalkenburg")
+        self.assertEqual(cache._models, {
+            "LisaFonssagrives": model,
+            "JinxFalkenburg": model2,
+        })
+        self.assertEqual(
+            set(cache._evictors.keys()),
+            set(["LisaFonssagrives", "JinxFalkenburg"]))
+
+        self.clock.advance(3)
+        self.assertEqual(cache._models, {
+            "JinxFalkenburg": model2,
+        })
+        self.assertEqual(cache._evictors.keys(), ["JinxFalkenburg"])
+
+        self.clock.advance(3)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    @inlineCallbacks
+    def test_get_model_no_caching(self):
+        """
+        When caching is disabled, we always fetch the model and never
+        store it.
+        """
+        cache = ModelObjectCache(self.clock, 0)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+        getter = self.make_object_getter()
+        model = yield cache.get_model(getter, "LisaFonssagrives")
+        self.assertEqual(model.key, "LisaFonssagrives")
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    @inlineCallbacks
+    def test_schedule_duplicate_eviction(self):
+        """
+        If we schedule an eviction that already exists, we keep the old one
+        instead.
+        """
+        cache = ModelObjectCache(self.clock, 5)
+        getter = self.make_object_getter()
+        yield cache.get_model(getter, "LisaFonssagrives")
+        self.assertEqual(cache._evictors.keys(), ["LisaFonssagrives"])
+
+        delayed_call = cache._evictors["LisaFonssagrives"]
+        self.clock.advance(1)
+
+        # Calling schedule_eviction() doesn't replace the existing one.
+        cache.schedule_eviction("LisaFonssagrives")
+        self.assertNotEqual(cache._models, {})
+        self.assertEqual(cache._evictors["LisaFonssagrives"], delayed_call)
+
+        # The existing eviction happens at the expected time.
+        self.clock.advance(4)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+        # Advance to the time the new eviction would have been schduled to make
+        # sure nothing breaks.
+        self.clock.advance(1)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    @inlineCallbacks
+    def test_get_missing_model(self):
+        """
+        If a getter returns None instead of a model, the None is cached.
+        """
+        cache = ModelObjectCache(self.clock, 5)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+        getter = self.make_object_getter(missing_keys=["TinLizzy"])
+        model = yield cache.get_model(getter, "TinLizzy")
+        self.assertEqual(model, None)
+        self.assertEqual(cache._models, {"TinLizzy": None})
+        self.assertEqual(cache._evictors.keys(), ["TinLizzy"])
+
+        # Clean up remaining state.
+        cache.cleanup()
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    def test_overlapping_gets(self):
+        """
+        If there are multiple pending gets for the same uncached key, the
+        cached value will be replaced when each returns.
+        """
+        cache = ModelObjectCache(self.clock, 5)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+        getter = self.make_object_getter(delay=3)
+        getter_missing = self.make_object_getter(
+            missing_keys=["LisaFonssagrives"], delay=1)
+        model1_d = cache.get_model(getter, "LisaFonssagrives")
+        self.clock.advance(1)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors.keys(), [])
+
+        model2_d = cache.get_model(getter_missing, "LisaFonssagrives")
+        self.clock.advance(1)
+        model2 = self.successResultOf(model2_d)
+        self.assertNoResult(model1_d)
+        self.assertEqual(model2, None)
+        self.assertEqual(cache._models, {"LisaFonssagrives": None})
+        self.assertEqual(cache._evictors.keys(), ["LisaFonssagrives"])
+
+        self.clock.advance(1)
+        model1 = self.successResultOf(model1_d)
+        self.assertEqual(model1.key, "LisaFonssagrives")
+        self.assertEqual(cache._models, {"LisaFonssagrives": model1})
+        self.assertEqual(cache._evictors.keys(), ["LisaFonssagrives"])
+
+        # Clean up remaining state.
+        cache.cleanup()
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+    @inlineCallbacks
+    def test_get_account_object(self):
+        """
+        The cache works correctly when fetching real model objects.
+        """
+        vumi_helper = yield self.add_helper(VumiApiHelper())
+        user_helper = yield vumi_helper.make_user(u'testuser')
+        account_key = user_helper.account_key
+
+        cache = ModelObjectCache(self.clock, 5)
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})
+
+        getter = vumi_helper.get_vumi_api().get_user_account
+        model = yield cache.get_model(getter, account_key)
+        self.assertEqual(model.key, account_key)
+        self.assertEqual(cache._models, {account_key: model})
+        self.assertEqual(cache._evictors.keys(), [account_key])
+
+        # Clean up remaining state.
+        cache.cleanup()
+        self.assertEqual(cache._models, {})
+        self.assertEqual(cache._evictors, {})


### PR DESCRIPTION
We do this for account objects in the routing table dispatcher, so we should do it for conversation objects as well.
