### PR TITLE
Add support for setting whitelisted helper_metadata on outbound jsbox messages. 

### DIFF
--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -82,9 +82,14 @@ class GoOutboundResource(SandboxResource):
     def _check_helper_metadata(self, helper_metadata):
         if any(key not in self._allowed_helper_metadata
                for key in helper_metadata.iterkeys()):
-            raise InvalidHelperMetadata(
-                "'helper_metadata' may only contain the following keys: %s" %
-                ', '.join(sorted(self._allowed_helper_metadata)))
+            if self._allowed_helper_metadata:
+                errmsg = (
+                    "'helper_metadata' may only contain the following keys: %s"
+                    % ', '.join(sorted(self._allowed_helper_metadata)))
+            else:
+                errmsg = (
+                    "'helper_metadata' is not allowed")
+            raise InvalidHelperMetadata(errmsg)
 
     def _handle_reply(self, api, command, reply_func):
         if not 'content' in command:

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -221,7 +221,22 @@ class TestGoOutboundResource(ResourceTestCaseBase):
             "Could not find original message with id: u'unknown'",
             'reply_to', content='Hello?', in_reply_to=u'unknown')
 
+    def test_reply_to_helper_metadata_not_allowed(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' is not allowed",
+            'reply_to',
+            to_addr='6789', content='bar', in_reply_to=u'unknown',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_helper_metadata_invalid(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            'reply_to',
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'unknown',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
     @inlineCallbacks
+
     def test_reply_to_group(self):
         yield self.create_resource({})
         msg = self.make_inbound('Hello', helper_metadata={'orig': 'data'})
@@ -277,6 +292,21 @@ class TestGoOutboundResource(ResourceTestCaseBase):
         return self.assert_cmd_fails(
             "Could not find original message with id: u'unknown'",
             'reply_to_group', content='Hello?', in_reply_to=u'unknown')
+
+    def test_reply_to_group_helper_metadata_not_allowed(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' is not allowed",
+            'reply_to_group',
+            to_addr='6789', content='bar', in_reply_to=u'unknown',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_group_helper_metadata_invalid(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            'reply_to_group',
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'unknown',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
 
     def assert_sent(self, to_addr, content, msg_options):
         self.app_worker.send_to.assert_called_once_with(

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -403,3 +403,10 @@ class TestGoOutboundResource(ResourceTestCaseBase):
             "'helper_metadata' is not allowed",
             to_addr='6789', endpoint='extra_endpoint', content='bar',
             helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_send_to_endpoint_helper_metadata_invalid(self):
+        return self.assert_send_to_endpoint_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', endpoint='extra_endpoint', content='bar',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -267,6 +267,14 @@ class TestGoOutboundResource(ResourceTestCaseBase):
             to_addr='6789', content='bar', in_reply_to=u'unknown',
             helper_metadata={'go': {'conversation': 'someone-elses'}})
 
+    def test_reply_to_helper_metadata_wrong_type(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' must be object or null.",
+            'reply_to',
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'unknown',
+            helper_metadata="Not a dict.")
+
     @inlineCallbacks
     def test_reply_to_group(self):
         yield self.create_resource({})

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -454,6 +454,34 @@ class TestGoOutboundResource(ResourceTestCaseBase):
             'helper_metadata': {},
         })
 
+    @inlineCallbacks
+    def test_send_to_endpoint_with_helper_metadata(self):
+        yield self.create_resource({
+            'allowed_helper_metadata': ['voice'],
+        })
+
+        with LogCatcher() as lc:
+            reply = yield self.dispatch_command(
+                'send_to_endpoint', endpoint='extra_endpoint', to_addr='6789',
+                content='bar',
+                helper_metadata={
+                    'voice': {
+                        'speech_url': 'http://www.example.com/audio.wav',
+                    },
+                })
+            self.assertEqual(lc.messages(), [
+                "Sending outbound message to u'6789' via endpoint "
+                "u'extra_endpoint', content: u'bar'"])
+        self.check_reply(reply)
+        self.assert_sent('6789', 'bar', {
+            'endpoint': 'extra_endpoint',
+            'helper_metadata': {
+                'voice': {
+                    'speech_url': 'http://www.example.com/audio.wav',
+                },
+            },
+        })
+
     def test_send_to_endpoint_not_configured(self):
         return self.assert_send_to_endpoint_fails(
             "Endpoint u'bad_endpoint' not configured",

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -49,6 +49,11 @@ class StubbedAppWorker(DummyAppWorker):
     def add_inbound_message(self, msg):
         self._inbound_messages[msg['message_id']] = msg
 
+    def add_conv_to_msg_options(self, conv, msg_options):
+        helper_metadata = msg_options.setdefault('helper_metadata', {})
+        conv.set_go_helper_metadata(helper_metadata)
+        return msg_options
+
 
 class TestInboundPushTriggerUtils(VumiTestCase):
 
@@ -288,7 +293,10 @@ class TestGoOutboundResource(ResourceTestCaseBase):
                 "Sending outbound message to u'6789' via tag "
                 "(u'pool1', u'1234'), content: u'bar'"])
         self.check_reply(reply)
-        self.assert_sent('6789', 'bar', {'endpoint': 'pool1:1234'})
+        self.assert_sent('6789', 'bar', {
+            'endpoint': 'pool1:1234',
+            'helper_metadata': {},
+        })
 
     def test_send_to_tag_unacquired(self):
         return self.assert_send_to_tag_fails(
@@ -326,7 +334,10 @@ class TestGoOutboundResource(ResourceTestCaseBase):
                 "Sending outbound message to u'6789' via endpoint "
                 "u'extra_endpoint', content: u'bar'"])
         self.check_reply(reply)
-        self.assert_sent('6789', 'bar', {'endpoint': 'extra_endpoint'})
+        self.assert_sent('6789', 'bar', {
+            'endpoint': 'extra_endpoint',
+            'helper_metadata': {},
+        })
 
     @inlineCallbacks
     def test_send_to_endpoint_null_content(self):
@@ -338,7 +349,10 @@ class TestGoOutboundResource(ResourceTestCaseBase):
                 "Sending outbound message to u'6789' via endpoint "
                 "u'extra_endpoint', content: None"])
         self.check_reply(reply)
-        self.assert_sent('6789', None, {'endpoint': 'extra_endpoint'})
+        self.assert_sent('6789', None, {
+            'endpoint': 'extra_endpoint',
+            'helper_metadata': {},
+        })
 
     def test_send_to_endpoint_not_configured(self):
         return self.assert_send_to_endpoint_fails(


### PR DESCRIPTION
Applications that use voice transport potentially need to supply additional metadata describing, e.g. where to obtain audio files to send or what characters should terminate IVR input. It seems sensible to add slightly more generic support for setting helper_metadata to the jsbox outbound message resource.

Because some helper_metadata fields contain information that shouldn't be modifiable from the sandbox (e.g. which Vumi Go account and conversation a message is associated with) the helper_metadata fields that can be set need to be white listed.
