### PR TITLE
billing api to block accounts with insufficient credits

### DIFF
--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -267,13 +267,11 @@ class TransactionResource(BaseResource):
         last_topup_balance = result.get('last_topup_balance')
         credit_balance = result.get('credit_balance')
 
-        def credit_percent():
-            return self._ceil_percent(credit_balance, last_topup_balance)
-
         # If the message is outbound and limit is reached, don't charge
         if (app_settings.ENABLE_LOW_CREDIT_CUTOFF and last_topup_balance and
                 message_direction == MESSAGE_DIRECTION_OUTBOUND):
-            if credit_percent() < self._notification_mapping[0]:
+            if (self._ceil_percent(credit_balance, last_topup_balance) <
+                    self._notification_mapping[0]):
                 defer.returnValue({
                     'credit_cutoff_reached': True,
                     'transaction': None,
@@ -378,7 +376,8 @@ class TransactionResource(BaseResource):
                 account_number)
 
         if app_settings.ENABLE_LOW_CREDIT_CUTOFF and last_topup_balance:
-            if credit_percent() < self._notification_mapping[0]:
+            if (self._ceil_percent(credit_balance, last_topup_balance) <
+                    self._notification_mapping[0]):
                 defer.returnValue({
                     'transaction': transaction,
                     'credit_cutoff_reached': True,

--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -268,11 +268,11 @@ class TransactionResource(BaseResource):
         credit_balance = result.get('credit_balance')
 
         # If the message is outbound and limit is reached, don't charge
-        if (last_topup_balance and
+        if (app_settings.ENABLE_LOW_CREDIT_CUTOFF and last_topup_balance and
                 message_direction == MESSAGE_DIRECTION_OUTBOUND):
             credit_percent = int(math.ceil(
                 (credit_balance) * 100 / last_topup_balance))
-            if credit_percent < app_settings.CREDIT_PERCENT_CUTOFF:
+            if credit_percent < self._notification_mapping[0]:
                 defer.returnValue({'credit_cutoff_reached': True})
 
         # Create a new transaction
@@ -373,10 +373,10 @@ class TransactionResource(BaseResource):
                 credit_balance, credit_amount, last_topup_balance,
                 account_number)
 
-        if last_topup_balance:
+        if app_settings.ENABLE_LOW_CREDIT_CUTOFF and last_topup_balance:
             credit_percent = int(math.ceil(
                 credit_balance * 100 / last_topup_balance))
-            if credit_percent < app_settings.CREDIT_PERCENT_CUTOFF:
+            if credit_percent < self._notification_mapping[0]:
                 transaction['credit_cutoff_reached'] = True
 
         defer.returnValue(transaction)

--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -274,7 +274,10 @@ class TransactionResource(BaseResource):
         if (app_settings.ENABLE_LOW_CREDIT_CUTOFF and last_topup_balance and
                 message_direction == MESSAGE_DIRECTION_OUTBOUND):
             if credit_percent() < self._notification_mapping[0]:
-                defer.returnValue({'credit_cutoff_reached': True})
+                defer.returnValue({
+                    'credit_cutoff_reached': True,
+                    'transaction': None,
+                })
 
         # Create a new transaction
         query = """
@@ -376,9 +379,15 @@ class TransactionResource(BaseResource):
 
         if app_settings.ENABLE_LOW_CREDIT_CUTOFF and last_topup_balance:
             if credit_percent() < self._notification_mapping[0]:
-                transaction['credit_cutoff_reached'] = True
+                defer.returnValue({
+                    'transaction': transaction,
+                    'credit_cutoff_reached': True,
+                })
 
-        defer.returnValue(transaction)
+        defer.returnValue({
+            'transaction': transaction,
+            'credit_cutoff_reached': False,
+        })
 
     def check_and_notify_low_credit_threshold(
             self, credit_balance, credit_amount, last_topup_balance,

--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -351,6 +351,12 @@ class TransactionResource(BaseResource):
                 credit_balance, credit_amount, last_topup_balance,
                 account_number)
 
+        if last_topup_balance:
+            credit_percent = int(math.ceil(
+                credit_balance * 100 / last_topup_balance))
+            if credit_percent < app_settings.CREDIT_PERCENT_CUTOFF:
+                transaction['credit_cutoff_reached'] = True
+
         defer.returnValue(transaction)
 
     def check_and_notify_low_credit_threshold(

--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -56,6 +56,9 @@ LOW_CREDIT_NOTIFICATION_PERCENTAGES = getattr(
 LOW_CREDIT_NOTIFICATION_EMAIL = getattr(
     settings, 'BILLING_LOW_CREDIT_NOTIFICATION_EMAIL', 'support@vumi.org')
 
+CREDIT_PERCENT_CUTOFF = getattr(
+    settings, 'BILLING_CREDIT_PERCENT_CUTOFF', None)
+
 PROVIDERS = getattr(settings, 'BILLING_PROVIDERS', {
     'mtn': 'MTN',
     'vodacom': 'Vodacom',

--- a/go/billing/settings.py
+++ b/go/billing/settings.py
@@ -56,8 +56,8 @@ LOW_CREDIT_NOTIFICATION_PERCENTAGES = getattr(
 LOW_CREDIT_NOTIFICATION_EMAIL = getattr(
     settings, 'BILLING_LOW_CREDIT_NOTIFICATION_EMAIL', 'support@vumi.org')
 
-CREDIT_PERCENT_CUTOFF = getattr(
-    settings, 'BILLING_CREDIT_PERCENT_CUTOFF', None)
+ENABLE_LOW_CREDIT_CUTOFF = getattr(
+    settings, 'BILLING_ENABLE_LOW_CREDIT_CUTOFF', False)
 
 PROVIDERS = getattr(settings, 'BILLING_PROVIDERS', {
     'mtn': 'MTN',

--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -296,43 +296,43 @@ class TestTransaction(BillingApiTestCase):
         self.assertTrue(transaction2.get('credit_cutoff_reached', False))
         self.assertEqual(Transaction.objects.count(), 3)
 
-        @inlineCallbacks
-        def test_credit_cutoff_outbound(self):
-            self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
+    @inlineCallbacks
+    def test_credit_cutoff_outbound(self):
+        self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
 
-            mk_message_cost(
-                tag_pool=self.pool1,
-                message_direction=MessageCost.DIRECTION_OUTBOUND,
-                message_cost=0.2,
-                storage_cost=0.0,
-                session_cost=0.0,
-                markup_percent=0.0)
+        mk_message_cost(
+            tag_pool=self.pool1,
+            message_direction=MessageCost.DIRECTION_OUTBOUND,
+            message_cost=0.2,
+            storage_cost=0.0,
+            session_cost=0.0,
+            markup_percent=0.0)
 
-            load_account_credits(self.account, 10)
+        load_account_credits(self.account, 10)
 
-            transaction1 = yield self.create_api_transaction(
-                account_number=self.account.account_number,
-                message_id='msg-id-1',
-                tag_pool_name='pool1',
-                tag_name='tag1',
-                message_direction=MessageCost.DIRECTION_OUTBOUND,
-                session_created=False,
-                transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
+        transaction1 = yield self.create_api_transaction(
+            account_number=self.account.account_number,
+            message_id='msg-id-1',
+            tag_pool_name='pool1',
+            tag_name='tag1',
+            message_direction=MessageCost.DIRECTION_OUTBOUND,
+            session_created=False,
+            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-            self.assertFalse(transaction1.get('credit_cutoff_reached', False))
-            self.assertEqual(Transaction.objects.count(), 2)
+        self.assertFalse(transaction1.get('credit_cutoff_reached', False))
+        self.assertEqual(Transaction.objects.count(), 2)
 
-            transaction2 = yield self.create_api_transaction(
-                account_number=self.account.account_number,
-                message_id='msg-id-1',
-                tag_pool_name='pool1',
-                tag_name='tag1',
-                message_direction=MessageCost.DIRECTION_OUTBOUND,
-                session_created=False,
-                transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
+        transaction2 = yield self.create_api_transaction(
+            account_number=self.account.account_number,
+            message_id='msg-id-1',
+            tag_pool_name='pool1',
+            tag_name='tag1',
+            message_direction=MessageCost.DIRECTION_OUTBOUND,
+            session_created=False,
+            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-            self.assertTrue(transaction2.get('credit_cutoff_reached', False))
-            self.assertEqual(Transaction.objects.count(), 2)
+        self.assertTrue(transaction2.get('credit_cutoff_reached', False))
+        self.assertEqual(Transaction.objects.count(), 2)
 
     @inlineCallbacks
     def test_transaction(self):

--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -259,7 +259,7 @@ class TestTransaction(BillingApiTestCase):
         self.assertFalse(mock_task_delay.called)
 
     @inlineCallbacks
-    def test_credit_cutoff_inbound(self):
+    def test_credit_cutoff_inbound_not_reached(self):
         self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
 
         mk_message_cost(
@@ -283,21 +283,35 @@ class TestTransaction(BillingApiTestCase):
 
         self.assertFalse(transaction1.get('credit_cutoff_reached', False))
         self.assertEqual(Transaction.objects.count(), 2)
-
-        transaction2 = yield self.create_api_transaction(
-            account_number=self.account.account_number,
-            message_id='msg-id-1',
-            tag_pool_name='pool1',
-            tag_name='tag1',
-            message_direction=MessageCost.DIRECTION_INBOUND,
-            session_created=False,
-            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
-
-        self.assertTrue(transaction2.get('credit_cutoff_reached', False))
-        self.assertEqual(Transaction.objects.count(), 3)
 
     @inlineCallbacks
-    def test_credit_cutoff_outbound(self):
+    def test_credit_cutoff_inbound_reached(self):
+        self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
+
+        mk_message_cost(
+            tag_pool=self.pool1,
+            message_direction=MessageCost.DIRECTION_INBOUND,
+            message_cost=0.4,
+            storage_cost=0.0,
+            session_cost=0.0,
+            markup_percent=0.0)
+
+        load_account_credits(self.account, 10)
+
+        transaction = yield self.create_api_transaction(
+            account_number=self.account.account_number,
+            message_id='msg-id-1',
+            tag_pool_name='pool1',
+            tag_name='tag1',
+            message_direction=MessageCost.DIRECTION_INBOUND,
+            session_created=False,
+            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
+
+        self.assertTrue(transaction.get('credit_cutoff_reached', False))
+        self.assertEqual(Transaction.objects.count(), 2)
+
+    @inlineCallbacks
+    def test_credit_cutoff_outbound_not_reached(self):
         self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
 
         mk_message_cost(
@@ -322,6 +336,20 @@ class TestTransaction(BillingApiTestCase):
         self.assertFalse(transaction1.get('credit_cutoff_reached', False))
         self.assertEqual(Transaction.objects.count(), 2)
 
+    @inlineCallbacks
+    def test_credit_cutoff_outbound_reached(self):
+        self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
+
+        mk_message_cost(
+            tag_pool=self.pool1,
+            message_direction=MessageCost.DIRECTION_OUTBOUND,
+            message_cost=0.4,
+            storage_cost=0.0,
+            session_cost=0.0,
+            markup_percent=0.0)
+
+        load_account_credits(self.account, 10)
+
         transaction2 = yield self.create_api_transaction(
             account_number=self.account.account_number,
             message_id='msg-id-1',
@@ -329,7 +357,8 @@ class TestTransaction(BillingApiTestCase):
             tag_name='tag1',
             message_direction=MessageCost.DIRECTION_OUTBOUND,
             session_created=False,
-            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
+            transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE
+        )
 
         self.assertTrue(transaction2.get('credit_cutoff_reached', False))
         self.assertEqual(Transaction.objects.count(), 2)

--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -260,12 +260,12 @@ class TestTransaction(BillingApiTestCase):
 
     @inlineCallbacks
     def test_credit_cutoff_inbound(self):
-        self.patch(app_settings, 'CREDIT_PERCENT_CUTOFF', -5)
+        self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
 
         mk_message_cost(
             tag_pool=self.pool1,
             message_direction=MessageCost.DIRECTION_INBOUND,
-            message_cost=1.0,
+            message_cost=0.2,
             storage_cost=0.0,
             session_cost=0.0,
             markup_percent=0.0)
@@ -298,12 +298,12 @@ class TestTransaction(BillingApiTestCase):
 
         @inlineCallbacks
         def test_credit_cutoff_outbound(self):
-            self.patch(app_settings, 'CREDIT_PERCENT_CUTOFF', -5)
+            self.patch(app_settings, 'ENABLE_LOW_CREDIT_CUTOFF', True)
 
             mk_message_cost(
                 tag_pool=self.pool1,
                 message_direction=MessageCost.DIRECTION_OUTBOUND,
-                message_cost=1.0,
+                message_cost=0.2,
                 storage_cost=0.0,
                 session_cost=0.0,
                 markup_percent=0.0)

--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -270,7 +270,7 @@ class TestTransaction(BillingApiTestCase):
 
         load_account_credits(self.account, 10)
 
-        transaction1 = yield self.create_api_transaction(
+        transaction = yield self.create_api_transaction(
             account_number=self.account.account_number,
             message_id='msg-id-1',
             tag_pool_name='pool1',
@@ -279,7 +279,8 @@ class TestTransaction(BillingApiTestCase):
             session_created=False,
             transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-        self.assertFalse(transaction1['credit_cutoff_reached'])
+        self.assertFalse(transaction['credit_cutoff_reached'])
+        self.assertTrue(transaction['transaction'] is not None)
         self.assertEqual(Transaction.objects.count(), 2)
 
     @inlineCallbacks
@@ -293,6 +294,8 @@ class TestTransaction(BillingApiTestCase):
             )
 
         load_account_credits(self.account, 10)
+        self.account.credit_balance = 6
+        self.account.save()
 
         transaction_kwargs = {
             'account_number': self.account.account_number,
@@ -304,11 +307,11 @@ class TestTransaction(BillingApiTestCase):
             'transaction_type': Transaction.TRANSACTION_TYPE_MESSAGE
         }
 
-        yield self.create_api_transaction(**transaction_kwargs)
         transaction = yield self.create_api_transaction(**transaction_kwargs)
 
         self.assertTrue(transaction['credit_cutoff_reached'])
-        self.assertEqual(Transaction.objects.count(), 3)
+        self.assertTrue(transaction['transaction'] is not None)
+        self.assertEqual(Transaction.objects.count(), 2)
 
     @inlineCallbacks
     def test_credit_cutoff_outbound_not_reached(self):
@@ -322,7 +325,7 @@ class TestTransaction(BillingApiTestCase):
 
         load_account_credits(self.account, 10)
 
-        transaction1 = yield self.create_api_transaction(
+        transaction = yield self.create_api_transaction(
             account_number=self.account.account_number,
             message_id='msg-id-1',
             tag_pool_name='pool1',
@@ -331,7 +334,8 @@ class TestTransaction(BillingApiTestCase):
             session_created=False,
             transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-        self.assertFalse(transaction1['credit_cutoff_reached'])
+        self.assertFalse(transaction['credit_cutoff_reached'])
+        self.assertTrue(transaction['transaction'] is not None)
         self.assertEqual(Transaction.objects.count(), 2)
 
     @inlineCallbacks
@@ -345,6 +349,8 @@ class TestTransaction(BillingApiTestCase):
             )
 
         load_account_credits(self.account, 10)
+        self.account.credit_balance = 6
+        self.account.save()
 
         transaction_kwargs = {
             'account_number': self.account.account_number,
@@ -356,11 +362,11 @@ class TestTransaction(BillingApiTestCase):
             'transaction_type': Transaction.TRANSACTION_TYPE_MESSAGE
         }
 
-        yield self.create_api_transaction(**transaction_kwargs)
         transaction = yield self.create_api_transaction(**transaction_kwargs)
 
         self.assertTrue(transaction['credit_cutoff_reached'])
-        self.assertEqual(Transaction.objects.count(), 2)
+        self.assertTrue(transaction['transaction'] is None)
+        self.assertEqual(Transaction.objects.count(), 1)
 
     @inlineCallbacks
     def test_transaction(self):


### PR DESCRIPTION
The billing API should return something in it's reply to notify the billing dispatcher that the account has run out of credits, which the billing dispatcher could then handle.
