### PR TITLE
Refactor management commands to use common base classes

### DIFF
--- a/go/base/command_utils.py
+++ b/go/base/command_utils.py
@@ -69,7 +69,7 @@ class BaseGoCommand(BaseCommand):
         if email_address is None and options is None:
             raise ValueError("email_address or options is required")
         if email_address is None:
-            if 'email_address' not in options:
+            if options.get('email_address', None) is None:
                 raise CommandError("--email-address must be specified")
             email_address = options.get('email_address')
         user = get_user_by_email(email_address)

--- a/go/base/management/commands/go_account_stats.py
+++ b/go/base/management/commands/go_account_stats.py
@@ -1,8 +1,6 @@
-from django.core.management.base import BaseCommand
 from vumi.message import parse_vumi_date
 
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand
 
 
 def print_dates(bucket, io):
@@ -11,7 +9,7 @@ def print_dates(bucket, io):
         io.write('%s: %s\n' % (item.strftime('%Y-%m-%d'), count))
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = """
     Generate stats for a given Vumi Go account.
 
@@ -31,14 +29,10 @@ class Command(BaseCommand):
         email_address = args[0]
         command = args[1]
 
-        user = get_user_by_email(email=email_address)
-        api = self.get_api(user)
+        user, api = self.mk_user_api(email_address)
 
         handler = getattr(self, 'handle_%s' % (command,), self.unknown_command)
         handler(user, api, args[2:])
-
-    def get_api(self, user):
-        return vumi_api_for_user(user)
 
     def out(self, data):
         self.stdout.write(data.encode(self.encoding))

--- a/go/base/management/commands/go_assign_tagpool.py
+++ b/go/base/management/commands/go_assign_tagpool.py
@@ -1,13 +1,11 @@
 import uuid
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
 from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError, get_user_by_email
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Give a Vumi Go user access to a certain tagpool"
 
     LOCAL_OPTIONS = [
@@ -27,7 +25,7 @@ class Command(BaseCommand):
             default=False,
             help='Update an existing permission with a new max-keys value'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def handle(self, *args, **options):
         options = options.copy()

--- a/go/base/management/commands/go_assign_tagpool.py
+++ b/go/base/management/commands/go_assign_tagpool.py
@@ -1,17 +1,13 @@
 import uuid
 from optparse import make_option
 
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import BaseGoCommand, CommandError, get_user_by_email
+from go.base.command_utils import BaseGoAccountCommand, CommandError
 
 
-class Command(BaseGoCommand):
+class Command(BaseGoAccountCommand):
     help = "Give a Vumi Go user access to a certain tagpool"
 
     LOCAL_OPTIONS = [
-        make_option('--email-address',
-            dest='email-address',
-            help='Email address for the Vumi Go user'),
         make_option('--tagpool',
             dest='tagpool',
             help='The tagpool to give access to'),
@@ -25,9 +21,9 @@ class Command(BaseGoCommand):
             default=False,
             help='Update an existing permission with a new max-keys value'),
     ]
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoAccountCommand.option_list + tuple(LOCAL_OPTIONS)
 
-    def handle(self, *args, **options):
+    def handle_no_command(self, *args, **options):
         options = options.copy()
         for opt in self.LOCAL_OPTIONS:
             if options.get(opt.dest) is None:
@@ -40,12 +36,10 @@ class Command(BaseGoCommand):
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        email_address = options['email-address']
         tagpool = unicode(options['tagpool'])
         max_keys = int(options['max-keys']) or None
 
-        user = get_user_by_email(email_address)
-        account = user.get_profile().get_user_account()
+        account = self.user.get_profile().get_user_account()
         existing_tagpools = []
         for permissions in account.tagpools.load_all_bunches():
             existing_tagpools.extend([
@@ -63,15 +57,14 @@ class Command(BaseGoCommand):
                 raise CommandError('Permission already exists, use '
                     '--update to update the value of max-keys')
         else:
-            self.create_permission(user, account, tagpool, max_keys)
+            self.create_permission(account, tagpool, max_keys)
 
     def update_permission(self, tagpool_permission, max_keys):
         tagpool_permission.max_keys = max_keys
         tagpool_permission.save()
 
-    def create_permission(self, user, account, tagpool, max_keys):
-        user_api = vumi_api_for_user(user)
-        api = user_api.api
+    def create_permission(self, account, tagpool, max_keys):
+        api = self.user_api.api
 
         if tagpool not in api.tpm.list_pools():
             raise CommandError("Tagpool '%s' does not exist" % (tagpool,))

--- a/go/base/management/commands/go_assign_tagpool.py
+++ b/go/base/management/commands/go_assign_tagpool.py
@@ -12,7 +12,7 @@ class Command(BaseGoAccountCommand):
             dest='tagpool',
             help='The tagpool to give access to'),
         make_option('--max-keys',
-            dest='max-keys',
+            dest='max_keys',
             help='Maximum number of keys that can be acquired '
                     '(0 == Unlimited)'),
         make_option('--update',
@@ -37,7 +37,7 @@ class Command(BaseGoAccountCommand):
 
     def handle_validated(self, *args, **options):
         tagpool = unicode(options['tagpool'])
-        max_keys = int(options['max-keys']) or None
+        max_keys = int(options['max_keys']) or None
 
         account = self.user.get_profile().get_user_account()
         existing_tagpools = []

--- a/go/base/management/commands/go_create_user.py
+++ b/go/base/management/commands/go_create_user.py
@@ -1,13 +1,13 @@
 import getpass
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
 from django.core.validators import validate_email
 from django.core import exceptions
 from django.contrib.auth import get_user_model
 
+from go.base.command_utils import BaseGoCommand, CommandError
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Create a Vumi Go user"
 
     PARAMS = [
@@ -21,7 +21,7 @@ class Command(BaseCommand):
                 raw_input),
     ]
 
-    option_list = BaseCommand.option_list + tuple([
+    option_list = BaseGoCommand.option_list + tuple([
         make_option('--%s' % key, dest=key, help=hlp)
         for key, hlp, _ in PARAMS
     ])

--- a/go/base/management/commands/go_generate_export_conversations_urls.py
+++ b/go/base/management/commands/go_generate_export_conversations_urls.py
@@ -5,8 +5,7 @@ from optparse import make_option
 from django.core.management.base import CommandError
 from django.utils.text import slugify
 
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import BaseGoCommand, get_user_by_email
+from go.base.command_utils import BaseGoCommand
 
 
 class Command(BaseGoCommand):
@@ -38,8 +37,7 @@ class Command(BaseGoCommand):
             raise CommandError('--base-url is mandatory.')
         self.template = kwargs['template']
 
-        self.user = get_user_by_email(self.email)
-        self.user_api = vumi_api_for_user(self.user)
+        self.user, self.user_api = self.mk_user_api(self.email)
 
         conversation_store = self.user_api.conversation_store
         conversation_keys = conversation_store.list_conversations()

--- a/go/base/management/commands/go_generate_export_conversations_urls.py
+++ b/go/base/management/commands/go_generate_export_conversations_urls.py
@@ -8,6 +8,8 @@ from django.utils.text import slugify
 from go.base.command_utils import BaseGoCommand
 
 
+# We don't extend BaseGoAccountCommand since the '--email' option is used
+# instead of '--email-address'
 class Command(BaseGoCommand):
 
     help = "Dump URLs for use with cURL for downloading message data."

--- a/go/base/management/commands/go_import_contacts.py
+++ b/go/base/management/commands/go_import_contacts.py
@@ -10,7 +10,7 @@ class Command(BaseGoAccountCommand):
 
     LOCAL_OPTIONS = [
         make_option('--contacts-csv',
-            dest='contacts-csv',
+            dest='contacts_csv',
             help='The CSV file containing contacts to import'),
         make_option('--group',
             dest='groups',
@@ -36,7 +36,7 @@ class Command(BaseGoAccountCommand):
     def handle_no_command(self, *args, **options):
         options = options.copy()
 
-        self.ask_for_options(options, ['contacts-csv'])
+        self.ask_for_options(options, ['contacts_csv'])
         groups = [g.key for g in self.user_api.list_groups()]
         for group in options['groups']:
             if group not in groups:
@@ -44,7 +44,7 @@ class Command(BaseGoAccountCommand):
         return self.import_contacts(options)
 
     def import_contacts(self, options):
-        file_path = options['contacts-csv']
+        file_path = options['contacts_csv']
         try:
             _, parser = ContactFileParser.get_parser(file_path)
             # No Django silliness, please.

--- a/go/base/management/commands/go_import_contacts.py
+++ b/go/base/management/commands/go_import_contacts.py
@@ -1,14 +1,11 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
-from go.base.utils import vumi_api_for_user
 from go.contacts.parsers import ContactFileParser
 
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Manage contact groups belonging to a Vumi Go account."
 
     LOCAL_OPTIONS = [
@@ -24,7 +21,7 @@ class Command(BaseCommand):
             default=[],
             help='Group to add the imported contacts to (multiple)'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def ask_for_option(self, options, opt):
         if options.get(opt.dest) is None:
@@ -43,8 +40,7 @@ class Command(BaseCommand):
         options = options.copy()
 
         self.ask_for_options(options, ['email-address', 'contacts-csv'])
-        user = get_user_by_email(options['email-address'])
-        user_api = vumi_api_for_user(user)
+        user, user_api = self.mk_user_api(options['email-address'])
         groups = [g.key for g in user_api.list_groups()]
         for group in options['groups']:
             if group not in groups:

--- a/go/base/management/commands/go_list_accounts.py
+++ b/go/base/management/commands/go_list_accounts.py
@@ -1,13 +1,13 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand
 from django.db.models import Q
 
-from go.base.command_utils import get_users, user_details_as_string
+from go.base.command_utils import (
+    BaseGoCommand, get_users, user_details_as_string)
 from go.base.utils import vumi_api_for_user
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = """
     List known accounts on Vumi Go. Allows for optional searching on the
     username.
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     args = "[optional username regex]"
     encoding = 'utf-8'
 
-    option_list = BaseCommand.option_list + (
+    option_list = BaseGoCommand.option_list + (
         make_option(
             '--show-pools', dest='show-pools', default=False,
             action='store_true',

--- a/go/base/management/commands/go_list_opt_outs.py
+++ b/go/base/management/commands/go_list_opt_outs.py
@@ -1,24 +1,31 @@
 from optparse import make_option
 
-from go.base.command_utils import BaseGoCommand, make_email_option
+from django.core.management.base import BaseCommand
+
+from go.base.utils import vumi_api_for_user
+from go.base.command_utils import get_user_by_email
 from go.vumitools.opt_out import OptOutStore
 
 
-class Command(BaseGoCommand):
+class Command(BaseCommand):
     help = "List opt-outs from a particular account"
 
-    LOCAL_OPTIONS = [
-        make_email_option()
-    ]
-
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+    LOCAL_OPTIONS = (
+        make_option('--email-address',
+                    dest='email-address',
+                    help='Email address for the Vumi Go user'),
+    )
+    option_list = BaseCommand.option_list + LOCAL_OPTIONS
 
     def handle(self, *args, **options):
         options = options.copy()
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        _, user_api = self.mk_user_api(options['email-address'])
+        email_address = options['email-address']
+
+        user = get_user_by_email(email_address)
+        user_api = vumi_api_for_user(user)
 
         self.show_opt_outs(user_api, email_address)
 

--- a/go/base/management/commands/go_list_opt_outs.py
+++ b/go/base/management/commands/go_list_opt_outs.py
@@ -1,22 +1,30 @@
 from optparse import make_option
 
-from go.base.command_utils import BaseGoAccountCommand
+from go.base.command_utils import BaseGoCommand, make_email_option
 from go.vumitools.opt_out import OptOutStore
 
 
 class Command(BaseGoCommand):
     help = "List opt-outs from a particular account"
 
-    def handle_no_command(self, *args, **options):
+    LOCAL_OPTIONS = [
+        make_email_option()
+    ]
+
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+
+    def handle(self, *args, **options):
         options = options.copy()
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        self.show_opt_outs()
+        _, user_api = self.mk_user_api(options['email-address'])
 
-    def show_opt_outs(self):
-        opt_out_store = OptOutStore(self.user_api.manager,
-                                    self.user_api.user_account_key)
+        self.show_opt_outs(user_api, email_address)
+
+    def show_opt_outs(self, user_api, email_address):
+        opt_out_store = OptOutStore(user_api.manager,
+                                    user_api.user_account_key)
         opt_outs = opt_out_store.list_opt_outs()
 
         print "Address Type, Address, Message ID, Timestamp"

--- a/go/base/management/commands/go_list_opt_outs.py
+++ b/go/base/management/commands/go_list_opt_outs.py
@@ -1,31 +1,24 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand
-
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, make_email_option
 from go.vumitools.opt_out import OptOutStore
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "List opt-outs from a particular account"
 
-    LOCAL_OPTIONS = (
-        make_option('--email-address',
-                    dest='email-address',
-                    help='Email address for the Vumi Go user'),
-    )
-    option_list = BaseCommand.option_list + LOCAL_OPTIONS
+    LOCAL_OPTIONS = [
+        make_email_option()
+    ]
+
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def handle(self, *args, **options):
         options = options.copy()
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        email_address = options['email-address']
-
-        user = get_user_by_email(email_address)
-        user_api = vumi_api_for_user(user)
+        _, user_api = self.mk_user_api(options['email-address'])
 
         self.show_opt_outs(user_api, email_address)
 

--- a/go/base/management/commands/go_list_opt_outs.py
+++ b/go/base/management/commands/go_list_opt_outs.py
@@ -1,30 +1,22 @@
 from optparse import make_option
 
-from go.base.command_utils import BaseGoCommand, make_email_option
+from go.base.command_utils import BaseGoAccountCommand
 from go.vumitools.opt_out import OptOutStore
 
 
 class Command(BaseGoCommand):
     help = "List opt-outs from a particular account"
 
-    LOCAL_OPTIONS = [
-        make_email_option()
-    ]
-
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
-
-    def handle(self, *args, **options):
+    def handle_no_command(self, *args, **options):
         options = options.copy()
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        _, user_api = self.mk_user_api(options['email-address'])
+        self.show_opt_outs()
 
-        self.show_opt_outs(user_api, email_address)
-
-    def show_opt_outs(self, user_api, email_address):
-        opt_out_store = OptOutStore(user_api.manager,
-                                    user_api.user_account_key)
+    def show_opt_outs(self):
+        opt_out_store = OptOutStore(self.user_api.manager,
+                                    self.user_api.user_account_key)
         opt_outs = opt_out_store.list_opt_outs()
 
         print "Address Type, Address, Message ID, Timestamp"

--- a/go/base/management/commands/go_manage_application.py
+++ b/go/base/management/commands/go_manage_application.py
@@ -8,8 +8,8 @@ class Command(BaseGoAccountCommand):
     help = "Give a Vumi Go user access to a certain application"
 
     LOCAL_OPTIONS = [
-        make_option('--application-module',
-            dest='application-module',
+        make_option('--application_module',
+            dest='application_module',
             help='The application module to give access to'),
         make_option('--enable',
             dest='enable',
@@ -37,7 +37,7 @@ class Command(BaseGoAccountCommand):
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        application_module = unicode(options['application-module'])
+        application_module = unicode(options['application_module'])
         enable = options['enable']
         disable = options['disable']
 

--- a/go/base/management/commands/go_manage_application.py
+++ b/go/base/management/commands/go_manage_application.py
@@ -1,13 +1,11 @@
 import uuid
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
 from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError, get_user_by_email
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Give a Vumi Go user access to a certain application"
 
     LOCAL_OPTIONS = [
@@ -28,7 +26,7 @@ class Command(BaseCommand):
             default=False,
             help='Revoke access to this application'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def handle(self, *args, **options):
         options = options.copy()

--- a/go/base/management/commands/go_manage_application.py
+++ b/go/base/management/commands/go_manage_application.py
@@ -1,17 +1,13 @@
 import uuid
 from optparse import make_option
 
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import BaseGoCommand, CommandError, get_user_by_email
+from go.base.command_utils import BaseGoAccountCommand, CommandError
 
 
-class Command(BaseGoCommand):
+class Command(BaseGoAccountCommand):
     help = "Give a Vumi Go user access to a certain application"
 
     LOCAL_OPTIONS = [
-        make_option('--email-address',
-            dest='email-address',
-            help='Email address for the Vumi Go user'),
         make_option('--application-module',
             dest='application-module',
             help='The application module to give access to'),
@@ -26,9 +22,9 @@ class Command(BaseGoCommand):
             default=False,
             help='Revoke access to this application'),
     ]
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoAccountCommand.option_list + tuple(LOCAL_OPTIONS)
 
-    def handle(self, *args, **options):
+    def handle_no_command(self, *args, **options):
         options = options.copy()
         for opt in self.LOCAL_OPTIONS:
             if options.get(opt.dest) is None:
@@ -41,7 +37,6 @@ class Command(BaseGoCommand):
         self.handle_validated(*args, **options)
 
     def handle_validated(self, *args, **options):
-        email_address = options['email-address']
         application_module = unicode(options['application-module'])
         enable = options['enable']
         disable = options['disable']
@@ -50,8 +45,7 @@ class Command(BaseGoCommand):
             raise CommandError(
                 'Please specify either --enable or --disable.')
 
-        user = get_user_by_email(email_address)
-        account = user.get_profile().get_user_account()
+        account = self.user.get_profile().get_user_account()
         all_permissions = []
         for permissions in account.applications.load_all_bunches():
             all_permissions.extend(permissions)
@@ -67,7 +61,7 @@ class Command(BaseGoCommand):
 
         if enable:
             if application_module not in existing_applications:
-                self.enable_application(user, account, application_module)
+                self.enable_application(account, application_module)
             else:
                 raise CommandError('User already has this permission')
 
@@ -75,9 +69,8 @@ class Command(BaseGoCommand):
         account.applications.remove(app_permission)
         account.save()
 
-    def enable_application(self, user, account, application_module):
-        user_api = vumi_api_for_user(user)
-        api = user_api.api
+    def enable_application(self, account, application_module):
+        api = self.user_api.api
 
         app_permission = api.account_store.application_permissions(
             uuid.uuid4().hex, application=application_module)

--- a/go/base/management/commands/go_manage_application.py
+++ b/go/base/management/commands/go_manage_application.py
@@ -8,7 +8,7 @@ class Command(BaseGoAccountCommand):
     help = "Give a Vumi Go user access to a certain application"
 
     LOCAL_OPTIONS = [
-        make_option('--application_module',
+        make_option('--application-module',
             dest='application_module',
             help='The application module to give access to'),
         make_option('--enable',

--- a/go/base/management/commands/go_manage_contact_group.py
+++ b/go/base/management/commands/go_manage_contact_group.py
@@ -1,12 +1,9 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Manage contact groups belonging to a Vumi Go account."
 
     LOCAL_OPTIONS = [
@@ -40,7 +37,7 @@ class Command(BaseCommand):
             default=False,
             help='Delete a group'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def ask_for_option(self, options, opt):
         if options.get(opt.dest) is None:
@@ -71,8 +68,7 @@ class Command(BaseCommand):
             options, ('list', 'create', 'create-smart', 'delete'))
 
         self.ask_for_options(options, ['email-address'])
-        user = get_user_by_email(options['email-address'])
-        user_api = vumi_api_for_user(user)
+        user, user_api = self.mk_user_api(options['email-address'])
 
         if operation == 'list':
             return self.handle_list(user_api, options)

--- a/go/base/management/commands/go_manage_contact_group.py
+++ b/go/base/management/commands/go_manage_contact_group.py
@@ -1,43 +1,29 @@
 from optparse import make_option
 
-from go.base.command_utils import BaseGoCommand, CommandError
+from go.base.command_utils import (
+    BaseGoAccountCommand, CommandError, make_command_option)
 
 
-class Command(BaseGoCommand):
+class Command(BaseGoAccountCommand):
     help = "Manage contact groups belonging to a Vumi Go account."
 
     LOCAL_OPTIONS = [
-        make_option('--email-address',
-            dest='email-address',
-            help='Email address for the Vumi Go user'),
         make_option('--group',
             dest='group',
             help='The contact group to operate on'),
         make_option('--query',
             dest='query',
             help='The query for a newly-created smart group'),
-        make_option('--list',
-            dest='list',
-            action='store_true',
-            default=False,
+        make_command_option('list',
             help='List groups'),
-        make_option('--create',
-            dest='create',
-            action='store_true',
-            default=False,
+        make_command_option('create',
             help='Create a new group'),
-        make_option('--create-smart',
-            dest='create-smart',
-            action='store_true',
-            default=False,
+        make_command_option('create_smart',
             help='Create a new smart group'),
-        make_option('--delete',
-            dest='delete',
-            action='store_true',
-            default=False,
+        make_command_option('delete',
             help='Delete a group'),
     ]
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoAccountCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def ask_for_option(self, options, opt):
         if options.get(opt.dest) is None:
@@ -52,62 +38,36 @@ class Command(BaseGoCommand):
             if opt.dest in opt_dests:
                 self.ask_for_option(options, opt)
 
-    def get_operation(self, options, operations):
-        chosen_operations = [op for op in operations if options[op]]
-        if len(chosen_operations) != 1:
-            # Assume we have more than one possible operation.
-            opts = ['--%s' for op in operations]
-            opts[-1] = 'or %s' % (opts[-1],)
-            raise CommandError(
-                "Please provide either %s." % (', '.join(opts),))
-        return chosen_operations[0]
-
-    def handle(self, *args, **options):
-        options = options.copy()
-        operation = self.get_operation(
-            options, ('list', 'create', 'create-smart', 'delete'))
-
-        self.ask_for_options(options, ['email-address'])
-        user, user_api = self.mk_user_api(options['email-address'])
-
-        if operation == 'list':
-            return self.handle_list(user_api, options)
-        elif operation == 'create':
-            self.ask_for_options(options, ['group'])
-            return self.handle_create(user_api, options)
-        elif operation == 'create-smart':
-            self.ask_for_options(options, ['group', 'query'])
-            return self.handle_create_smart(user_api, options)
-        elif operation == 'delete':
-            self.ask_for_options(options, ['group'])
-            return self.handle_delete(user_api, options)
-
     def format_group(self, group):
         return '%s [%s] %s"%s"' % (
             group.key, group.created_at.strftime("%Y-%m-%d %H:%M"),
             '(smart) ' if group.is_smart_group() else '', group.name)
 
-    def handle_list(self, user_api, options):
-        groups = user_api.list_groups()
+    def handle_command_list(self, *args, **options):
+        groups = self.user_api.list_groups()
         if groups:
             for group in sorted(groups, key=lambda g: g.created_at):
                 self.stdout.write(" * %s\n" % (self.format_group(group),))
         else:
             self.stdout.write("No contact groups found.\n")
 
-    def handle_create(self, user_api, options):
-        group = user_api.contact_store.new_group(
+    def handle_command_create(self, *args, **options):
+        self.ask_for_options(options, ['group'])
+
+        group = self.user_api.contact_store.new_group(
             options['group'].decode('utf-8'))
         self.stdout.write(
             "Group created:\n * %s\n" % (self.format_group(group),))
 
-    def handle_create_smart(self, user_api, options):
-        group = user_api.contact_store.new_smart_group(
+    def handle_command_create_smart(self, *args, **options):
+        self.ask_for_options(options, ['group', 'query'])
+
+        group = self.user_api.contact_store.new_smart_group(
             options['group'].decode('utf-8'), options['query'].decode('utf-8'))
         self.stdout.write(
             "Group created:\n * %s\n" % (self.format_group(group),))
 
-    def handle_delete(self, user_api, options):
+    def handle_command_delete(self, *args, **options):
         # NOTE: Copied from go.conversation.tasks and expanded.
         #
         # NOTE: There is a small chance that this can break when running in
@@ -116,7 +76,9 @@ class Command(BaseGoCommand):
         #       the group, new contacts could have been added before the group
         #       has been deleted. If this happens those contacts will have
         #       secondary indexes in Riak pointing to a non-existent Group.
-        group = user_api.contact_store.get_group(options['group'])
+        self.ask_for_options(options, ['group'])
+
+        group = self.user_api.contact_store.get_group(options['group'])
         if group is None:
             raise CommandError(
                 "Group '%s' not found. Please use the group key (UUID)." % (
@@ -129,7 +91,7 @@ class Command(BaseGoCommand):
         contacts_page = group.backlinks.contact_keys()
         while contacts_page is not None:
             for contact_key in contacts_page:
-                contact = user_api.contact_store.get_contact_by_key(
+                contact = self.user_api.contact_store.get_contact_by_key(
                     contact_key)
                 contact.groups.remove(group)
                 contact.save()

--- a/go/base/management/commands/go_manage_http_api.py
+++ b/go/base/management/commands/go_manage_http_api.py
@@ -1,16 +1,13 @@
 from uuid import uuid4
 from optparse import make_option
 
-from go.base.command_utils import BaseGoCommand, CommandError
+from go.base.command_utils import BaseGoAccountCommand, CommandError
 
 
-class Command(BaseGoCommand):
+class Command(BaseGoAccountCommand):
     help = "manage access to an HTTP api"
 
     LOCAL_OPTIONS = [
-        make_option('--email-address',
-                    dest='email_address',
-                    help='Email address for the Vumi Go user'),
         make_option('--conversation-key',
                     dest='conversation_key',
                     help='The conversation key'),
@@ -35,12 +32,11 @@ class Command(BaseGoCommand):
                     dest='remove_event_url',
                     help='Remove an event URL'),
     ]
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoAccountCommand.option_list + tuple(LOCAL_OPTIONS)
     allowed_conversation_types = ['http_api', 'jsbox']
 
-    def handle(self, *args, **options):
-        user, user_api = self.mk_user_api(options['email_address'])
-        conversation = user_api.get_wrapped_conversation(
+    def handle_no_command(self, *args, **options):
+        conversation = self.user_api.get_wrapped_conversation(
             options['conversation_key'])
 
         if conversation is None:

--- a/go/base/management/commands/go_manage_http_api.py
+++ b/go/base/management/commands/go_manage_http_api.py
@@ -1,13 +1,10 @@
 from uuid import uuid4
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "manage access to an HTTP api"
 
     LOCAL_OPTIONS = [
@@ -38,12 +35,11 @@ class Command(BaseCommand):
                     dest='remove_event_url',
                     help='Remove an event URL'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
     allowed_conversation_types = ['http_api', 'jsbox']
 
     def handle(self, *args, **options):
-        user = get_user_by_email(options['email_address'])
-        user_api = vumi_api_for_user(user)
+        user, user_api = self.mk_user_api(options['email_address'])
         conversation = user_api.get_wrapped_conversation(
             options['conversation_key'])
 

--- a/go/base/management/commands/go_manage_message_cache.py
+++ b/go/base/management/commands/go_manage_message_cache.py
@@ -110,6 +110,6 @@ class Command(BaseGoCommand):
 
     def handle_command_rebuild(self, *args, **options):
         def rebuild(batch_id):
-            self.mk_vumi_api().mdb.reconcile_cache(batch_id)
+            self.vumi_api.mdb.reconcile_cache(batch_id)
 
         self._apply_command(rebuild)

--- a/go/base/management/commands/go_manage_routing_table.py
+++ b/go/base/management/commands/go_manage_routing_table.py
@@ -1,13 +1,10 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError
 from go.vumitools.routing_table import GoConnector, RoutingTable
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Manage the routing table for a Vumi Go user"
 
     LOCAL_OPTIONS = [
@@ -37,7 +34,7 @@ class Command(BaseCommand):
             help='Remove the routing table entry with four params: '
                     'src_conn src_endpoint dest_conn dest_endpoint'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     CONFLICTING_OPTIONS = ['show', 'clear', 'add', 'remove']
 
@@ -56,8 +53,7 @@ class Command(BaseCommand):
             raise CommandError('Please provide exactly one of: %s' % (
                 ['--%s' % c for c in self.CONFLICTING_OPTIONS],))
 
-        user = get_user_by_email(options['email-address'])
-        user_api = vumi_api_for_user(user)
+        user, user_api = self.mk_user_api(options['email-address'])
 
         if options['show']:
             return self.handle_show(user_api, options)

--- a/go/base/management/commands/go_manage_routing_table.py
+++ b/go/base/management/commands/go_manage_routing_table.py
@@ -7,7 +7,7 @@ from go.vumitools.routing_table import GoConnector, RoutingTable
 class Command(BaseGoAccountCommand):
     help = "Manage the routing table for a Vumi Go user"
 
-    LOCAL_OPTIONS = [
+    COMMAND_OPTIONS = [
         make_option('--show',
             dest='show',
             action='store_true',
@@ -31,7 +31,11 @@ class Command(BaseGoAccountCommand):
             help='Remove the routing table entry with four params: '
                     'src_conn src_endpoint dest_conn dest_endpoint'),
     ]
-    option_list = BaseGoAccountCommand.option_list + tuple(LOCAL_OPTIONS)
+    LOCAL_OPTIONS = []
+    option_list = (
+        BaseGoAccountCommand.option_list +
+        tuple(COMMAND_OPTIONS) +
+        tuple(LOCAL_OPTIONS))
 
     def handle_no_command(self, *args, **options):
         options = options.copy()
@@ -43,11 +47,11 @@ class Command(BaseGoAccountCommand):
                 else:
                     raise CommandError('Please provide %s:' % (opt.dest,))
 
-        # Ensure a single option is chosen from the local options
-        cmd_options = [c.dest for c in self.LOCAL_OPTIONS if options[c.dest]]
+        # Ensure a single option is chosen from the command options
+        cmd_options = [c.dest for c in self.COMMAND_OPTIONS if options[c.dest]]
         if len(cmd_options) != 1:
             raise CommandError('Please provide exactly one of: %s' % (
-                ['--%s' % c.dest for c in self.LOCAL_OPTIONS],))
+                ['--%s' % c.dest for c in self.COMMAND_OPTIONS],))
 
         if options['show']:
             return self.handle_show(options)

--- a/go/base/management/commands/go_migrate_conversations.py
+++ b/go/base/management/commands/go_migrate_conversations.py
@@ -1,13 +1,12 @@
 from optparse import make_option
 import textwrap
 
-from django.core.management.base import BaseCommand
 from django.db.models import Q
 
 from vumi.persist.model import ModelMigrationError
 
 from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_users
+from go.base.command_utils import BaseGoCommand, get_users
 
 
 class Migration(object):
@@ -174,7 +173,7 @@ class FixJsboxEndpoint(Migration):
         conv.save()
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = """
     Find and migrate conversations for known accounts in Vumi Go.
     Allows for optional searching on the email.
@@ -200,7 +199,7 @@ class Command(BaseCommand):
 
     args = "[optional username regex]"
     encoding = 'utf-8'
-    option_list = BaseCommand.option_list + (
+    option_list = BaseGoCommand.option_list + (
         make_option('-l', '--list', action='store_true',
                     dest='list_migrations',
                     default=False, help='List available migrations.'),

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -1,8 +1,7 @@
-from django.core.management.base import BaseCommand, CommandError
-
 from go.vumitools.api import VumiApiCommand
 from go.base.utils import vumi_api_for_user
-from go.base.command_utils import BaseGoCommand, get_user_by_account_key
+from go.base.command_utils import (
+    BaseGoCommand, CommandError, get_user_by_account_key)
 
 
 class Command(BaseGoCommand):

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -9,7 +9,7 @@ class Command(BaseGoCommand):
     help = "Send a VumiApi command to an application worker"
     args = "<worker-name> <command> key1=value1 key2=value2"
 
-    def handle(self, worker_name, command, *parameters, **config):
+    def handle_no_command(self, worker_name, command, *parameters, **config):
         handler = getattr(self, 'handle_%s' % (command,), None)
         if handler is None:
             raise CommandError('Unknown command %s' % (command,))
@@ -24,7 +24,7 @@ class Command(BaseGoCommand):
                 args.append(parameter)
 
         cmd = handler(worker_name, command, *args, **kwargs)
-        self.mk_vumi_api().mapi.send_command(cmd)
+        self.vumi_api.mapi.send_command(cmd)
 
     def handle_reconcile_cache(self, worker_name, command, account_key,
                                conversation_key):

--- a/go/base/management/commands/go_send_app_worker_command.py
+++ b/go/base/management/commands/go_send_app_worker_command.py
@@ -1,11 +1,11 @@
 from django.core.management.base import BaseCommand, CommandError
 
 from go.vumitools.api import VumiApiCommand
-from go.base.utils import vumi_api, vumi_api_for_user
-from go.base.command_utils import get_user_by_account_key
+from go.base.utils import vumi_api_for_user
+from go.base.command_utils import BaseGoCommand, get_user_by_account_key
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Send a VumiApi command to an application worker"
     args = "<worker-name> <command> key1=value1 key2=value2"
 
@@ -24,7 +24,7 @@ class Command(BaseCommand):
                 args.append(parameter)
 
         cmd = handler(worker_name, command, *args, **kwargs)
-        vumi_api().mapi.send_command(cmd)
+        self.mk_vumi_api().mapi.send_command(cmd)
 
     def handle_reconcile_cache(self, worker_name, command, account_key,
                                conversation_key):

--- a/go/base/management/commands/go_start_conversation.py
+++ b/go/base/management/commands/go_start_conversation.py
@@ -1,12 +1,9 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError
-
-from go.base.utils import vumi_api_for_user
-from go.base.command_utils import get_user_by_email
+from go.base.command_utils import BaseGoCommand, CommandError
 
 
-class Command(BaseCommand):
+class Command(BaseGoCommand):
     help = "Tell a conversation to start"
 
     LOCAL_OPTIONS = [
@@ -18,10 +15,7 @@ class Command(BaseCommand):
             default=False,
             help='The account to start a conversation for.'),
     ]
-    option_list = BaseCommand.option_list + tuple(LOCAL_OPTIONS)
-
-    def get_user_api(self, email):
-        return vumi_api_for_user(get_user_by_email(email))
+    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
 
     def handle(self, *apps, **options):
         email_address = options['email_address']
@@ -32,7 +26,7 @@ class Command(BaseCommand):
         if not conversation_key:
             raise CommandError('Please provide --conversation-key.')
 
-        user_api = self.get_user_api(email_address)
+        _, user_api = self.mk_user_api(email_address)
         conversation = user_api.get_wrapped_conversation(conversation_key)
         if conversation is None:
             raise CommandError('Conversation does not exist.')

--- a/go/base/management/commands/go_start_conversation.py
+++ b/go/base/management/commands/go_start_conversation.py
@@ -1,42 +1,33 @@
 from optparse import make_option
 
-from go.base.command_utils import BaseGoCommand, CommandError
+from go.base.command_utils import BaseGoAccountCommand, CommandError
 
 
-class Command(BaseGoCommand):
+class Command(BaseGoAccountCommand):
     help = "Tell a conversation to start"
 
     LOCAL_OPTIONS = [
         make_option('--conversation-key',
             dest='conversation_key',
             help='What conversation to load'),
-        make_option('--email-address',
-            dest='email_address',
-            default=False,
-            help='The account to start a conversation for.'),
     ]
-    option_list = BaseGoCommand.option_list + tuple(LOCAL_OPTIONS)
+    option_list = BaseGoAccountCommand.option_list + tuple(LOCAL_OPTIONS)
 
-    def handle(self, *apps, **options):
-        email_address = options['email_address']
-        if not email_address:
-            raise CommandError('Please provide --email-address.')
-
+    def handle_no_command(self, *apps, **options):
         conversation_key = options['conversation_key']
         if not conversation_key:
             raise CommandError('Please provide --conversation-key.')
 
-        _, user_api = self.mk_user_api(email_address)
-        conversation = user_api.get_wrapped_conversation(conversation_key)
+        conversation = self.user_api.get_wrapped_conversation(conversation_key)
         if conversation is None:
             raise CommandError('Conversation does not exist.')
 
         handler = getattr(self, 'start_%s' %
             (conversation.conversation_type,),
             self.default_start_conversation)
-        handler(user_api, conversation)
+        handler(conversation)
 
-    def default_start_conversation(self, user_api, conversation):
+    def default_start_conversation(self, conversation):
         if conversation.archived() or conversation.running():
             raise CommandError('Conversation already started.')
 

--- a/go/base/tests/test_command_utils.py
+++ b/go/base/tests/test_command_utils.py
@@ -28,6 +28,9 @@ class TestBaseGoAccountCommand(GoAccountCommandTestCase):
         self.assertRaisesRegexp(
             CommandError, '--email-address must be specified',
             self.command.handle)
+        self.assertRaisesRegexp(
+            CommandError, '--email-address must be specified',
+            self.command.handle, email_address=None)
 
     def test_user_account_must_exist(self):
         self.assertRaisesRegexp(

--- a/go/base/tests/test_go_assign_tagpool.py
+++ b/go/base/tests/test_go_assign_tagpool.py
@@ -21,7 +21,7 @@ class TestGoAssignTagpoolCommand(GoDjangoTestCase):
         self.command.handle(**{
             "email_address": self.user_helper.get_django_user().email,
             "tagpool": tagpool,
-            "max-keys": max_keys,
+            "max_keys": max_keys,
             "update": update
         })
         output = self.command.stdout.getvalue().strip().split('\n')

--- a/go/base/tests/test_go_assign_tagpool.py
+++ b/go/base/tests/test_go_assign_tagpool.py
@@ -22,7 +22,7 @@ class TestGoAssignTagpoolCommand(GoDjangoTestCase):
             "email_address": self.user_helper.get_django_user().email,
             "tagpool": tagpool,
             "max_keys": max_keys,
-            "update": update
+            "update": update,
         })
         output = self.command.stdout.getvalue().strip().split('\n')
         return output

--- a/go/base/tests/test_go_assign_tagpool.py
+++ b/go/base/tests/test_go_assign_tagpool.py
@@ -19,7 +19,7 @@ class TestGoAssignTagpoolCommand(GoDjangoTestCase):
 
     def handle_command(self, tagpool=None, max_keys=None, update=False):
         self.command.handle(**{
-            "email-address": self.user_helper.get_django_user().email,
+            "email_address": self.user_helper.get_django_user().email,
             "tagpool": tagpool,
             "max-keys": max_keys,
             "update": update

--- a/go/base/tests/test_go_import_contacts.py
+++ b/go/base/tests/test_go_import_contacts.py
@@ -21,7 +21,7 @@ class TestGoImportContactsCommand(GoDjangoTestCase):
 
     def invoke_command(self, **kw):
         options = {
-            'email-address': self.user_helper.get_django_user().email,
+            'email_address': self.user_helper.get_django_user().email,
             'contacts-csv': os.path.join(
                 settings.PROJECT_ROOT, 'base', 'fixtures',
                 'sample-contacts-with-headers.csv'),

--- a/go/base/tests/test_go_import_contacts.py
+++ b/go/base/tests/test_go_import_contacts.py
@@ -22,7 +22,7 @@ class TestGoImportContactsCommand(GoDjangoTestCase):
     def invoke_command(self, **kw):
         options = {
             'email_address': self.user_helper.get_django_user().email,
-            'contacts-csv': os.path.join(
+            'contacts_csv': os.path.join(
                 settings.PROJECT_ROOT, 'base', 'fixtures',
                 'sample-contacts-with-headers.csv'),
             'groups': [],

--- a/go/base/tests/test_go_manage_applications.py
+++ b/go/base/tests/test_go_manage_applications.py
@@ -22,8 +22,8 @@ class TestGoManageApplicationCommand(GoDjangoTestCase):
         return self.profile.get_user_account()
 
     def set_permissions(self, application, enabled):
-        self.command.handle_validated(**{
-            'email-address': self.user_helper.get_django_user().email,
+        self.command.handle(**{
+            'email_address': self.user_helper.get_django_user().email,
             'application-module': application,
             'enable': enabled,
             'disable': not enabled,

--- a/go/base/tests/test_go_manage_applications.py
+++ b/go/base/tests/test_go_manage_applications.py
@@ -24,7 +24,7 @@ class TestGoManageApplicationCommand(GoDjangoTestCase):
     def set_permissions(self, application, enabled):
         self.command.handle(**{
             'email_address': self.user_helper.get_django_user().email,
-            'application-module': application,
+            'application_module': application,
             'enable': enabled,
             'disable': not enabled,
         })

--- a/go/base/tests/test_go_manage_contact_group.py
+++ b/go/base/tests/test_go_manage_contact_group.py
@@ -14,13 +14,9 @@ class TestGoManageContactGroupCommand(GoDjangoTestCase):
 
     def invoke_command(self, command, **kw):
         options = {
-            'email-address': self.user_helper.get_django_user().email,
-            'list': False,
-            'create': False,
-            'create-smart': False,
-            'delete': False,
+            'email_address': self.user_helper.get_django_user().email,
+            'command': [command]
         }
-        options[command] = True
         options.update(kw)
         self.command.stdout = StringIO()
         self.command.handle(**options)
@@ -57,7 +53,7 @@ class TestGoManageContactGroupCommand(GoDjangoTestCase):
     def test_create_smart_group(self):
         self.assertEqual([], self.user_helper.user_api.list_groups())
         output = self.invoke_command(
-            'create-smart', group='smart group', query='foo')
+            'create_smart', group='smart group', query='foo')
         [group] = self.user_helper.user_api.list_groups()
         self.assertEqual(group.name, u'smart group')
         self.assertEqual(group.query, u'foo')

--- a/go/base/tests/test_go_manage_contact_group.py
+++ b/go/base/tests/test_go_manage_contact_group.py
@@ -15,7 +15,7 @@ class TestGoManageContactGroupCommand(GoDjangoTestCase):
     def invoke_command(self, command, **kw):
         options = {
             'email_address': self.user_helper.get_django_user().email,
-            'command': [command]
+            'command': [command],
         }
         options.update(kw)
         self.command.stdout = StringIO()

--- a/go/base/tests/test_go_manage_routing_table.py
+++ b/go/base/tests/test_go_manage_routing_table.py
@@ -24,7 +24,7 @@ class TestGoManageRoutingTableCommand(GoDjangoTestCase):
 
     def handle_command(self, **options):
         user_email = self.user_helper.get_django_user().email
-        options.setdefault('email-address', user_email)
+        options.setdefault('email_address', user_email)
         options.setdefault('show', False)
         options.setdefault('clear', False)
         options.setdefault('add', ())

--- a/go/base/tests/test_go_start_conversation.py
+++ b/go/base/tests/test_go_start_conversation.py
@@ -18,8 +18,6 @@ class TestGoStartConversation(GoDjangoTestCase):
         self.command.stderr = StringIO()
 
     def test_sanity_checks(self):
-        self.assertRaisesRegexp(CommandError, 'provide --email-address',
-            self.command.handle, email_address=None, conversation_key=None)
         self.assertRaisesRegexp(CommandError, 'provide --conversation-key',
             self.command.handle, email_address=self.user_email,
             conversation_key=None)

--- a/go/base/tests/test_go_start_conversation.py
+++ b/go/base/tests/test_go_start_conversation.py
@@ -18,6 +18,9 @@ class TestGoStartConversation(GoDjangoTestCase):
         self.command.stderr = StringIO()
 
     def test_sanity_checks(self):
+        self.assertRaisesRegexp(CommandError,
+            '--email-address must be specified', self.command.handle,
+            email_address=None, conversation_key=None)
         self.assertRaisesRegexp(CommandError, 'provide --conversation-key',
             self.command.handle, email_address=self.user_email,
             conversation_key=None)


### PR DESCRIPTION
We have some base classes that a few of our management commands use. The others (with a couple of exceptions, probably) should be rewritten to use these.
