### PR TITLE
Add fallback edit view so that every conversation type has one.

### DIFF
--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -476,6 +476,11 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertEqual(reloaded_conv.name, 'test-name')
         self.assertEqual(reloaded_conv.description, 'test-desc')
 
+    def test_edit_fallback(self):
+        conv = self.user_helper.create_conversation(u'dummy')
+        response = self.client.get(self.get_view_url(conv, 'edit'))
+        self.assertRedirects(response, self.get_view_url(conv, 'show'))
+
     def test_conversation_contact_group_listing(self):
         conv = self.user_helper.create_conversation(
             u'dummy', name=u'test', description=u'test')

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -485,6 +485,20 @@ def check_action_is_enabled(f):
     return wrapper
 
 
+class FallbackEditConversationView(ConversationApiView):
+    """A fallback 'edit' view that redirects to the 'show' view.
+
+    For use on conversation types that have no custom edit
+    view to prevent 404s from occurring if another part of
+    the user interface directs a person to the edit view.
+    """
+    view_name = 'edit'
+    path_suffix = 'edit/'
+
+    def get(self, request, conversation):
+        return self.redirect_to('show', conversation_key=conversation.key)
+
+
 class ConversationActionView(ConversationTemplateView):
     """View for performing an arbitrary conversation action.
 
@@ -762,6 +776,8 @@ class ConversationViewDefinitionBase(object):
         self._views = list(self.DEFAULT_CONVERSATION_VIEWS)
         if self.edit_view is not None:
             self._views.append(self.edit_view)
+        else:
+            self._views.append(FallbackEditConversationView)
         self._views.extend(self.extra_views)
 
         self._view_mapping = {}


### PR DESCRIPTION
Currently the campaign routing table links to the edit view of conversations but some types (e.g. group message) don't have edit views. We should add a fallback edit view to avoid such 404s in this case and in potential other cases.
