### PR TITLE
Filter line items with 0 units when creating statements

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -20,7 +20,7 @@ from go.billing.models import (
     Account, MessageCost, Transaction, Statement, LineItem, TransactionArchive,
     LowCreditNotification)
 from go.billing.django_utils import TransactionSerializer
-from go.base.utils import vumi_api, format_currency
+from go.base.utils import format_currency
 
 
 def month_range(months_ago=1, today=None):
@@ -111,6 +111,10 @@ def get_session_length_transactions(transactions):
     transactions = transactions.filter(
         transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
+    transactions = transactions.exclude(session_length=0)
+    transactions = transactions.exclude(session_length=None)
+    transactions = transactions.exclude(session_length_cost=0)
+
     transactions = transactions.values(
         'tag_pool_name',
         'tag_name',
@@ -174,11 +178,8 @@ def get_count(transaction):
 def get_session_length_count(transaction):
     length_cost = get_session_length_cost(transaction)
     unit_cost = get_session_length_unit_cost(transaction)
-
-    if unit_cost == 0:
-        return Decimal(0)
-    else:
-        return length_cost / unit_cost
+    # no 0 unit costs will appear, these are filtered out
+    return length_cost / unit_cost
 
 
 def get_message_unit_cost(transaction):

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -592,7 +592,7 @@ class TestMonthlyStatementTask(GoDjangoTestCase):
             self.account,
             session_unit_time=20,
             session_unit_cost=0.2,
-            session_length=None,
+            session_length=0,
             markup_percent=10.0)
 
         statement = tasks.generate_monthly_statement(

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -565,13 +565,43 @@ class TestMonthlyStatementTask(GoDjangoTestCase):
 
         statement = tasks.generate_monthly_statement(
             self.account.id, *this_month())
-        [item] = get_line_items(statement).filter(
+
+        items = get_line_items(statement).filter(
             description='Session intervals (billed per 20s)')
 
-        self.assertEqual(item.credits, 0)
-        self.assertEqual(item.unit_cost, 0)
-        self.assertEqual(item.cost, 0)
-        self.assertEqual(item.units, 0)
+        self.assertFalse(items.exists())
+
+    def test_generate_monthly_statement_none_session_length(self):
+        mk_transaction(
+            self.account,
+            session_unit_time=20,
+            session_unit_cost=0.2,
+            session_length=None,
+            markup_percent=10.0)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        items = get_line_items(statement).filter(
+            description='Session intervals (billed per 20s)')
+
+        self.assertFalse(items.exists())
+
+    def test_generate_monthly_statement_zero_session_length(self):
+        mk_transaction(
+            self.account,
+            session_unit_time=20,
+            session_unit_cost=0.2,
+            session_length=None,
+            markup_percent=10.0)
+
+        statement = tasks.generate_monthly_statement(
+            self.account.id, *this_month())
+
+        items = get_line_items(statement).filter(
+            description='Session intervals (billed per 20s)')
+
+        self.assertFalse(items.exists())
 
     def test_generate_monthly_statement_session_length_different_markups(self):
         mk_transaction(


### PR DESCRIPTION
Since session interval line items have 0 unit counts when the session unit cost is 0: We work out the unit count as `total_session_length_cost / session_unit_cost`, but use `0` if the total session length cost (and thus also the unit cost) is zero. These items are more confusing than they are useful.
