### PR TITLE
Add routers for celery tasks.

### DIFF
--- a/go/base/celery_routers.py
+++ b/go/base/celery_routers.py
@@ -1,0 +1,13 @@
+import re
+
+
+class CeleryRegexRouter(object):
+    def __init__(self, regex, queue):
+        self.regex = re.compile(regex)
+        self.queue = queue
+
+    def route_for_task(self, task, args=None, kwargs=None):
+        if self.regex.match(task):
+            return {'queue': self.queue}
+        else:
+            return None

--- a/go/base/celery_routers.py
+++ b/go/base/celery_routers.py
@@ -11,3 +11,8 @@ class CeleryRegexRouter(object):
             return {'queue': self.queue}
         else:
             return None
+
+
+class CeleryAppRouter(object):
+    def route_for_task(self, task, args=None, kwargs=None):
+        return {'queue': '.'.join(task.split('.')[:2])}

--- a/go/base/tests/test_celery_routers.py
+++ b/go/base/tests/test_celery_routers.py
@@ -1,4 +1,4 @@
-from go.base.celery_routers import CeleryRegexRouter
+from go.base.celery_routers import CeleryAppRouter, CeleryRegexRouter
 from go.base.tests.helpers import GoDjangoTestCase
 
 
@@ -11,3 +11,24 @@ class TestCeleryRegexRouter(GoDjangoTestCase):
     def test_router_for_task_non_match(self):
         router = CeleryRegexRouter(r'[^a]+', 'foo')
         self.assertEqual(router.route_for_task('aaa'), None)
+
+
+class TestAppRouter(GoDjangoTestCase):
+    def test_router_for_task(self):
+        router = CeleryAppRouter()
+
+        self.assertEqual(
+            router.route_for_task('a.b.c.d'),
+            {'queue': 'a.b'})
+
+        self.assertEqual(
+            router.route_for_task('foo.bar.baz.quux'),
+            {'queue': 'foo.bar'})
+
+        self.assertEqual(
+            router.route_for_task('foo.bar'),
+            {'queue': 'foo.bar'})
+
+        self.assertEqual(
+            router.route_for_task('foo'),
+            {'queue': 'foo'})

--- a/go/base/tests/test_celery_routers.py
+++ b/go/base/tests/test_celery_routers.py
@@ -1,0 +1,13 @@
+from go.base.celery_routers import CeleryRegexRouter
+from go.base.tests.helpers import GoDjangoTestCase
+
+
+class TestCeleryRegexRouter(GoDjangoTestCase):
+    def test_router_for_task_match(self):
+        router = CeleryRegexRouter(r'[^a]+', 'foo')
+        self.assertEqual(router.route_for_task('bbb'), {'queue': 'foo'})
+        self.assertEqual(router.route_for_task('ccc'), {'queue': 'foo'})
+
+    def test_router_for_task_non_match(self):
+        router = CeleryRegexRouter(r'[^a]+', 'foo')
+        self.assertEqual(router.route_for_task('aaa'), None)


### PR DESCRIPTION
Celery allows custom routers for tasks, see https://celery.readthedocs.org/en/latest/userguide/routing.html#routers. I propose adding two custom router classes:
- `CeleryRegexRouter` that directs tasks based on a regular expression for the task name (this is low credit notifications so that they don't need to set behind statement generation and archival tasks)
- `CeleryAppRouter` that directs tasks based on the first two parts of the task name (so all tasks that start with `go.billing.*` are directed to `go.billing`, all tasks that start with `go.conversation.*` go to `go.conversation`).

```
CELERY_ROUTES = (
    CeleryRegexRouter(r'^go\.billing\..*low_credit.*$', queue='go.billing.low_credit'),
    CeleryAppRouter(),
)
```
