### PR TITLE
Push triggers for dialogues and jsbox should set the session_event to new

### DIFF
--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -134,8 +134,10 @@ class GoOutboundResource(SandboxResource):
 
         # convert replies to push triggers into ordinary sends
         if is_inbound_push_trigger(orig_msg):
-            d = self.app_worker.send_to(orig_msg["from_addr"], content,
-                                        helper_metadata=helper_metadata)
+            d = self.app_worker.send_to(
+                orig_msg["from_addr"], content,
+                session_event=TransportUserMessage.SESSION_NEW,
+                helper_metadata=helper_metadata)
         else:
             d = reply_func(orig_msg, content,
                            continue_session=continue_session,

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -4,6 +4,7 @@ from mock import Mock
 
 from twisted.internet.defer import inlineCallbacks, succeed
 
+from vumi.message import TransportUserMessage
 from vumi.tests.utils import LogCatcher, VumiTestCase
 from vumi.application.tests.test_sandbox import (
     ResourceTestCaseBase, DummyAppWorker)
@@ -193,6 +194,7 @@ class TestGoOutboundResource(ResourceTestCaseBase):
         self.app_worker.reply_to.assert_not_called()
         self.app_worker.send_to.assert_called_once_with(
             "to-addr-1", u'Reply!',
+            session_event=TransportUserMessage.SESSION_NEW,
             helper_metadata={
                 "go": {
                     "conversation_type": u'dummy',
@@ -309,6 +311,7 @@ class TestGoOutboundResource(ResourceTestCaseBase):
         self.app_worker.reply_to_group.assert_not_called()
         self.app_worker.send_to.assert_called_once_with(
             "to-addr-1", u'Reply!',
+            session_event=TransportUserMessage.SESSION_NEW,
             helper_metadata={
                 "go": {
                     "conversation_type": u'dummy',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email='dev@praekeltfoundation.org',
     packages=find_packages(),
     install_requires=[
-        'vumi>=0.5.14',
+        'vumi>=0.5.16',
         'vxpolls',
         'vumi-wikipedia',
         'Django==1.5.8',


### PR DESCRIPTION
Currently they accidentally set the session_event to None, which is okay for non-session based transports, but not for session-bases transports that support pushed messages (e.g. voice).

This requires praekelt/vumi#930 to land first.
