### PR TITLE
Disable event statuses because they cause the message list to load too slowly.

### DIFF
--- a/go/conversation/settings.py
+++ b/go/conversation/settings.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+ENABLE_EVENT_STATUSES_IN_MESSAGE_LIST = getattr(
+    settings, 'GO_ENABLE_EVENT_STATUSES_IN_MESSAGE_LIST', False)

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -13,6 +13,7 @@ from django.utils.unittest import skip
 from vumi.message import TransportUserMessage
 
 import go.base.utils
+import go.conversation.settings
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
 from go.conversation.templatetags import conversation_tags
 from go.conversation.view_definition import (

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -5,8 +5,6 @@ from datetime import date
 from StringIO import StringIO
 from zipfile import ZipFile
 
-import mock
-
 from django import forms
 from django.core import mail
 from django.core.urlresolvers import reverse
@@ -357,13 +355,15 @@ class TestNewConversationView(BaseConversationViewTestCase):
 
 class TestConversationViews(BaseConversationViewTestCase):
 
-    with_event_statuses = mock.patch(
-        'go.conversation.settings.ENABLE_EVENT_STATUSES_IN_MESSAGE_LIST', True)
-
     def setUp(self):
         super(TestConversationViews, self).setUp()
         self.msg_helper = self.add_helper(
             GoMessageHelper(vumi_helper=self.vumi_helper))
+
+    def enable_event_statuses(self):
+        self.monkey_patch(
+            go.conversation.settings, 'ENABLE_EVENT_STATUSES_IN_MESSAGE_LIST',
+            True)
 
     def test_show_no_content_block(self):
         conv = self.user_helper.create_conversation(u'dummy')
@@ -863,8 +863,8 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertNotContains(r_out, "<td>Accepted", html=True)
         self.assertNotContains(r_out, "<td>Rejected", html=True)
 
-    @with_event_statuses
     def test_message_list_outbound_status_pending(self):
+        self.enable_event_statuses()
         conv = self.user_helper.create_conversation(u'dummy', started=True)
         self.msg_helper.make_stored_outbound(conv, "hi")
 
@@ -875,8 +875,8 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertNotContains(r_out, "<td>Accepted", html=True)
         self.assertNotContains(r_out, "<td>Rejected", html=True)
 
-    @with_event_statuses
     def test_message_list_outbound_status_failed(self):
+        self.enable_event_statuses()
         conv = self.user_helper.create_conversation(u'dummy', started=True)
         msg = self.msg_helper.make_stored_outbound(conv, "hi")
         self.msg_helper.make_stored_nack(conv, msg, nack_reason="no spoons")
@@ -888,8 +888,8 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertNotContains(r_out, "<td>Sending", html=True)
         self.assertNotContains(r_out, "<td>Accepted", html=True)
 
-    @with_event_statuses
     def test_message_list_outbound_status_sent(self):
+        self.enable_event_statuses()
         conv = self.user_helper.create_conversation(u'dummy', started=True)
         msg = self.msg_helper.make_stored_outbound(conv, "hi")
         self.msg_helper.make_stored_ack(conv, msg)

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -25,6 +25,8 @@ from go.conversation.tasks import export_conversation_messages_unsorted
 from go.conversation.utils import PagedMessageCache
 from go.dashboard.dashboard import Dashboard, ConversationReportsLayout
 
+import go.conversation.settings as conversation_settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -246,6 +248,9 @@ class MessageListView(ConversationTemplateView):
         batch_id = conversation.batch.key
 
         def add_event_status(msg):
+            if not conversation_settings.ENABLE_EVENT_STATUSES_IN_MESSAGE_LIST:
+                msg.event_status = "-"
+                return msg
             msg.event_status = u"Sending"
             get_event_info = conversation.mdb.message_event_keys_with_statuses
             for event_id, _, event_type in get_event_info(msg["message_id"]):


### PR DESCRIPTION
Displaying event status requires a riak index lookup for each message displayed in the message list (so 20 by default). These 20 index looks are slow and easily cause the page load to time out.
