### PR TITLE
Only repaint relevant connections when dragging dialogue states

### DIFF
--- a/go/base/static/js/src/apps/dialogue/layout.js
+++ b/go/base/static/js/src/apps/dialogue/layout.js
@@ -77,9 +77,11 @@
       return state;
     },
 
-    repaint: function() {
-      // TODO only repaint the relevant connections
-      jsPlumb.repaintEverything();
+    repaint: function(state) {
+      var endpoints = state.connectedEndpoints();
+      var i = endpoints.length;
+      while (i--) jsPlumb.repaint(endpoints[i].$el);
+      jsPlumb.repaint(state.diagram.entryPoint.$endpoint);
       this.trigger('repaint');
     },
 
@@ -133,7 +135,7 @@
         .get('layout')
         .set(this.coordsOf(state), {silent: true});
 
-      this.repaint();
+      this.repaint(state);
       this.resizeToFit(state);
     }
   });

--- a/go/base/static/js/src/components/plumbing/states.js
+++ b/go/base/static/js/src/components/plumbing/states.js
@@ -41,7 +41,7 @@
 
     isConnected: function() {
       var endpoints = this.endpoints.values(),
-      i = endpoints.length;
+          i = endpoints.length;
 
       while (i--) { if (endpoints[i].isConnected()) { return true; } }
       return false;

--- a/go/base/static/js/src/components/plumbing/states.js
+++ b/go/base/static/js/src/components/plumbing/states.js
@@ -41,7 +41,7 @@
 
     isConnected: function() {
       var endpoints = this.endpoints.values(),
-          i = endpoints.length;
+      i = endpoints.length;
 
       while (i--) { if (endpoints[i].isConnected()) { return true; } }
       return false;
@@ -56,6 +56,38 @@
       this.collection.appendToView(this);
       this.endpoints.render();
       return this;
+    },
+
+    connectedEndpoints: function() {
+      var results = [];
+
+      // using internal properties here for performance reasons, this method is
+      // sometimes used on each 'drag' event for diagrams with draggable states
+      var connections = this.diagram.connections._itemList;
+      var endpoints = this.endpoints._itemList;
+      var connectionsLen = connections.length;
+      var endpoint, conn, target, source;
+      var i, j;
+
+      i = endpoints.length;
+
+      while (i--) {
+        endpoint = endpoints[i].value;
+        j = connectionsLen;
+
+        while (j--) {
+          conn = connections[j].value;
+          source = conn.source;
+          target = conn.target;
+
+          if (target === endpoint || source === endpoint) {
+            results.push(source);
+            results.push(target);
+          }
+        }
+      }
+
+      return results;
     }
   });
 

--- a/go/base/static/js/test/apps/dialogue/layout.test.js
+++ b/go/base/static/js/test/apps/dialogue/layout.test.js
@@ -337,14 +337,33 @@ describe("go.apps.dialogue.layout", function() {
 
     describe(".repaint", function() {
       it("should repaint the relevant jsPlumb connections", function() {
-        sinon.spy(jsPlumb, 'repaintEverything');
+        sinon.spy(jsPlumb, 'repaint');
 
-        var layout = new DialogueStateLayout({states: states});
-        assert(!jsPlumb.repaintEverything.called);
-        layout.repaint();
-        assert(jsPlumb.repaintEverything.called);
+        var endpoints = diagram.endpoints;
+        var state1 = states.add({model: {type: 'dummy'}});
+        var state2 = states.add({model: {type: 'dummy'}});
+        var endpoint1 = endpoints.get(state1.model.get('exit_endpoint').id);
+        var endpoint2 = endpoints.get(state2.model.get('entry_endpoint').id);
 
-        jsPlumb.repaintEverything.restore();
+        diagram.render();
+        jsPlumb.connect({
+          source: endpoint1.$el,
+          target: endpoint2.$el
+        });
+
+        assert(!jsPlumb.repaint.called);
+        layout.repaint(state1);
+
+        var actual = _.chain(jsPlumb.repaint.args)
+          .map(function(args) { return args[0]; })
+          .sortBy(function($el) { return $el.attr('id'); })
+          .value();
+
+        assert(diagram.entryPoint.$endpoint.is(actual[0]));
+        assert(endpoint1.$el.is(actual[1]));
+        assert(endpoint2.$el.is(actual[2]));
+
+        jsPlumb.repaint.restore();
       });
     });
   });

--- a/go/base/static/js/test/apps/dialogue/layout.test.js
+++ b/go/base/static/js/test/apps/dialogue/layout.test.js
@@ -147,10 +147,10 @@ describe("go.apps.dialogue.layout", function() {
           numCols: 2
         });
 
-        layout.cellWidth = function() { return 23 };
-        layout.cellHeight = function() { return 21 };
-        layout.colOffset = function() { return 2 };
-        layout.rowMargin = function() { return 3 };
+        layout.cellWidth = function() { return 23; };
+        layout.cellHeight = function() { return 21; };
+        layout.colOffset = function() { return 2; };
+        layout.rowMargin = function() { return 3; };
 
         var state2 = states.get('state2');
         var state3 = states.get('state3');
@@ -185,10 +185,10 @@ describe("go.apps.dialogue.layout", function() {
           numCols: 2
         });
 
-        layout.cellWidth = function() { return 23 };
-        layout.cellHeight = function() { return 21 };
-        layout.colOffset = function() { return 2 };
-        layout.rowMargin = function() { return 3 };
+        layout.cellWidth = function() { return 23; };
+        layout.cellHeight = function() { return 21; };
+        layout.colOffset = function() { return 2; };
+        layout.rowMargin = function() { return 3; };
 
         var state2 = states.get('state2');
         var state3 = states.get('state3');

--- a/go/base/static/js/test/components/plumbing/states.test.js
+++ b/go/base/static/js/test/components/plumbing/states.test.js
@@ -1,6 +1,4 @@
 describe("go.components.plumbing.states", function() {
-  var stateMachine = go.components.stateMachine;
-
   var plumbing = go.components.plumbing;
 
   var testHelpers = plumbing.testHelpers,
@@ -72,6 +70,47 @@ describe("go.components.plumbing.states", function() {
         a1.endpoints.each(function(e) { assert(!e.rendered); });
         a1.render();
         a1.endpoints.each(function(e) { assert(e.rendered); });
+      });
+    });
+
+    describe(".connectedEndpoints", function() {
+      it("should return all endpoints connected to this state", function() {
+        var endpoints = diagram.endpoints;
+        diagram.render();
+        jsPlumb.detachEveryConnection();
+
+        connect(endpoints.get('a2R1'), endpoints.get('a1L1'));
+        connect(endpoints.get('a1R1'), endpoints.get('b1L1'));
+        connect(endpoints.get('a1R2'), endpoints.get('b2L1'));
+
+        var actual = diagram.states
+          .get('a1')
+          .connectedEndpoints()
+          .map(idFor)
+          .sort();
+
+        assert.deepEqual(actual, [
+            'a2R1',
+            'a1L1',
+            'a1R1',
+            'b1L1',
+            'a1R2',
+            'b2L1'
+          ]
+          .map(endpoints.get, endpoints)
+          .map(idFor)
+          .sort());
+
+        function idFor(obj) {
+          return obj.model.id;
+        }
+
+        function connect(source, target) {
+          jsPlumb.connect({
+            source: source.$el,
+            target: target.$el
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
At the moment we repaint everything, which is asking for lag for larger dialogues.
