### PR TITLE
Billing transaction archiving task uses lots of memory

### DIFF
--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -436,9 +436,12 @@ def archive_transactions(account_id, from_date, to_date, delete=True):
     transaction_query = Transaction.objects.filter(
         account_number=account.account_number,
         created__gte=from_date,
-        created__lt=(to_date + relativedelta(days=1)))
+        created__lt=(to_date + relativedelta(days=1)),
+    ).order_by("id")  # We order by id because chunking needs it.
 
     def generate_chunks(queryset, items_per_chunk=1000, sep="\n"):
+        # NOTE: This chunking method only works if the queryset has a well
+        #       defined order.
         for i in xrange(0, queryset.count(), items_per_chunk):
             data = list(queryset[i:i + items_per_chunk].iterator())
             yield sep.join(serializer.to_json(data))


### PR DESCRIPTION
The task fetches all transactions from the database before it processes them, which is a problem when there are lots of transactions.
