### PR TITLE
Allow filtering by account in billing admin interfaces

### DIFF
--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -112,11 +112,13 @@ class AccountAdmin(admin.ModelAdmin):
 
 
 class MessageCostAdmin(admin.ModelAdmin):
-    list_display = ('id', 'account', 'tag_pool', 'message_direction',
-                    'message_cost', 'storage_cost', 'session_cost',
-                    'session_unit_cost', 'session_unit_time', 'markup_percent',
-                    'message_credit_cost', 'storage_credit_cost',
-                    'session_credit_cost', 'session_length_credit_cost')
+    list_display = (
+        'id', 'account', 'provider', 'tag_pool', 'message_direction',
+        'message_cost', 'storage_cost', 'session_cost',
+        'session_unit_cost', 'session_unit_time', 'markup_percent',
+        'message_credit_cost', 'storage_credit_cost',
+        'session_credit_cost', 'session_length_credit_cost',
+    )
 
     search_fields = (
         'tag_pool__name', 'tag_pool__description', 'account__account_number',

--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -121,7 +121,7 @@ class MessageCostAdmin(admin.ModelAdmin):
     search_fields = (
         'tag_pool__name', 'tag_pool__description', 'account__account_number',
         'account__user__email', 'account__description')
-    list_filter = ('tag_pool', 'message_direction')
+    list_filter = ('account', 'tag_pool', 'message_direction')
     form = MessageCostForm
 
 
@@ -182,6 +182,8 @@ class StatementAdmin(admin.ModelAdmin):
         'view_html',
     )
 
+    list_filter = ('account',)
+
     readonly_fields = (
         'account', 'title', 'type', 'from_date', 'to_date', 'created',
     )
@@ -192,10 +194,14 @@ class StatementAdmin(admin.ModelAdmin):
     view_html.short_description = "HTML"
 
 
+class LowCreditNotificationAdmin(admin.ModelAdmin):
+    list_filter = ('account',)
+
+
 admin.site.register(TagPool, TagPoolAdmin)
 admin.site.register(Account, AccountAdmin)
 admin.site.register(MessageCost, MessageCostAdmin)
 admin.site.register(Transaction, TransactionAdmin)
 admin.site.register(TransactionArchive, TransactionArchiveAdmin)
 admin.site.register(Statement, StatementAdmin)
-admin.site.register(LowCreditNotification)
+admin.site.register(LowCreditNotification, LowCreditNotificationAdmin)

--- a/go/billing/admin.py
+++ b/go/billing/admin.py
@@ -195,6 +195,10 @@ class StatementAdmin(admin.ModelAdmin):
 
 
 class LowCreditNotificationAdmin(admin.ModelAdmin):
+    list_display = (
+        'account', 'created', 'success', 'threshold', 'credit_balance',
+    )
+
     list_filter = ('account',)
 
 

--- a/go/billing/tests/helpers.py
+++ b/go/billing/tests/helpers.py
@@ -1,6 +1,6 @@
 """ Helpers for billing tests. """
 
-from datetime import date, datetime
+from datetime import date
 from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 

--- a/go/billing/tests/test_admin.py
+++ b/go/billing/tests/test_admin.py
@@ -9,7 +9,8 @@ from go.billing.models import (
     Account, Transaction, TransactionArchive, LowCreditNotification)
 from go.billing.admin import AccountAdmin
 
-from .helpers import mk_statement, mk_transaction, mk_transaction_archive
+from .helpers import (
+    mk_message_cost, mk_statement, mk_transaction, mk_transaction_archive)
 
 
 class MockRequest(object):
@@ -105,6 +106,28 @@ class TestStatementAdmin(GoDjangoTestCase):
         self.assertNotContains(
             response,
             '<a href="/admin/billing/transactionarchive/%d/">' % archive1.pk)
+
+    def test_message_cost_admin_view(self):
+        mk_message_cost()
+        client = self.vumi_helper.get_client()
+        client.login()
+        response = client.get(
+            reverse('admin:billing_messagecost_changelist'))
+        self.assertContains(response, "Message costs")
+        self.assertContains(response, "Account")
+        self.assertContains(response, "Provider")
+        self.assertContains(response, "Tag pool")
+        self.assertContains(response, "Message direction")
+        self.assertContains(response, "Message cost")
+        self.assertContains(response, "Storage cost")
+        self.assertContains(response, "Session cost")
+        self.assertContains(response, "Session unit cost")
+        self.assertContains(response, "Session unit time")
+        self.assertContains(response, "Markup percent")
+        self.assertContains(response, "Message credit cost")
+        self.assertContains(response, "Storage credit cost")
+        self.assertContains(response, "Session credit cost")
+        self.assertContains(response, "Session length credit cost")
 
     def test_low_credit_notification_admin_view(self):
         notification = LowCreditNotification(

--- a/go/billing/tests/test_admin.py
+++ b/go/billing/tests/test_admin.py
@@ -5,7 +5,8 @@ from django.core.urlresolvers import reverse
 
 from go.base.utils import vumi_api_for_user
 from go.base.tests.helpers import GoDjangoTestCase, DjangoVumiApiHelper
-from go.billing.models import Account, Transaction, TransactionArchive
+from go.billing.models import (
+    Account, Transaction, TransactionArchive, LowCreditNotification)
 from go.billing.admin import AccountAdmin
 
 from .helpers import mk_statement, mk_transaction, mk_transaction_archive
@@ -104,6 +105,21 @@ class TestStatementAdmin(GoDjangoTestCase):
         self.assertNotContains(
             response,
             '<a href="/admin/billing/transactionarchive/%d/">' % archive1.pk)
+
+    def test_low_credit_notification_admin_view(self):
+        notification = LowCreditNotification(
+            account=self.account, threshold=10, credit_balance=100)
+        notification.save()
+        client = self.vumi_helper.get_client()
+        client.login()
+        response = client.get(
+            reverse('admin:billing_lowcreditnotification_changelist'))
+        self.assertContains(response, "Low credit notifications")
+        self.assertContains(response, "Account")
+        self.assertContains(response, "Created")
+        self.assertContains(response, "Success")
+        self.assertContains(response, "Threshold")
+        self.assertContains(response, "Credit balance")
 
     def test_account_admin_view(self):
         client = self.vumi_helper.get_client()


### PR DESCRIPTION
The following billing admin pages should allow filtering by account:
- low credit notifications
- message costs
- statements
