### PR TITLE
Fix endpoint creating on routing screen

### DIFF
--- a/go/base/static/js/src/components/plumbing/endpoints.js
+++ b/go/base/static/js/src/components/plumbing/endpoints.js
@@ -36,7 +36,7 @@
     plumbSourceOptions: function() {
       return {
         anchor: 'Continuous',
-        filter: this.dragFilter
+        filter: this.canMakeConnection
       };
     },
 
@@ -48,7 +48,7 @@
     },
 
     initialize: function(options) {
-      this.dragFilter = this.dragFilter.bind(this);
+      this.canMakeConnection = this.canMakeConnection.bind(this);
 
       // the state view that this endpoint is part of
       this.state = options.state;
@@ -85,8 +85,8 @@
       this.collection.appendToView(this);
     },
 
-    dragFilter: function() {
-      return !this.isConnected();
+    canMakeConnection: function() {
+      return !this.state.diagram.connections.findWhere({source: this});
     }
   });
 

--- a/go/base/static/js/test/components/plumbing/endpoints.test.js
+++ b/go/base/static/js/test/components/plumbing/endpoints.test.js
@@ -569,7 +569,7 @@ describe("go.components.plumbing.endpoints", function() {
     });
 
     describe(".canMakeConnection", function() {
-      it("should return true if the endpoint not yet a source", function() {
+      it("should return true if the endpoint is not yet a source", function() {
         assert(diagram.endpoints.get('x1').canMakeConnection());
         assert(diagram.endpoints.get('y2').canMakeConnection());
       });

--- a/go/base/static/js/test/components/plumbing/endpoints.test.js
+++ b/go/base/static/js/test/components/plumbing/endpoints.test.js
@@ -568,14 +568,14 @@ describe("go.components.plumbing.endpoints", function() {
       });
     });
 
-    describe(".dragFilter", function() {
-      it("should return true if the endpoint is not connected", function() {
-        assert(diagram.endpoints.get('x1').dragFilter());
+    describe(".canMakeConnection", function() {
+      it("should return true if the endpoint not yet a source", function() {
+        assert(diagram.endpoints.get('x1').canMakeConnection());
+        assert(diagram.endpoints.get('y2').canMakeConnection());
       });
 
-      it("should return false if the endpoint is connected", function() {
-        assert(!diagram.endpoints.get('x3').dragFilter());
-        assert(!diagram.endpoints.get('y2').dragFilter());
+      it("should return false if the endpoint is already a source", function() {
+        assert(!diagram.endpoints.get('x3').canMakeConnection());
       });
     });
   });


### PR DESCRIPTION
At the moment creating bi-directional connections aren't possible, when the user drags from the endpoint it picks up the state instead.
