### PR TITLE
Set default delivery class for bulk send to SMS (since USSD seldom makes sense).

### DIFF
--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -53,6 +53,8 @@ class TestBulkMessageViews(GoDjangoTestCase):
         self.assertContains(response, 'name="message"')
         self.assertContains(response, '<h1>Write and send bulk message</h1>')
         self.assertContains(response, 'name="delivery_class"')
+        self.assertContains(response,
+                            '<option value="sms" selected="selected">SMS<')
         self.assertContains(response, 'name="dedupe"')
         self.assertContains(response, '>Send message</button>')
 

--- a/go/apps/bulk_message/view_definition.py
+++ b/go/apps/bulk_message/view_definition.py
@@ -2,15 +2,17 @@ from django import forms
 
 from go.conversation.view_definition import ConversationViewDefinitionBase
 from go.base.widgets import BulkMessageWidget
-from go.vumitools.contact.models import (
-    DELIVERY_CLASSES, DEFAULT_DELIVERY_CLASS)
+from go.vumitools.contact.models import DELIVERY_CLASSES
+
+
+DEFAULT_BULK_SEND_DELIVERY_CLASS = 'sms'
 
 
 class MessageForm(forms.Form):
     message = forms.CharField(widget=BulkMessageWidget)
     delivery_class = forms.ChoiceField(
         required=True,
-        initial=DEFAULT_DELIVERY_CLASS,
+        initial=DEFAULT_BULK_SEND_DELIVERY_CLASS,
         choices=[(d_name, d['label']) for d_name, d
                  in DELIVERY_CLASSES.iteritems()])
     dedupe = forms.BooleanField(required=False)


### PR DESCRIPTION
The default default delivery class is USSD, which isn't particularly useful for bulk send, although it happens to be the global default (which is really the default for dialogues).
