### PR TITLE
Make cornerRadius massive

### DIFF
--- a/go/base/static/js/src/apps/dialogue/style.js
+++ b/go/base/static/js/src/apps/dialogue/style.js
@@ -26,7 +26,7 @@
 
     plumbDefaults.Connector = [
       'Flowchart', {
-       cornerRadius: 10
+       cornerRadius: 200
     }];
 
     plumbDefaults.ConnectionOverlays = [[


### PR DESCRIPTION
I've been having a look at making dialogues slightly easier to eyeball.
I've been tweaking all of [jsPlumb various options for `connector`s](https://jsplumbtoolkit.com/doc/connectors.html), but the only thing that doesn't make it dramatically worse is adjusting the bends of the arrows.

Before:
![screenshot 2015-05-07 11 47 39](https://cloud.githubusercontent.com/assets/1239497/7512692/f4e4e93a-f4ae-11e4-98a8-a32d011fa38d.png)

After:
![screenshot 2015-05-07 11 46 59](https://cloud.githubusercontent.com/assets/1239497/7512698/fc0ef4da-f4ae-11e4-85f2-126df8905f2d.png)

Less bad, @justinvdm ?
Although it's more visually noisy, it does separate out the lines a bit and allow for better following a path.
