### PR TITLE
Allow group message conversations to be used with non-SMS transports.

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -22,7 +22,7 @@ class BulkSendAction(ConversationAction):
         return self.send_command(
             'bulk_send', batch_id=self._conv.batch.key,
             msg_options={}, content=action_data['message'],
-            delivery_class=self._conv.delivery_class,
+            delivery_class=action_data['delivery_class'],
             dedupe=action_data['dedupe'])
 
 

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -52,6 +52,8 @@ class TestBulkMessageViews(GoDjangoTestCase):
         self.assertEqual([], self.app_helper.get_api_commands_sent())
         self.assertContains(response, 'name="message"')
         self.assertContains(response, '<h1>Write and send bulk message</h1>')
+        self.assertContains(response, 'name="delivery_class"')
+        self.assertContains(response, 'name="dedupe"')
         self.assertContains(response, '>Send message</button>')
 
     def test_action_bulk_send_no_group(self):
@@ -104,7 +106,8 @@ class TestBulkMessageViews(GoDjangoTestCase):
             started=True, channel=channel, groups=[group])
         response = self.client.post(
             conv_helper.get_action_view_url('bulk_send'),
-            {'message': 'I am ham, not spam.', 'dedupe': True})
+            {'message': 'I am ham, not spam.', 'delivery_class': 'sms',
+             'dedupe': True})
         self.assertRedirects(response, conv_helper.get_view_url('show'))
         [bulk_send_cmd] = self.app_helper.get_api_commands_sent()
         conversation = conv_helper.get_conversation()
@@ -114,7 +117,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},
-            delivery_class=conversation.delivery_class,
+            delivery_class='sms',
             content='I am ham, not spam.', dedupe=True))
 
     def test_action_bulk_send_no_dedupe(self):
@@ -124,7 +127,8 @@ class TestBulkMessageViews(GoDjangoTestCase):
             started=True, channel=channel, groups=[group])
         response = self.client.post(
             conv_helper.get_action_view_url('bulk_send'),
-            {'message': 'I am ham, not spam.', 'dedupe': False})
+            {'message': 'I am ham, not spam.', 'delivery_class': 'sms',
+             'dedupe': False})
         self.assertRedirects(response, conv_helper.get_view_url('show'))
         [bulk_send_cmd] = self.app_helper.get_api_commands_sent()
         conversation = conv_helper.get_conversation()
@@ -134,7 +138,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},
-            delivery_class=conversation.delivery_class,
+            delivery_class='sms',
             content='I am ham, not spam.', dedupe=False))
 
     def test_action_bulk_send_confirm(self):
@@ -159,7 +163,8 @@ class TestBulkMessageViews(GoDjangoTestCase):
             TokenManager, 'generate_token', lambda s: ('abcdef', '123456'))
         response = self.client.post(
             conv_helper.get_action_view_url('bulk_send'),
-            {'message': 'I am ham, not spam.', 'dedupe': True})
+            {'message': 'I am ham, not spam.', 'delivery_class': 'sms',
+             'dedupe': True})
         self.assertRedirects(response, conv_helper.get_view_url('show'))
 
         # Check that we get a confirmation message
@@ -200,5 +205,5 @@ class TestBulkMessageViews(GoDjangoTestCase):
             user_account_key=conversation.user_account.key,
             conversation_key=conversation.key,
             batch_id=conversation.batch.key, msg_options={},
-            delivery_class=conversation.delivery_class,
+            delivery_class='sms',
             content='I am ham, not spam.', dedupe=True))

--- a/go/apps/bulk_message/view_definition.py
+++ b/go/apps/bulk_message/view_definition.py
@@ -2,10 +2,17 @@ from django import forms
 
 from go.conversation.view_definition import ConversationViewDefinitionBase
 from go.base.widgets import BulkMessageWidget
+from go.vumitools.contact.models import (
+    DELIVERY_CLASSES, DEFAULT_DELIVERY_CLASS)
 
 
 class MessageForm(forms.Form):
     message = forms.CharField(widget=BulkMessageWidget)
+    delivery_class = forms.ChoiceField(
+        required=True,
+        initial=DEFAULT_DELIVERY_CLASS,
+        choices=[(d_name, d['label']) for d_name, d
+                 in DELIVERY_CLASSES.iteritems()])
     dedupe = forms.BooleanField(required=False)
 
 

--- a/go/vumitools/conversation/models.py
+++ b/go/vumitools/conversation/models.py
@@ -47,6 +47,7 @@ class Conversation(Model):
     groups = ManyToMany(ContactGroup)
     batch = ForeignKey(Batch)
 
+    # TODO: conversation.delivery_class is deprecated and should be removed
     delivery_class = Unicode(null=True)
 
     def active(self):
@@ -107,14 +108,6 @@ class Conversation(Model):
 
     def __unicode__(self):
         return self.name
-
-    def get_contacts_addresses(self, contacts):
-        """
-        Get the contacts assigned to this group with an address attribute
-        that is appropriate for this conversation's delivery_class
-        """
-        addrs = [contact.addr_for(self.delivery_class) for contact in contacts]
-        return [addr for addr in addrs if addr]
 
     def get_connector(self):
         return GoConnector.for_conversation(self.conversation_type, self.key)


### PR DESCRIPTION
This used to be possible, but when conversations stopped honouring `conv.delivery_class`, group message was never updated.

We need to make `delivery_class` an option in the group message send message action (similar to how it is for dialogues) and then pass that option through to the management command.
