### PR TITLE
Remove unnecessary outbound message look-up in HTTP API event processing.

### DIFF
--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -258,15 +258,6 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
 
     @inlineCallbacks
     def consume_unknown_event(self, event):
-        """
-        FIXME:  We're forced to do too much hoopla when trying to link events
-                back to the conversation the original message was part of.
-        """
-        outbound_message = yield self.find_outboundmessage_for_event(event)
-        if outbound_message is None:
-            log.warning('Unable to find message %s for event %s.' % (
-                event['user_message_id'], event['event_id']))
-
         config = yield self.get_message_config(event)
         conversation = config.conversation
         ignore = self.get_api_config(conversation, 'ignore_events', False)


### PR DESCRIPTION
See https://github.com/praekelt/vumi-go/blob/develop/go/apps/http_api_nostream/vumi_app.py#L265-L268. Notice that the outbound message is only used for logging and that an event can't be routed to an application worker unless the routing table dispatcher has found an outbound message for it.
