### PR TITLE
Unique identifier for command messages

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -110,7 +110,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
         conversation = conv_helper.get_conversation()
         self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
-            'bulk_send',
+            'bulk_send', command_id=bulk_send_cmd["command_id"],
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},
@@ -130,7 +130,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
         conversation = conv_helper.get_conversation()
         self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
-            'bulk_send',
+            'bulk_send', command_id=bulk_send_cmd["command_id"],
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},
@@ -168,7 +168,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
         self.assertEqual(
             VumiApiCommand.command(
                 '%s_application' % (conversation.conversation_type,),
-                'send_message',
+                'send_message', command_id=token_send_cmd["command_id"],
                 user_account_key=conversation.user_account.key,
                 conversation_key=conversation.key,
                 command_data=dict(
@@ -196,7 +196,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
         [bulk_send_cmd] = self.app_helper.get_api_commands_sent()
         self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
-            'bulk_send',
+            'bulk_send', command_id=bulk_send_cmd["command_id"],
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -43,7 +43,7 @@ class TestDialogueViews(GoDjangoTestCase):
         conversation = conv_helper.get_conversation()
         self.assertEqual(send_jsbox_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
-            'send_jsbox',
+            'send_jsbox', command_id=send_jsbox_cmd["command_id"],
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key))

--- a/go/apps/jsbox/tests/test_views.py
+++ b/go/apps/jsbox/tests/test_views.py
@@ -44,7 +44,7 @@ class TestJsBoxViews(GoDjangoTestCase):
         conversation = conv_helper.get_conversation()
         self.assertEqual(send_jsbox_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
-            'send_jsbox',
+            'send_jsbox', command_id=send_jsbox_cmd["command_id"],
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key))

--- a/go/apps/surveys/tests/test_views.py
+++ b/go/apps/surveys/tests/test_views.py
@@ -46,7 +46,7 @@ class TestSurveysViews(GoDjangoTestCase):
         conversation = conv_helper.get_conversation()
         self.assertEqual(send_survey_cmd, VumiApiCommand.command(
             '%s_application' % (conversation.conversation_type,),
-            'send_survey',
+            'send_survey', command_id=send_survey_cmd["command_id"],
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -528,6 +528,7 @@ class TestConversationViews(BaseConversationViewTestCase):
         [start_cmd] = self.get_api_commands_sent()
         self.assertEqual(start_cmd, VumiApiCommand.command(
             '%s_application' % (conv.conversation_type,), 'start',
+            command_id=start_cmd["command_id"],
             user_account_key=conv.user_account.key, conversation_key=conv.key))
 
     def test_stop(self):

--- a/go/routers/app_multiplexer/tests/test_views.py
+++ b/go/routers/app_multiplexer/tests/test_views.py
@@ -52,6 +52,7 @@ class ApplicationMultiplexerViewTests(GoDjangoTestCase):
         self.assertEqual(
             start_cmd, VumiApiCommand.command(
                 '%s_router' % (router.router_type,), 'start',
+                command_id=start_cmd["command_id"],
                 user_account_key=router.user_account.key,
                 router_key=router.key))
 
@@ -62,10 +63,11 @@ class ApplicationMultiplexerViewTests(GoDjangoTestCase):
         self.assertRedirects(response, rtr_helper.get_view_url('show'))
         router = rtr_helper.get_router()
         self.assertTrue(router.stopping())
-        [start_cmd] = self.router_helper.get_api_commands_sent()
+        [stop_cmd] = self.router_helper.get_api_commands_sent()
         self.assertEqual(
-            start_cmd, VumiApiCommand.command(
+            stop_cmd, VumiApiCommand.command(
                 '%s_router' % (router.router_type,), 'stop',
+                command_id=stop_cmd["command_id"],
                 user_account_key=router.user_account.key,
                 router_key=router.key))
 

--- a/go/routers/group/tests/test_views.py
+++ b/go/routers/group/tests/test_views.py
@@ -50,6 +50,7 @@ class GroupViewTests(GoDjangoTestCase):
         self.assertEqual(
             start_cmd, VumiApiCommand.command(
                 '%s_router' % (router.router_type,), 'start',
+                command_id=start_cmd["command_id"],
                 user_account_key=router.user_account.key,
                 router_key=router.key))
 
@@ -60,10 +61,11 @@ class GroupViewTests(GoDjangoTestCase):
         self.assertRedirects(response, rtr_helper.get_view_url('show'))
         router = rtr_helper.get_router()
         self.assertTrue(router.stopping())
-        [start_cmd] = self.router_helper.get_api_commands_sent()
+        [stop_cmd] = self.router_helper.get_api_commands_sent()
         self.assertEqual(
-            start_cmd, VumiApiCommand.command(
+            stop_cmd, VumiApiCommand.command(
                 '%s_router' % (router.router_type,), 'stop',
+                command_id=stop_cmd["command_id"],
                 user_account_key=router.user_account.key,
                 router_key=router.key))
 

--- a/go/routers/keyword/tests/test_views.py
+++ b/go/routers/keyword/tests/test_views.py
@@ -50,6 +50,7 @@ class KeywordViewTests(GoDjangoTestCase):
         self.assertEqual(
             start_cmd, VumiApiCommand.command(
                 '%s_router' % (router.router_type,), 'start',
+                command_id=start_cmd["command_id"],
                 user_account_key=router.user_account.key,
                 router_key=router.key))
 
@@ -60,10 +61,11 @@ class KeywordViewTests(GoDjangoTestCase):
         self.assertRedirects(response, rtr_helper.get_view_url('show'))
         router = rtr_helper.get_router()
         self.assertTrue(router.stopping())
-        [start_cmd] = self.router_helper.get_api_commands_sent()
+        [stop_cmd] = self.router_helper.get_api_commands_sent()
         self.assertEqual(
-            start_cmd, VumiApiCommand.command(
+            stop_cmd, VumiApiCommand.command(
                 '%s_router' % (router.router_type,), 'stop',
+                command_id=stop_cmd["command_id"],
                 user_account_key=router.user_account.key,
                 router_key=router.key))
 


### PR DESCRIPTION
Turns out it's useful to be able to differentiate between different commands that are otherwise identical.
