### PR TITLE
Move over to vxsandbox

### DIFF
--- a/go/apps/dialogue/tests/test_vumi_app.py
+++ b/go/apps/dialogue/tests/test_vumi_app.py
@@ -8,9 +8,10 @@ import pkg_resources
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.application.tests.helpers import find_nodejs_or_skip_test
-from vumi.application.tests.test_sandbox import (
-    ResourceTestCaseBase, DummyAppWorker)
+from vxsandbox.utils import find_nodejs_or_skip_test
+from vxsandbox.tests.utils import DummyAppWorker
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
+
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 
@@ -64,7 +65,7 @@ class TestDialogueApplication(VumiTestCase):
                     'cls': 'go.apps.jsbox.contacts.ContactsResource',
                 },
                 'kv': {
-                    'cls': 'vumi.application.sandbox.RedisResource',
+                    'cls': 'vxsandbox.RedisResource',
                     'redis_manager': {'FAKE_REDIS': self.kv_redis},
                 },
                 'outbound': {

--- a/go/apps/dialogue/vumi_app.py
+++ b/go/apps/dialogue/vumi_app.py
@@ -3,7 +3,7 @@
 import pkg_resources
 import json
 
-from vumi.application.sandbox import SandboxResource
+from vxsandbox import SandboxResource
 
 from go.apps.jsbox.vumi_app import JsBoxConfig, JsBoxApplication
 from go.apps.dialogue.utils import dialogue_js_config

--- a/go/apps/jsbox/contacts.py
+++ b/go/apps/jsbox/contacts.py
@@ -3,7 +3,7 @@
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.application.sandbox import SandboxResource, SandboxError
+from vxsandbox import SandboxResource, SandboxError
 
 from go.vumitools.contact import (
     Contact, ContactStore, ContactError, ContactNotFoundError)

--- a/go/apps/jsbox/log.py
+++ b/go/apps/jsbox/log.py
@@ -6,8 +6,9 @@ import datetime
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
+from vxsandbox import LoggingResource
+
 from vumi import log
-from vumi.application.sandbox import LoggingResource
 from vumi.persist.redis_base import Manager
 from vumi.persist.txredis_manager import TxRedisManager
 

--- a/go/apps/jsbox/message_store.py
+++ b/go/apps/jsbox/message_store.py
@@ -10,7 +10,7 @@ from functools import wraps
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.application.sandbox import SandboxResource
+from vxsandbox import SandboxResource
 
 
 def conversation_owner(func):

--- a/go/apps/jsbox/metrics.py
+++ b/go/apps/jsbox/metrics.py
@@ -5,7 +5,7 @@
 
 import re
 
-from vumi.application.sandbox import SandboxResource
+from vxsandbox import SandboxResource
 
 from vumi.blinkenlights.metrics import SUM, AVG, MIN, MAX, LAST
 

--- a/go/apps/jsbox/opt_out.py
+++ b/go/apps/jsbox/opt_out.py
@@ -8,7 +8,7 @@ from functools import wraps
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.application.sandbox import SandboxResource
+from vxsandbox import SandboxResource
 
 
 def optout_authorized(func):

--- a/go/apps/jsbox/outbound.py
+++ b/go/apps/jsbox/outbound.py
@@ -5,7 +5,8 @@
 
 from twisted.internet.defer import inlineCallbacks, returnValue, succeed
 
-from vumi.application.sandbox import SandboxResource
+from vxsandbox import SandboxResource
+
 from vumi.message import TransportUserMessage
 from vumi import log
 

--- a/go/apps/jsbox/tests/test_contacts.py
+++ b/go/apps/jsbox/tests/test_contacts.py
@@ -4,8 +4,8 @@ import json
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.application.tests.test_sandbox import (
-    ResourceTestCaseBase, DummyAppWorker)
+from vxsandbox.tests.utils import DummyAppWorker
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
 
 from go.apps.jsbox.contacts import ContactsResource, GroupsResource
 from go.vumitools.tests.helpers import VumiApiHelper

--- a/go/apps/jsbox/tests/test_log.py
+++ b/go/apps/jsbox/tests/test_log.py
@@ -8,8 +8,9 @@ import re
 from mock import Mock
 from twisted.internet.defer import inlineCallbacks
 
-from vumi.application.tests.test_sandbox import (
-    ResourceTestCaseBase, DummyAppWorker)
+from vxsandbox.tests.utils import DummyAppWorker
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
+
 from vumi.tests.helpers import VumiTestCase, PersistenceHelper
 from vumi.tests.utils import LogCatcher
 

--- a/go/apps/jsbox/tests/test_message_store.py
+++ b/go/apps/jsbox/tests/test_message_store.py
@@ -2,8 +2,8 @@
 
 from twisted.internet.defer import inlineCallbacks
 
-from vumi.application.tests.test_sandbox import (
-    ResourceTestCaseBase, DummyAppWorker)
+from vxsandbox.tests.utils import DummyAppWorker
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
 
 from go.apps.jsbox.message_store import MessageStoreResource
 from go.vumitools.tests.helpers import GoMessageHelper, VumiApiHelper

--- a/go/apps/jsbox/tests/test_metrics.py
+++ b/go/apps/jsbox/tests/test_metrics.py
@@ -2,7 +2,8 @@
 
 import mock
 
-from vumi.application.sandbox import SandboxCommand
+from vxsandbox.resources import SandboxCommand
+
 from vumi.tests.helpers import VumiTestCase
 
 from go.apps.jsbox.metrics import (

--- a/go/apps/jsbox/tests/test_opt_out.py
+++ b/go/apps/jsbox/tests/test_opt_out.py
@@ -2,8 +2,8 @@
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.application.tests.test_sandbox import (
-    ResourceTestCaseBase, DummyAppWorker)
+from vxsandbox.tests.utils import DummyAppWorker
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
 
 from go.apps.jsbox.opt_out import OptOutResource
 from go.vumitools.opt_out import OptOutStore

--- a/go/apps/jsbox/tests/test_outbound.py
+++ b/go/apps/jsbox/tests/test_outbound.py
@@ -4,10 +4,11 @@ from mock import Mock
 
 from twisted.internet.defer import inlineCallbacks, succeed
 
+from vxsandbox.tests.utils import DummyAppWorker
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
+
 from vumi.message import TransportUserMessage
 from vumi.tests.utils import LogCatcher, VumiTestCase
-from vumi.application.tests.test_sandbox import (
-    ResourceTestCaseBase, DummyAppWorker)
 
 from go.apps.jsbox.outbound import (
     GoOutboundResource, mk_inbound_push_trigger, is_inbound_push_trigger,

--- a/go/apps/jsbox/tests/test_vumi_app.py
+++ b/go/apps/jsbox/tests/test_vumi_app.py
@@ -6,7 +6,9 @@ import mock
 
 from twisted.internet.defer import inlineCallbacks
 
-from vumi.application.sandbox import JsSandbox, SandboxCommand
+from vxsandbox import JsSandbox
+from vxsandbox.resources import SandboxCommand
+
 from vumi.application.tests.helpers import find_nodejs_or_skip_test
 from vumi.middleware.tagger import TaggingMiddleware
 from vumi.tests.helpers import VumiTestCase

--- a/go/apps/jsbox/vumi_app.py
+++ b/go/apps/jsbox/vumi_app.py
@@ -7,7 +7,8 @@ import logging
 
 from twisted.internet.defer import inlineCallbacks
 
-from vumi.application.sandbox import JsSandbox, SandboxResource
+from vxsandbox import JsSandbox, SandboxResource
+
 from vumi.config import ConfigDict
 from vumi import log
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'vumi>=0.5.16',
+        'vxsandbox>=0.5.0',
         'vxpolls',
         'vumi-wikipedia',
         'Django==1.5.8',


### PR DESCRIPTION
Now that we've moved the sandbox code to [vumi-sandbox](https://github.com/praekelt/vumi-sandbox), tell vumi-go things using sandbox things to use it.
