### PR TITLE
Fix message store timestamp index parsing in go_account_stats

### DIFF
--- a/go/base/tests/test_go_account_stats.py
+++ b/go/base/tests/test_go_account_stats.py
@@ -58,6 +58,14 @@ class TestGoAccountStatsCommand(GoDjangoTestCase):
         self.assertEqual(len(output), 1)
         self.assertTrue(active_conv.key in output[0])
 
+    def test_parse_timestamp_to_date(self):
+        self.assertEqual(
+            self.command.parse_timestamp_to_date('2015-01-01 12:00:00'),
+            datetime(2015, 1, 1, 0, 0, 0).date())
+        self.assertEqual(
+            self.command.parse_timestamp_to_date('2015-01-01 12:00:00.123'),
+            datetime(2015, 1, 1, 0, 0, 0).date())
+
     def test_stats(self):
         msg_helper = GoMessageHelper(vumi_helper=self.vumi_helper)
         conv = self.user_helper.create_conversation(


### PR DESCRIPTION
Currently the Vumi message store formats timestamps in indexes using `str(msg['timestamp'])` which results in different behaviour depending on whether the microseconds are zero or not:

```
>>> str(n.replace(microsecond=0))
'2015-03-05 22:11:00'
>>> str(n)
'2015-03-05 22:11:00.124000'
```

Current go_account_stats only supports timestamps with microseconds set to 0 (unlikely in production).
