### PR TITLE
Fix tests for unique address counts

### DIFF
--- a/go/account/tests.py
+++ b/go/account/tests.py
@@ -234,9 +234,8 @@ class TestEmail(GoDjangoTestCase):
         self.assertTrue('"Group Message" Sent: 5' in email.body)
         self.assertTrue('"Group Message" Received: 5' in email.body)
 
-        # TODO fix once we support uniques properly again
-        self.assertTrue('Sent: 5 to 0 uniques.' in email.body)
-        self.assertTrue('Received: 5 from 0 uniques.' in email.body)
+        self.assertTrue('Sent: 5 to 5 uniques.' in email.body)
+        self.assertTrue('Received: 5 from 5 uniques.' in email.body)
 
     def test_send_scheduled_account_summary_task(self):
         user_account = self.user_helper.get_user_account()

--- a/go/apps/jsbox/tests/test_message_store.py
+++ b/go/apps/jsbox/tests/test_message_store.py
@@ -85,15 +85,13 @@ class TestMessageStoreResource(ResourceTestCaseBase):
     def test_handle_count_inbound_uniques(self):
         reply = yield self.dispatch_command('count_inbound_uniques')
         self.assertTrue(reply['success'])
-        # TODO fix once we support uniques properly again
-        self.assertEqual(reply['count'], 0)
+        self.assertEqual(reply['count'], 1)
 
     @inlineCallbacks
     def test_handle_count_outbound_uniques(self):
         reply = yield self.dispatch_command('count_outbound_uniques')
         self.assertTrue(reply['success'])
-        # TODO fix once we support uniques properly again
-        self.assertEqual(reply['count'], 0)
+        self.assertEqual(reply['count'], 1)
 
     @inlineCallbacks
     def test_handle_inbound_throughput(self):

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -719,10 +719,9 @@ class TestConversationViews(BaseConversationViewTestCase):
 
     def test_message_list_inbound_uniques_display(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
-        msgs = self.msg_helper.add_inbound_to_conv(conv, 10)
+        self.msg_helper.add_inbound_to_conv(conv, 10)
         response = self.client.get(self.get_view_url(conv, 'message_list'))
-        # TODO fix once we support uniques properly again
-        self.assertContains(response, 'Messages from 0 unique people')
+        self.assertContains(response, 'Messages from 10 unique people')
 
     def test_message_list_inbound_download_links_display(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
@@ -739,13 +738,12 @@ class TestConversationViews(BaseConversationViewTestCase):
     def test_message_list_outbound_uniques_display(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
         msgs = self.msg_helper.add_inbound_to_conv(conv, 10)
-        replies = self.msg_helper.add_replies_to_conv(conv, msgs)
+        self.msg_helper.add_replies_to_conv(conv, msgs)
         response = self.client.get(
             self.get_view_url(conv, 'message_list'), {
                 'direction': 'outbound'
             })
-        # TODO fix once we support uniques properly again
-        self.assertContains(response, 'Messages to 0 unique people')
+        self.assertContains(response, 'Messages to 10 unique people')
 
     def test_message_list_outbound_download_links_display(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)

--- a/go/vumitools/conversation/tests/test_utils.py
+++ b/go/vumitools/conversation/tests/test_utils.py
@@ -73,22 +73,22 @@ class TestConversationWrapper(VumiTestCase):
         # TODO fix once we support uniques properly again
         yield self.conv.start()
         yield self.msg_helper.add_inbound_to_conv(self.conv, 3)
-        self.assertEqual((yield self.conv.count_inbound_uniques()), 0)
+        self.assertEqual((yield self.conv.count_inbound_uniques()), 3)
         yield self.msg_helper.add_inbound_to_conv(self.conv, 4)
-        self.assertEqual((yield self.conv.count_inbound_uniques()), 0)
+        self.assertEqual((yield self.conv.count_inbound_uniques()), 4)
         yield self.msg_helper.add_inbound_to_conv(self.conv, 2)
-        self.assertEqual((yield self.conv.count_inbound_uniques()), 0)
+        self.assertEqual((yield self.conv.count_inbound_uniques()), 4)
 
     @inlineCallbacks
     def test_count_outbound_uniques(self):
         # TODO fix once we support uniques properly again
         yield self.conv.start()
         yield self.msg_helper.add_outbound_to_conv(self.conv, 3)
-        self.assertEqual((yield self.conv.count_outbound_uniques()), 0)
+        self.assertEqual((yield self.conv.count_outbound_uniques()), 3)
         yield self.msg_helper.add_outbound_to_conv(self.conv, 4)
-        self.assertEqual((yield self.conv.count_outbound_uniques()), 0)
+        self.assertEqual((yield self.conv.count_outbound_uniques()), 4)
         yield self.msg_helper.add_outbound_to_conv(self.conv, 2)
-        self.assertEqual((yield self.conv.count_outbound_uniques()), 0)
+        self.assertEqual((yield self.conv.count_outbound_uniques()), 4)
 
     @inlineCallbacks
     def test_collect_messages(self):


### PR DESCRIPTION
Now that the message store supports unique address counts again, we need to fix the tests that assert on it.
