### PR TITLE
Limit contact export size in celery task

### DIFF
--- a/go/settings.py
+++ b/go/settings.py
@@ -309,6 +309,10 @@ CELERYBEAT_SCHEDULE = {
     # },
 }
 
+
+# Exporting hundreds of thousands of contacts makes celery use all the memory.
+CONTACT_EXPORT_TASK_LIMIT = 100000
+
 try:
     from production_settings import *
 except ImportError as err:


### PR DESCRIPTION
This is a short-term measure to avoid letting excessively large contact exports break other things. See #1229 for discussion around a longer-term solution.
