### PR TITLE
NormalizingMsisdnMiddleware breaks if the MSISDN is None.

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -47,16 +47,20 @@ class NormalizeMsisdnMiddleware(TransportMiddleware):
         self.strip_plus = self.config.strip_plus
 
     def handle_inbound(self, message, endpoint):
-        from_addr = normalize_msisdn(message.get('from_addr'),
-                                     country_code=self.country_code)
+        from_addr = message.get('from_addr')
+        if from_addr is not None:
+            from_addr = normalize_msisdn(from_addr,
+                                         country_code=self.country_code)
         message['from_addr'] = from_addr
         return message
 
     def handle_outbound(self, message, endpoint):
-        to_addr = normalize_msisdn(message.get('to_addr'),
-                                   country_code=self.country_code)
-        if self.strip_plus:
-            to_addr = to_addr.lstrip('+')
+        to_addr = message.get('to_addr')
+        if to_addr is not None:
+            to_addr = normalize_msisdn(to_addr,
+                                       country_code=self.country_code)
+            if self.strip_plus:
+                to_addr = to_addr.lstrip('+')
         message['to_addr'] = to_addr
         return message
 

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -46,22 +46,24 @@ class NormalizeMsisdnMiddleware(TransportMiddleware):
         self.country_code = self.config.country_code
         self.strip_plus = self.config.strip_plus
 
+    def _normalize_msisdn(self, addr, country_code, strip_plus):
+        if addr is None:
+            return addr
+        addr = normalize_msisdn(addr, country_code=country_code)
+        if strip_plus:
+            addr = addr.lstrip('+')
+        return addr
+
     def handle_inbound(self, message, endpoint):
-        from_addr = message.get('from_addr')
-        if from_addr is not None:
-            from_addr = normalize_msisdn(from_addr,
-                                         country_code=self.country_code)
-        message['from_addr'] = from_addr
+        message['from_addr'] = self._normalize_msisdn(
+            message.get('from_addr'), country_code=self.country_code,
+            strip_plus=False)
         return message
 
     def handle_outbound(self, message, endpoint):
-        to_addr = message.get('to_addr')
-        if to_addr is not None:
-            to_addr = normalize_msisdn(to_addr,
-                                       country_code=self.country_code)
-            if self.strip_plus:
-                to_addr = to_addr.lstrip('+')
-        message['to_addr'] = to_addr
+        message['to_addr'] = self._normalize_msisdn(
+            message.get('to_addr'), country_code=self.country_code,
+            strip_plus=self.strip_plus)
         return message
 
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -93,6 +93,17 @@ class TestNormalizeMisdnMiddleware(VumiTestCase):
         msg = self.mw.handle_inbound(msg, 'dummy_endpoint')
         self.assertEqual(msg['from_addr'], None)
 
+    @inlineCallbacks
+    def test_inbound_normalization_ignores_strip_plus(self):
+        mw = yield self.mw_helper.create_middleware({
+            'country_code': '256',
+            'strip_plus': True,
+        })
+        msg = self.mw_helper.make_inbound(
+            "foo", to_addr='8007', from_addr='+256123456789')
+        msg = mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['from_addr'], '+256123456789')
+
     def test_outbound_normalization(self):
         msg = self.mw_helper.make_outbound(
             "foo", to_addr='0123456789', from_addr='8007')
@@ -104,6 +115,17 @@ class TestNormalizeMisdnMiddleware(VumiTestCase):
             "foo", to_addr=None, from_addr='8007')
         msg = self.mw.handle_outbound(msg, 'dummy_endpoint')
         self.assertEqual(msg['to_addr'], None)
+
+    @inlineCallbacks
+    def test_outbound_normalization_applies_strip_plus(self):
+        mw = yield self.mw_helper.create_middleware({
+            'country_code': '256',
+            'strip_plus': True,
+        })
+        msg = self.mw_helper.make_outbound(
+            "foo", to_addr='0123456789', from_addr='8007')
+        msg = mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['to_addr'], '256123456789')
 
 
 class TestOptOutMiddleware(VumiTestCase):

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -87,11 +87,23 @@ class TestNormalizeMisdnMiddleware(VumiTestCase):
         msg = self.mw.handle_inbound(msg, 'dummy_endpoint')
         self.assertEqual(msg['from_addr'], '+256123456789')
 
+    def test_inbound_normalization_of_null_from_addr(self):
+        msg = self.mw_helper.make_inbound(
+            "foo", to_addr='8007', from_addr=None)
+        msg = self.mw.handle_inbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['from_addr'], None)
+
     def test_outbound_normalization(self):
         msg = self.mw_helper.make_outbound(
             "foo", to_addr='0123456789', from_addr='8007')
         msg = self.mw.handle_outbound(msg, 'dummy_endpoint')
         self.assertEqual(msg['to_addr'], '+256123456789')
+
+    def test_outbound_normalization_of_null_to_addr(self):
+        msg = self.mw_helper.make_outbound(
+            "foo", to_addr=None, from_addr='8007')
+        msg = self.mw.handle_outbound(msg, 'dummy_endpoint')
+        self.assertEqual(msg['to_addr'], None)
 
 
 class TestOptOutMiddleware(VumiTestCase):


### PR DESCRIPTION
```
2015-03-09 08:53:57+0000 Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/connectors.py", line 65, in handler
            return self._consume_message(mtype, msg)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/connectors.py", line 89, in _consume_message
            d = self._middlewares.apply_consume(mtype, msg, self.name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 216, in apply_consume
            self.consume_middlewares, handler_name, message, connector_name)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1237, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
            result = g.send(result)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 206, in _handle
            message = yield handler(message, connector_name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 115, in handle_consume_outbound
            return self.handle_outbound(message, connector_name)
          File "/var/praekelt/vumi-go/go/vumitools/middleware.py", line 57, in handle_outbound
            country_code=self.country_code)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/utils.py", line 192, in normalize_msisdn
            if len(raw) <= 5:
        exceptions.TypeError: object of type 'NoneType' has no len()
```
