### PR TITLE
Fix jsPlumb connection detaching

### DIFF
--- a/go/base/static/js/src/components/plumbing/connections.js
+++ b/go/base/static/js/src/components/plumbing/connections.js
@@ -55,13 +55,11 @@
     },
 
     destroy: function() {
-      var plumbConnection = this.plumbConnection;
-
-      if (plumbConnection) {
-        this.plumbConnection = null;
-        jsPlumb.detach(plumbConnection);
+      if (this.plumbConnection && this.plumbConnection.endpoints) {
+        jsPlumb.detach(this.plumbConnection);
       }
 
+      this.plumbConnection = null;
       return this;
     },
 

--- a/go/base/static/js/src/components/plumbing/connections.js
+++ b/go/base/static/js/src/components/plumbing/connections.js
@@ -54,9 +54,19 @@
       }, _(this).result('plumbOptions'));
     },
 
-    destroy: function() {
-      if (this.plumbConnection && this.plumbConnection.endpoints) {
-        jsPlumb.detach(this.plumbConnection);
+    destroy: function(options) {
+      options = _.defaults(options || {}, {
+        detach: true,
+        fireDetach: false
+      });
+
+      if (this.plumbConnection && options.detach) {
+        // `fireEvent` defaults to `false` according to the docs, not setting
+        // it to `false` appears to cause endless recursion for user-initiated
+        // detaches in jsPlumb 1.7.5 (what one would expect if `fireEvent` was
+        // set to `true`).
+        // jsplumbtoolkit.com/apidocs/classes/jsPlumb.html#method_detach
+        jsPlumb.detach(this.plumbConnection, {fireEvent: options.fireDetach});
       }
 
       this.plumbConnection = null;
@@ -182,7 +192,7 @@
       // -------
       // The connection was removed in the UI, so the model and view still
       // exist. We need to remove them.
-      this.remove(connectionId);
+      this.remove(connectionId, {detach: false});
     }
   });
 

--- a/go/base/static/js/src/components/plumbing/endpoints.js
+++ b/go/base/static/js/src/components/plumbing/endpoints.js
@@ -49,6 +49,14 @@
 
       // the collection of endpoint views that this endpoint is part of
       this.collection = options.collection;
+
+      if (this.isSource) {
+        jsPlumb.makeSource(this.$el, _(this).result('plumbSourceOptions'));
+      }
+
+      if (this.isTarget) {
+        jsPlumb.makeTarget(this.$el, _(this).result('plumbTargetOptions'));
+      }
     },
 
     isConnected: function() {
@@ -65,14 +73,6 @@
 
     render: function() {
       this.collection.appendToView(this);
-
-      if (this.isSource) {
-        jsPlumb.makeSource(this.$el, _(this).result('plumbSourceOptions'));
-      }
-
-      if (this.isTarget) {
-        jsPlumb.makeTarget(this.$el, _(this).result('plumbTargetOptions'));
-      }
     }
   });
 

--- a/go/base/static/js/src/components/plumbing/endpoints.js
+++ b/go/base/static/js/src/components/plumbing/endpoints.js
@@ -33,8 +33,14 @@
 
     // The params passed to jsPlumb when configuring the element as a
     // connection source/target
-    plumbSourceOptions: {anchor: 'Continuous', maxConnections: 1},
-    plumbTargetOptions: {anchor: 'Continuous'},
+    plumbSourceOptions: {
+      anchor: 'Continuous',
+      maxConnections: 1
+    },
+
+    plumbTargetOptions: {
+      anchor: 'Continuous'
+    },
 
     initialize: function(options) {
       // the state view that this endpoint is part of
@@ -43,14 +49,6 @@
 
       // the collection of endpoint views that this endpoint is part of
       this.collection = options.collection;
-
-      if (this.isSource) {
-        jsPlumb.makeSource(this.$el, _(this).result('plumbSourceOptions'));
-      }
-
-      if (this.isTarget) {
-        jsPlumb.makeTarget(this.$el, _(this).result('plumbTargetOptions'));
-      }
     },
 
     isConnected: function() {
@@ -67,6 +65,14 @@
 
     render: function() {
       this.collection.appendToView(this);
+
+      if (this.isSource) {
+        jsPlumb.makeSource(this.$el, _(this).result('plumbSourceOptions'));
+      }
+
+      if (this.isTarget) {
+        jsPlumb.makeTarget(this.$el, _(this).result('plumbTargetOptions'));
+      }
     }
   });
 

--- a/go/base/static/js/src/components/structures.js
+++ b/go/base/static/js/src/components/structures.js
@@ -425,7 +425,7 @@
           view = this.get(id);
 
       if (!view) { return; }
-      if (typeof view.destroy === 'function') { view.destroy(); }
+      if (typeof view.destroy === 'function') { view.destroy(options); }
 
       var model = view.model;
       if (model && this.models.get(model)) {

--- a/go/base/static/js/test/components/plumbing/connections.test.js
+++ b/go/base/static/js/test/components/plumbing/connections.test.js
@@ -43,7 +43,7 @@ describe("go.components.plumbing.connections", function() {
           done();
         });
 
-        x3_y2.destroy();
+        x3_y2.destroy({fireDetach: true});
       });
 
       it("should unset the jsPlumb connection", function() {
@@ -57,7 +57,10 @@ describe("go.components.plumbing.connections", function() {
         var detached = false;
         jsPlumb.detach(plumbConnection);
         jsPlumb.bind('connectionDetached', function() { detached = true; });
-        x3_y2.destroy();
+        x3_y2.destroy({
+          detach: false,
+          fireDetach: true
+        });
         assert(!detached);
       });
     });

--- a/go/base/static/js/test/components/plumbing/connections.test.js
+++ b/go/base/static/js/test/components/plumbing/connections.test.js
@@ -35,18 +35,30 @@ describe("go.components.plumbing.connections", function() {
     });
 
     describe(".destroy", function() {
-      it("should remove the actual jsPlumb connection", function(done) {
+      it("should detach the connection", function(done) {
         var plumbConnection = x3_y2.plumbConnection;
-
-        assert(plumbConnection);
 
         jsPlumb.bind('connectionDetached', function(e) {
           assert.equal(plumbConnection, e.connection);
-          assert.isNull(x3_y2.plumbConnection);
           done();
         });
 
         x3_y2.destroy();
+      });
+
+      it("should unset the jsPlumb connection", function() {
+        assert.isNotNull(x3_y2.plumbConnection);
+        x3_y2.destroy();
+        assert.isNull(x3_y2.plumbConnection);
+      });
+
+      it("should not detach an already detached connection", function() {
+        var plumbConnection = x3_y2.plumbConnection;
+        var detached = false;
+        jsPlumb.detach(plumbConnection);
+        jsPlumb.bind('connectionDetached', function(e) { detached = true; });
+        x3_y2.destroy();
+        assert(!detached);
       });
     });
 

--- a/go/base/static/js/test/components/plumbing/connections.test.js
+++ b/go/base/static/js/test/components/plumbing/connections.test.js
@@ -52,7 +52,7 @@ describe("go.components.plumbing.connections", function() {
         assert.isNull(x3_y2.plumbConnection);
       });
 
-      it("should not detach an already detached connection", function() {
+      it("should not detach if told not to", function() {
         var plumbConnection = x3_y2.plumbConnection;
         var detached = false;
         jsPlumb.detach(plumbConnection);

--- a/go/base/static/js/test/components/plumbing/connections.test.js
+++ b/go/base/static/js/test/components/plumbing/connections.test.js
@@ -56,7 +56,7 @@ describe("go.components.plumbing.connections", function() {
         var plumbConnection = x3_y2.plumbConnection;
         var detached = false;
         jsPlumb.detach(plumbConnection);
-        jsPlumb.bind('connectionDetached', function(e) { detached = true; });
+        jsPlumb.bind('connectionDetached', function() { detached = true; });
         x3_y2.destroy();
         assert(!detached);
       });

--- a/go/base/static/js/test/components/structures.test.js
+++ b/go/base/static/js/test/components/structures.test.js
@@ -741,8 +741,30 @@ describe("go.components.structures", function() {
         views.remove('c');
       });
 
-      it("should call the view's destroy() function if it exists", function() {
+      it("should call the view's destroy() method if it exists", function() {
         assert(views.remove('c').destroyed);
+      });
+
+      it("should pass options to the view's .destroy() method", function() {
+        var destroyOptions;
+
+        var ToyView = Backbone.View.extend({
+          id: function() {
+            return this.model.id;
+          },
+          destroy: function(options) {
+            destroyOptions = options;
+          }
+        });
+
+        var views = new ToyViewCollection({
+          type: ToyView,
+          models: models
+        });
+
+        assert.isUndefined(destroyOptions);
+        views.remove('a', {foo: 23});
+        assert.equal(destroyOptions.foo, 23);
       });
 
       it("should remove the view's model if 'removeModel' is true", function() {


### PR DESCRIPTION
At the moment, destination endpoint connection detaches are broken. We've been using our own slightly modified jsPlumb fork with a workaround for this, but the workaround appears to not always work. After a bit of tinkering, it seems that jsPlumb is unhappy if `jsPlumb.detach()` is called on an already detached endpoint.  Fixing that is simple enough -- just infer whether the connection has already been detached before trying to detach it.
