### PR TITLE
Fix billing transaction search.

### DIFF
--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -138,7 +138,8 @@ class TransactionAdmin(admin.ModelAdmin):
 
     readonly_fields = list_display
 
-    search_fields = ('account__account_number', 'tag_pool_name', 'tag_name')
+    search_fields = ('account_number', 'tag_pool_name', 'tag_name',
+                     'transaction_type')
     list_filter = ('message_direction', 'status', 'created', 'last_modified')
 
     def has_add_permission(self, request):


### PR DESCRIPTION
Error:

```
FieldError: Cannot resolve keyword 'account' into field. Choices are: account_number, created, credit_amount, credit_factor, id, last_modified, markup_percent, message_cost, message_credits, message_direction, message_id, provider, session_cost, session_created, session_credits, session_length, session_length_cost, session_length_credits, session_unit_cost, session_unit_time, status, storage_cost, storage_credits, tag_name, tag_pool_name, transaction_type

WSGIRequest
path:/admin/billing/transaction/,
GET:<QueryDict: {u'q': [u'topup']}>,
POST:<QueryDict: {}>,
```

which was triggered by @rudigiesler searching for `topup` in the billing transaction search in the Django admin interface.

We should write a unit test for this.
