### PR TITLE
Avoid creating a VumiApi when we only need Redis manager

### DIFF
--- a/go/api/go_api/session.py
+++ b/go/api/go_api/session.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # -*- test-case-name: go.api.go_api.tests.test_session -*-
 
-from django.conf import settings
 from django.contrib.sessions.backends.base import SessionBase, CreateError
-from vumi.persist.redis_manager import RedisManager
 
+from go.base.utils import get_redis_manager
 from go.api.go_api.session_manager import SessionManager
 
 
@@ -14,10 +13,8 @@ class SessionStore(SessionBase):
     """
     def __init__(self, session_key=None):
         super(SessionStore, self).__init__(session_key)
-        redis_config = settings.VUMI_API_CONFIG.get('redis_manager', {})
-        redis = RedisManager.from_config(redis_config)
         self.session_manager = SessionManager(
-            redis.sub_manager('session_manager'))
+            get_redis_manager().sub_manager('session_manager'))
 
     def encode(self, data):
         """Replace Django's pickle serialization with a null-op.

--- a/go/api/go_api/session.py
+++ b/go/api/go_api/session.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # -*- test-case-name: go.api.go_api.tests.test_session -*-
 
+from django.conf import settings
 from django.contrib.sessions.backends.base import SessionBase, CreateError
+from vumi.persist.redis_manager import RedisManager
 
-from go.base.utils import vumi_api
+from go.api.go_api.session_manager import SessionManager
 
 
 class SessionStore(SessionBase):
@@ -12,7 +14,10 @@ class SessionStore(SessionBase):
     """
     def __init__(self, session_key=None):
         super(SessionStore, self).__init__(session_key)
-        self.session_manager = vumi_api().session_manager
+        redis_config = settings.VUMI_API_CONFIG.get('redis_manager', {})
+        redis = RedisManager.from_config(redis_config)
+        self.session_manager = SessionManager(
+            redis.sub_manager('session_manager'))
 
     def encode(self, data):
         """Replace Django's pickle serialization with a null-op.

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -9,6 +9,7 @@ from urlparse import urlparse, urlunparse
 from django import forms
 from django.http import Http404, HttpResponse
 from django.conf import settings
+from vumi.persist.redis_manager import RedisManager
 
 from go.errors import UnknownConversationType, UnknownRouterType
 from go.config import (
@@ -45,6 +46,14 @@ def sendfile(url, buffering=True, filename=None):
         response.write(url)
 
     return response
+
+
+def get_redis_manager():
+    """
+    Build a Django-configured Redis manager.
+    """
+    redis_config = settings.VUMI_API_CONFIG.get('redis_manager', {})
+    return RedisManager.from_config(redis_config)
 
 
 def vumi_api():

--- a/go/token/views.py
+++ b/go/token/views.py
@@ -9,14 +9,13 @@ from django.contrib.auth.decorators import login_required
 
 from vumi.utils import load_class_by_string
 
-from go.base.utils import vumi_api
+from go.base.utils import get_redis_manager
+from go.vumitools.token_manager import TokenManager
 
 
 def token(request, token):
-    # We only need the redis manager here, but it's saner to get a whole
-    # vumi_api and not worry about all the setup magic.
-    api = vumi_api()
-    token_data = api.token_manager.get(token)
+    tm = TokenManager(get_redis_manager().sub_manager('token_manager'))
+    token_data = tm.get(token)
     if not token_data:
         raise Http404
 


### PR DESCRIPTION
There are two places we do this, and it's a bunch of unnecessary work.

This is even more of a problem when we start needing to clean up Riak managers properly.
