### PR TITLE
Improve Transaction Archive admin view.

### DIFF
--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -149,6 +149,15 @@ class TransactionAdmin(admin.ModelAdmin):
         return False
 
 
+class TransactionArchiveAdmin(admin.ModelAdmin):
+    list_display = ('account', 'from_date', 'to_date', 'status', 'created')
+    search_fields = (
+        'account__account_number', 'account__user__email',
+        'from_date', 'to_date', 'status', 'created',
+    )
+    list_filter = ('account', 'status')
+
+
 class LineItemInline(admin.TabularInline):
     model = LineItem
 
@@ -187,6 +196,6 @@ admin.site.register(TagPool, TagPoolAdmin)
 admin.site.register(Account, AccountAdmin)
 admin.site.register(MessageCost, MessageCostAdmin)
 admin.site.register(Transaction, TransactionAdmin)
+admin.site.register(TransactionArchive, TransactionArchiveAdmin)
 admin.site.register(Statement, StatementAdmin)
 admin.site.register(LowCreditNotification)
-admin.site.register(TransactionArchive)

--- a/go/billing/tests/helpers.py
+++ b/go/billing/tests/helpers.py
@@ -110,9 +110,9 @@ def mk_transaction(account, tag_pool_name='pool1',
 def mk_transaction_archive(account, from_date=None, to_date=None,
                            status=TransactionArchive.STATUS_ARCHIVE_CREATED):
     if from_date is None:
-        from_date = datetime.now()
+        from_date = date.today()
     if to_date is None:
-        to_date = datetime.now()
+        to_date = date.today()
     archive = TransactionArchive(
         account=account, from_date=from_date, to_date=to_date, status=status)
     archive.save()

--- a/go/billing/tests/helpers.py
+++ b/go/billing/tests/helpers.py
@@ -1,12 +1,13 @@
 """ Helpers for billing tests. """
 
-from datetime import date
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 
 from go.billing import settings
 from go.billing.models import (
-    TagPool, Account, MessageCost, Transaction, Statement, LineItem)
+    TagPool, Account, MessageCost, Transaction, TransactionArchive,
+    Statement, LineItem)
 
 
 def start_of_month(day=None):
@@ -104,6 +105,18 @@ def mk_transaction(account, tag_pool_name='pool1',
         transaction.created = created
         transaction.save()
     return transaction
+
+
+def mk_transaction_archive(account, from_date=None, to_date=None,
+                           status=TransactionArchive.STATUS_ARCHIVE_CREATED):
+    if from_date is None:
+        from_date = datetime.now()
+    if to_date is None:
+        to_date = datetime.now()
+    archive = TransactionArchive(
+        account=account, from_date=from_date, to_date=to_date, status=status)
+    archive.save()
+    return archive
 
 
 def mk_statement(account,

--- a/go/billing/tests/test_admin.py
+++ b/go/billing/tests/test_admin.py
@@ -5,10 +5,10 @@ from django.core.urlresolvers import reverse
 
 from go.base.utils import vumi_api_for_user
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
-from go.billing.models import Account, Transaction
+from go.billing.models import Account, Transaction, TransactionArchive
 from go.billing.admin import AccountAdmin
 
-from .helpers import mk_statement, mk_transaction
+from .helpers import mk_statement, mk_transaction, mk_transaction_archive
 
 
 class MockRequest(object):
@@ -71,6 +71,39 @@ class TestStatementAdmin(GoDjangoTestCase):
         self.assertContains(response, "Credits")
         self.assertContains(response, "Unit cost")
         self.assertContains(response, "Cost")
+
+    def test_transaction_archive_admin_view(self):
+        mk_transaction_archive(self.account)
+        client = self.vumi_helper.get_client()
+        client.login()
+        response = client.get(
+            reverse('admin:billing_transactionarchive_changelist'))
+        self.assertContains(response, "Transaction archives")
+        self.assertContains(response, "Account")
+        self.assertContains(response, "From date")
+        self.assertContains(response, "To date")
+        self.assertContains(response, "Status")
+        self.assertContains(response, "Created")
+
+    def test_transaction_archive_search(self):
+        archive1 = mk_transaction_archive(
+            self.account,
+            status=TransactionArchive.STATUS_ARCHIVE_CREATED)
+        archive2 = mk_transaction_archive(
+            self.account,
+            status=TransactionArchive.STATUS_ARCHIVE_COMPLETED)
+        client = self.vumi_helper.get_client()
+        client.login()
+        response = client.get(
+            reverse('admin:billing_transactionarchive_changelist'),
+            {'q': 'completed'})
+        self.assertContains(response, "1 result")
+        self.assertContains(
+            response,
+            '<a href="/admin/billing/transactionarchive/%d/">' % archive2.pk)
+        self.assertNotContains(
+            response,
+            '<a href="/admin/billing/transactionarchive/%d/">' % archive1.pk)
 
     def test_account_admin_view(self):
         client = self.vumi_helper.get_client()

--- a/go/billing/tests/test_helpers.py
+++ b/go/billing/tests/test_helpers.py
@@ -3,10 +3,12 @@ from datetime import date
 
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
 from go.billing.models import (
-    Account, TagPool, MessageCost, Transaction, Statement, LineItem)
+    Account, TagPool, MessageCost, Transaction, TransactionArchive,
+    Statement, LineItem)
 from go.billing.tests.helpers import (
     start_of_month, end_of_month, this_month, maybe_decimal,
-    get_billing_account, mk_tagpool, mk_message_cost, mk_transaction,
+    get_billing_account, mk_tagpool, mk_message_cost,
+    mk_transaction, mk_transaction_archive,
     mk_statement, get_session_length_cost,
     get_message_credits, get_session_credits,
     get_storage_credits, get_session_length_credits, get_line_items)
@@ -139,6 +141,21 @@ class TestHelpers(GoDjangoTestCase):
             status=Transaction.STATUS_COMPLETED)
 
         self.assertEqual(transaction, found_transaction)
+
+    def test_mk_transaction_archive(self):
+        archive = mk_transaction_archive(
+            account=self.account,
+            from_date=date(2015, 3, 21),
+            to_date=date(2015, 3, 22),
+            status=TransactionArchive.STATUS_ARCHIVE_COMPLETED)
+
+        [found_archive] = TransactionArchive.objects.filter(
+            account=self.account,
+            from_date=date(2015, 3, 21),
+            to_date=date(2015, 3, 22),
+            status=TransactionArchive.STATUS_ARCHIVE_COMPLETED)
+
+        self.assertEqual(archive, found_archive)
 
     def test_mk_statement(self):
         statement = mk_statement(


### PR DESCRIPTION
Currently the transaction archive list shows only the names of the archives which isn't very useful. We need to be able to see more of the details and be able to filter by status and account.
