### PR TITLE
different email for last low credit notification

### DIFF
--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -404,9 +404,10 @@ class TransactionResource(BaseResource):
         level = self.check_all_low_credit_thresholds(
             credit_balance, credit_amount, last_topup_balance)
         if level is not None:
+            cutoff_notification = level * 100 == self._notification_mapping[0]
             return spawn_celery_task_via_thread(
                 create_low_credit_notification, account_number,
-                level, credit_balance, level*100 == self._notification_mapping[0])
+                level, credit_balance, cutoff_notification)
 
     def _get_notification_level(self, percentage):
         """

--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -406,7 +406,7 @@ class TransactionResource(BaseResource):
         if level is not None:
             return spawn_celery_task_via_thread(
                 create_low_credit_notification, account_number,
-                level, credit_balance, level == self._notification_mapping[0])
+                level, credit_balance, level*100 == self._notification_mapping[0])
 
     def _get_notification_level(self, percentage):
         """

--- a/go/billing/api.py
+++ b/go/billing/api.py
@@ -406,7 +406,7 @@ class TransactionResource(BaseResource):
         if level is not None:
             return spawn_celery_task_via_thread(
                 create_low_credit_notification, account_number,
-                level, credit_balance)
+                level, credit_balance, level == self._notification_mapping[0])
 
     def _get_notification_level(self, percentage):
         """

--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -521,7 +521,7 @@ def low_credit_notification_confirm_sent(res, notification_id):
 
 
 @task()
-def create_low_credit_notification(account_number, threshold, balance):
+def create_low_credit_notification(account_number, threshold, balance, cutoff_notification):
     """
     Sends a low credit notification. Returns (model instance id, email_task).
     """
@@ -537,8 +537,13 @@ def create_low_credit_notification(account_number, threshold, balance):
     email_from = settings.LOW_CREDIT_NOTIFICATION_EMAIL
     email_to = account.user.email
     formatted_balance = format_currency(balance)
+    if cutoff_notification:
+        template = 'billing/credit_cutoff_notification_email.txt'
+    else:
+        template = 'billing/low_credit_notification_email.txt'
+	
     message = render_to_string(
-        'billing/low_credit_notification_email.txt',
+        template,
         {
             'user': account.user,
             'account': account,

--- a/go/billing/templates/billing/credit_cutoff_notification_email.txt
+++ b/go/billing/templates/billing/credit_cutoff_notification_email.txt
@@ -1,0 +1,13 @@
+
+Hi {{user.get_full_name}}!
+
+Please note that your Vumi Go account ({{account.user.email}}) has reached {{threshold_percent}}% used of the total available credits. Your remaining balance is {{credit_balance}} credits. This means that you will no longer be able to send any more messages, and all session based transport requests will be terminated with a message indicating that the account has run out of credits. All incoming messages will be received as normal, and you will still be charged for them.
+
+To top up your credits contact your Praekelt programme manager with the number of messages/sessions you want loaded. Once you have loaded enough credits, all messages will be sent and received as normal.
+
+
+Regards,
+
+The Vumi Go Team.
+
+Notification reference number: {{reference}}

--- a/go/billing/templates/billing/credit_cutoff_notification_email.txt
+++ b/go/billing/templates/billing/credit_cutoff_notification_email.txt
@@ -3,7 +3,7 @@ Hi {{user.get_full_name}}!
 
 Please note that your Vumi Go account ({{account.user.email}}) has reached {{threshold_percent}}% used of the total available credits. Your remaining balance is {{credit_balance}} credits.
 
-You will no longer be able to send message. Contacts on campaigns over USSD or Voice will receive a message saying that your account has run out of credits. All incoming messages will be received as normal.
+You will no longer be able to send messages. Contacts on campaigns over USSD or Voice will receive a notification saying that your account has run out of credits. All incoming messages will be received as normal.
 
 To top up your credits contact your Praekelt programme manager with the number of messages/sessions you want loaded. Once you have loaded enough credits, all messages will be sent and received as normal.
 

--- a/go/billing/templates/billing/credit_cutoff_notification_email.txt
+++ b/go/billing/templates/billing/credit_cutoff_notification_email.txt
@@ -1,7 +1,9 @@
 
 Hi {{user.get_full_name}}!
 
-Please note that your Vumi Go account ({{account.user.email}}) has reached {{threshold_percent}}% used of the total available credits. Your remaining balance is {{credit_balance}} credits. This means that you will no longer be able to send any more messages, and all session based transport requests will be terminated with a message indicating that the account has run out of credits. All incoming messages will be received as normal, and you will still be charged for them.
+Please note that your Vumi Go account ({{account.user.email}}) has reached {{threshold_percent}}% used of the total available credits. Your remaining balance is {{credit_balance}} credits.
+
+You will no longer be able to send message. Contacts on campaigns over USSD or Voice will receive a message saying that your account has run out of credits. All incoming messages will be received as normal.
 
 To top up your credits contact your Praekelt programme manager with the number of messages/sessions you want loaded. Once you have loaded enough credits, all messages will be sent and received as normal.
 

--- a/go/billing/tests/test_api.py
+++ b/go/billing/tests/test_api.py
@@ -180,7 +180,8 @@ class TestTransaction(BillingApiTestCase):
         mock_task_delay.assert_called_once_with(
             account.account_number,
             Decimal('0.9'),
-            account.credit_balance)
+            account.credit_balance,
+            False)
         mock_task_delay.reset_mock()
 
         # Create another transaction
@@ -197,7 +198,8 @@ class TestTransaction(BillingApiTestCase):
         mock_task_delay.assert_called_once_with(
             account.account_number,
             Decimal('0.8'),
-            account.credit_balance)
+            account.credit_balance,
+            False)
         mock_task_delay.reset_mock()
 
         # Create a third transaction
@@ -214,7 +216,8 @@ class TestTransaction(BillingApiTestCase):
         mock_task_delay.assert_called_once_with(
             account.account_number,
             Decimal('0.7'),
-            account.credit_balance)
+            account.credit_balance,
+            True)
         mock_task_delay.reset_mock()
 
         # Create a fourth transaction

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -1278,7 +1278,7 @@ class TestLowCreditNotificationTask(GoDjangoTestCase):
         self.assertTrue(str(notification.pk) in email.body)
         self.assertTrue(str(self.acc.user.email) in email.body)
         self.assertTrue(
-                'you will no longer be able to send any more messages'
+                'You will no longer be able to send messages'
                 in email.body)
 
 

--- a/go/billing/tests/test_tasks.py
+++ b/go/billing/tests/test_tasks.py
@@ -1224,22 +1224,22 @@ class TestLowCreditNotificationTask(GoDjangoTestCase):
                                  + 'EmailBackend')
         self.user_helper = self.vumi_helper.make_django_user()
 
-    def mk_notification(self, percent, balance):
+    def mk_notification(self, percent, balance, cutoff_notification):
         self.django_user = self.user_helper.get_django_user()
         self.acc = Account.objects.get(user=self.django_user)
         percent = Decimal(percent)
         balance = Decimal(balance)
         return tasks.create_low_credit_notification(
-            self.acc.account_number, percent, balance)
+            self.acc.account_number, percent, balance, cutoff_notification)
 
     def test_confirm_sent(self):
-        notification_id, res = self.mk_notification('0.60', '31.41')
+        notification_id, res = self.mk_notification('0.60', '31.41', False)
         notification = LowCreditNotification.objects.get(pk=notification_id)
         timestamp = res.get()
         self.assertEqual(timestamp, notification.success)
 
     def test_email_sent(self):
-        notification_id, res = self.mk_notification('0.701', '1234.5678')
+        notification_id, res = self.mk_notification('0.701', '1234.5678', False)
         notification = LowCreditNotification.objects.get(pk=notification_id)
         self.assertTrue(res.get() is not None)
         self.assertEqual(len(mail.outbox), 1)
@@ -1257,6 +1257,29 @@ class TestLowCreditNotificationTask(GoDjangoTestCase):
         self.assertTrue(self.django_user.get_full_name() in email.body)
         self.assertTrue(str(notification.pk) in email.body)
         self.assertTrue(str(self.acc.user.email) in email.body)
+
+    def test_credit_cutoff_email_sent(self):
+        notification_id, res = self.mk_notification('0.701', '1234.5678', True)
+        notification = LowCreditNotification.objects.get(pk=notification_id)
+        self.assertTrue(res.get() is not None)
+        self.assertEqual(len(mail.outbox), 1)
+        [email] = mail.outbox
+
+        self.assertEqual(email.recipients(), [self.django_user.email])
+        self.assertEqual(email.from_email, 'support@vumi.org')
+        self.assertEqual(
+            'Vumi Go account %s (%s) at %s%% left of available credits' % (
+                str(self.acc.user.email), str(self.acc.user.get_full_name()),
+                '70.100'),
+            email.subject)
+        self.assertTrue('29.900%' in email.body)
+        self.assertTrue('1,234.56 credits' in email.body)
+        self.assertTrue(self.django_user.get_full_name() in email.body)
+        self.assertTrue(str(notification.pk) in email.body)
+        self.assertTrue(str(self.acc.user.email) in email.body)
+        self.assertTrue(
+                'you will no longer be able to send any more messages'
+                in email.body)
 
 
 class TestLoadCreditsForDeveloperAccount(GoDjangoTestCase):


### PR DESCRIPTION
The email that is sent for the lowest notification should be different than the rest, as the last notification is the credit cutoff, and no more messages can be sent after this. The email should reflect this.
