### PR TITLE
Handle 0 session length unit costs when generating statements

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -172,7 +172,11 @@ def get_count(transaction):
 def get_session_length_count(transaction):
     length_cost = get_session_length_cost(transaction)
     unit_cost = get_session_length_unit_cost(transaction)
-    return length_cost / (unit_cost if unit_cost != 0 else 1)
+
+    if unit_cost == 0:
+        return Decimal(0)
+    else:
+        return length_cost / unit_cost
 
 
 def get_message_unit_cost(transaction):

--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -171,7 +171,8 @@ def get_count(transaction):
 
 def get_session_length_count(transaction):
     length_cost = get_session_length_cost(transaction)
-    return length_cost / get_session_length_unit_cost(transaction)
+    unit_cost = get_session_length_unit_cost(transaction)
+    return length_cost / (unit_cost if unit_cost != 0 else 1)
 
 
 def get_message_unit_cost(transaction):

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -555,6 +555,24 @@ class TestMonthlyStatementTask(GoDjangoTestCase):
         self.assertEqual(item3.cost, 600)
         self.assertEqual(item3.units, 2)
 
+    def test_generate_monthly_statement_zero_session_unit_cost(self):
+        mk_transaction(
+            self.account,
+            session_unit_time=20,
+            session_unit_cost=0,
+            session_length_cost=0,
+            markup_percent=10.0)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+        [item] = get_line_items(statement).filter(
+            description='Session intervals (billed per 20s)')
+
+        self.assertEqual(item.credits, 0)
+        self.assertEqual(item.unit_cost, 0)
+        self.assertEqual(item.cost, 0)
+        self.assertEqual(item.units, 0)
+
     def test_generate_monthly_statement_session_length_different_markups(self):
         mk_transaction(
             self.account,


### PR DESCRIPTION
At the moment this is causing zero divisions.
