### PR TITLE
don't credit developer accounts negatively

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -561,6 +561,7 @@ def set_account_balance(account_number, balance):
     """
     account = Account.objects.get(account_number=account_number)
     credit_amount = Decimal(str(balance)) - account.credit_balance
+    credit_amount = max(Decimal('0.0'), credit_amount)
     load_account_credits(account, credit_amount)
 
 

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -1295,3 +1295,11 @@ class TestLoadCreditsForDeveloperAccount(GoDjangoTestCase):
         tasks.set_developer_account_balances(Decimal('10.0'))
         self._assert_account_balance(self.user_account.key, Decimal('10.0'))
         self._assert_last_transaction_topup(Decimal('10.0'))
+
+    def test_dont_decrement_developer_account_balance(self):
+        self._assert_account_balance(self.user_account.key, Decimal('0.0'))
+        self._set_developer_flag(self.user_account, True)
+        tasks.set_developer_account_balances(Decimal('-10.0'))
+        self._assert_account_balance(self.user_account.key, Decimal('0.0'))
+        self._assert_last_transaction_topup(Decimal('0.0'))
+        self.assertEqual(Transaction.objects.count(), 1)


### PR DESCRIPTION
Make sure that the `set_developer_account_balances` function does not allow reducing the amount of credits of the account.
