### PR TITLE
Remove zomby connections

### DIFF
--- a/go/base/static/js/src/components/plumbing/connections.js
+++ b/go/base/static/js/src/components/plumbing/connections.js
@@ -122,6 +122,8 @@
       jsPlumb.bind(
         'connectionDetached',
         _.bind(this.onPlumbDisconnect, this));
+
+      this.removeZombies();
     },
 
     // Returns the first connection collection found that accepts a connection
@@ -219,6 +221,21 @@
       // The connection was removed in the UI, so the model and view still
       // exist. We need to remove them.
       this.remove(connectionId, {detach: false});
+    },
+
+    removeZombies: function() {
+      // HACK: there appears to be an obscure edge case where states are
+      // removed, but their connection still exists. This case is difficult to
+      // identify, so instead, to prevent broken, unusable dialogues as a
+      // result of this, we remove the connection
+      this
+        .where(this._isZomby)
+        .forEach(this.remove, this);
+    },
+
+    _isZomby: function(connection) {
+      return !connection.source
+          || !connection.target;
     }
   });
 

--- a/go/base/static/js/test/components/plumbing/connections.test.js
+++ b/go/base/static/js/test/components/plumbing/connections.test.js
@@ -132,6 +132,24 @@ describe("go.components.plumbing.connections", function() {
       });
     });
 
+    describe(".removeZombies", function() {
+      it("should remove connections with a non-existent source", function() {
+        var conn = diagram.connections.get('a1L2-b2R2');
+        conn.source = null;
+        assert(diagram.connections.has('a1L2-b2R2'));
+        connections.removeZombies();
+        assert(!diagram.connections.has('a1L2-b2R2'));
+      });
+
+      it("should remove connections with a non-existent target", function() {
+        var conn = diagram.connections.get('a1L2-b2R2');
+        conn.target = null;
+        assert(diagram.connections.has('a1L2-b2R2'));
+        connections.removeZombies();
+        assert(!diagram.connections.has('a1L2-b2R2'));
+      });
+    });
+
     describe("on 'connection' jsPlumb events", function() {
       beforeEach(function() {
         // render the diagram to ensure the jsPlumb endpoints are drawn


### PR DESCRIPTION
There appears to be an obscure edge case where an endpoint is removed, but the connection stays around. Finding and fixing this bug is one thing, but fixing existing dialogues broken as a result of this is another. This ticket is for fixing existing dialogues by removing these zomby connections.
