### PR TITLE
ConservationWrapper.collect_messages should filter tombstones.

### DIFF
--- a/go/vumitools/conversation/utils.py
+++ b/go/vumitools/conversation/utils.py
@@ -229,7 +229,8 @@ class ConversationWrapper(object):
         messages = []
         for key in keys:
             msg = yield get_msg(key)
-            messages.append(msg)
+            if msg is not None:
+                messages.append(msg)
 
         returnValue(self.filter_and_scrub_messages(
             messages, include_sensitive=include_sensitive, scrubber=scrubber))


### PR DESCRIPTION
Otherwise we get tracebacks like:

```
File "/var/praekelt/vumi-go/go/conversation/view_definition.py", line 257, in <lambda>
    start, stop)), 20)

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py", line 696, in wrapper
    return manager.call_decorator(func)(self, *args, **kw)

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/utils.py", line 369, in wrapped
    result = gen.send(result)

  File "/var/praekelt/vumi-go/go/vumitools/conversation/utils.py", line 296, in received_messages_in_cache
    keys, self.mdb.get_inbound_message, include_sensitive, scrubber)

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/persist/model.py", line 696, in wrapper
    return manager.call_decorator(func)(self, *args, **kw)

  File "/var/praekelt/vumi-go/ve/src/vumi/vumi/utils.py", line 369, in wrapped
    result = gen.send(result)

  File "/var/praekelt/vumi-go/go/vumitools/conversation/utils.py", line 235, in collect_messages
    messages, include_sensitive=include_sensitive, scrubber=scrubber))

  File "/var/praekelt/vumi-go/go/vumitools/conversation/utils.py", line 251, in filter_and_scrub_messages
    msg_mdh = MessageMetadataHelper(self.api, msg)

  File "/var/praekelt/vumi-go/go/vumitools/utils.py", line 138, in __init__
    message.get('helper_metadata', {}))

AttributeError: 'NoneType' object has no attribute 'get'
```
