### PR TITLE
allow contacts to be looked up through field

### DIFF
--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -222,8 +222,9 @@ class ContactStore(PerAccountStore):
     @Manager.calls_manager
     def new_smart_group(self, name, query):
         group_id = uuid4().get_hex()
-        group = self.groups(group_id, name=name,
-            user_account=self.user_account_key, query=query)
+        group = self.groups(
+            group_id, name=name, user_account=self.user_account_key,
+            query=query)
         yield group.save()
         returnValue(group)
 

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -124,6 +124,10 @@ class Contact(Model):
     mxit_id = Unicode(null=True, index=True)
     wechat_id = Unicode(null=True, index=True)
 
+    ADDRESS_FIELDS = [
+        'msisdn', 'twitter_handle', 'facebook_id', 'bbm_pin', 'gtalk_id',
+        'mxit_id', 'wechat_id']
+
     def add_to_group(self, group):
         if isinstance(group, ContactGroup):
             self.groups.add(group)

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -336,7 +336,6 @@ class ContactStore(PerAccountStore):
         Returns a contact from a field (address type) and address, raising a
         ContactNotFoundError exception if the contact does not exist.
         """
-        value = normalize_addr(field, value)
         keys = None
         if self.FIND_BY_INDEX:
             keys = yield self.contacts.index_keys(field, value)
@@ -373,6 +372,7 @@ class ContactStore(PerAccountStore):
         Returns a contact from a delivery class and address, raising a
         ContactNotFoundError exception if the contact does not exist.
         """
+        addr = normalize_addr(delivery_class, addr)
         field, value = contact_field_for_addr(delivery_class, addr)
         try:
             contact = yield self.contact_for_addr_field(field, value, create)
@@ -381,4 +381,3 @@ class ContactStore(PerAccountStore):
                 "Contact with address '%s' for delivery class '%s' not found."
                 % (addr, delivery_class))
         returnValue(contact)
-        

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -61,7 +61,8 @@ def normalize_addr(contact_field, addr):
         addr = '+' + addr.lstrip('+')
     elif contact_field == 'gtalk':
         addr = addr.partition('/')[0]
-    return (contact_field, addr)
+    return addr
+
 
 def contact_field_for_addr(delivery_class, addr):
     # TODO: change when we have proper address types in vumi
@@ -334,7 +335,7 @@ class ContactStore(PerAccountStore):
         Returns a contact from a field (address type) and address, raising a
         ContactNotFoundError exception if the contact does not exist.
         """
-        field, value = normalize_addr(field, value)
+        value = normalize_addr(field, value)
         keys = None
         if self.FIND_BY_INDEX:
             keys = yield self.contacts.index_keys(field, value)

--- a/go/vumitools/contact/models.py
+++ b/go/vumitools/contact/models.py
@@ -70,11 +70,7 @@ def contact_field_for_addr(delivery_class, addr):
         raise ContactError("Unsupported transport_type %r" % delivery_class)
 
     contact_field = delivery_class_dict['field']
-    if contact_field == 'msisdn':
-        addr = '+' + addr.lstrip('+')
-    elif contact_field == 'gtalk':
-        addr = addr.partition('/')[0]
-    return normalize_addr(contact_field, addr)
+    return contact_field, addr
 
 
 class ContactGroup(Model):

--- a/go/vumitools/contact/tests/test_models.py
+++ b/go/vumitools/contact/tests/test_models.py
@@ -193,6 +193,23 @@ class TestContactStore(VumiTestCase):
         self.assertEqual(contact.key, found_contact.key)
 
     @inlineCallbacks
+    def test_contact_for_field_msisdn(self):
+        contact = yield self.contact_store.new_contact(
+            name=u'name', msisdn=u'+123456')
+        found_contact = yield self.contact_store.contact_for_addr_field(
+            'msisdn', u'+123456', create=False)
+        self.assertEqual(contact.key, found_contact.key)
+
+    @inlineCallbacks
+    def test_contact_for_field_not_found(self):
+        yield self.contact_store.new_contact(
+            name=u'name', msisdn=u'+27831234567')
+        self.contact_store.FIND_BY_INDEX_SEARCH_FALLBACK = False
+        contact_d = self.contact_store.contact_for_addr_field(
+            'msisdn', u'nothing', create=False)
+        yield self.assertFailure(contact_d, ContactNotFoundError)
+
+    @inlineCallbacks
     def test_contact_for_addr_gtalk(self):
         contact = yield self.contact_store.new_contact(
             name=u'name', msisdn=u'+27831234567', gtalk_id=u'foo@example.com')


### PR DESCRIPTION
Allow contacts to be looked up by specifying a field and field value, as well as the delivery class. This is to form part of the plan to replace delivery classes with address types. Full plan discussed here: https://github.com/praekelt/go-contacts-api/pull/29#issuecomment-73244656
