### PR TITLE
Fix answers sent by HTTP from dialogues

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.js
+++ b/go/apps/dialogue/tests/test_vumi_app.js
@@ -367,7 +367,7 @@ describe("app", function() {
                                 data: JSON.stringify({
                                     user: {
                                         answers: {
-                                            'choice-1': 'value-5'
+                                            'message-1': 'value-5',
                                         }
                                     },
                                     contact: api.contacts.store[0],

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -96,7 +96,9 @@ var DialogueApp = App.extend(function(self) {
             self.im.user.answers,
             function(result, value, uuid) {
                 var desc = _.find(self.poll.states, {uuid: uuid});
-                result[desc.store_as] = value;
+                if (typeof desc !== 'undefined') {
+                    result[desc.store_as] = value;
+                }
             });
     };
 

--- a/go/apps/dialogue/vumi_app.js
+++ b/go/apps/dialogue/vumi_app.js
@@ -91,6 +91,15 @@ var DialogueApp = App.extend(function(self) {
         self.contact.extra[[key, n + 1].join('-')] = value;
     };
 
+    self.labelled_answers = function() {
+        return _.transform(
+            self.im.user.answers,
+            function(result, value, uuid) {
+                var desc = _.find(self.poll.states, {uuid: uuid});
+                result[desc.store_as] = value;
+            });
+    };
+
     self.types = {};
 
     self.types.choice = function(desc) {
@@ -173,7 +182,7 @@ var DialogueApp = App.extend(function(self) {
 
         var payload = {
             user: {
-                answers: self.im.user.answers
+                answers: self.labelled_answers(),
             },
             contact: self.contact,
             conversation_key: self.poll.conversation_key


### PR DESCRIPTION
When the dialogues send answers from HTTP they use the raw state IDs as the keys for the answer dictionary. We need to translate those to state names.
