### PR TITLE
Use batch_ids instead of batch_id in message store calls

### DIFF
--- a/go/apps/jsbox/tests/test_message_store.py
+++ b/go/apps/jsbox/tests/test_message_store.py
@@ -39,12 +39,12 @@ class TestMessageStoreResource(ResourceTestCaseBase):
         # store inbound
         yield self.message_store.add_inbound_message(
             self.msg_helper.make_inbound('hello'),
-            batch_id=self.conversation.batch.key)
+            batch_ids=[self.conversation.batch.key])
 
         # store outbound
         outbound_msg = self.msg_helper.make_outbound('hello')
         yield self.message_store.add_outbound_message(
-            outbound_msg, batch_id=self.conversation.batch.key)
+            outbound_msg, batch_ids=[self.conversation.batch.key])
 
         # ack outbound
         event = self.msg_helper.make_ack(outbound_msg)

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -152,7 +152,7 @@ class SequentialSendApplication(GoApplicationWorker):
     def send_message(self, batch_id, to_addr, content, msg_options):
         msg = yield self.send_to(
             to_addr, content, endpoint='default', **msg_options)
-        yield self.vumi_api.mdb.add_outbound_message(msg, batch_id=batch_id)
+        yield self.vumi_api.mdb.add_outbound_message(msg, batch_ids=[batch_id])
         log.info('Stored outbound %s' % (msg,))
 
     @inlineCallbacks

--- a/go/apps/subscription/vumi_app.py
+++ b/go/apps/subscription/vumi_app.py
@@ -19,7 +19,7 @@ class SubscriptionApplication(GoApplicationWorker):
         # TODO: Update
         msg = yield self.send_to(
             to_addr, content, endpoint='default', **msg_options)
-        yield self.vumi_api.mdb.add_outbound_message(msg, batch_id=batch_id)
+        yield self.vumi_api.mdb.add_outbound_message(msg, batch_ids=[batch_id])
         log.info('Stored outbound %s' % (msg,))
 
     def handlers_for_content(self, conv, content):

--- a/go/base/management/commands/go_migrate_conversations.py
+++ b/go/base/management/commands/go_migrate_conversations.py
@@ -104,10 +104,10 @@ class FixBatches(Migration):
     def _copy_msgs(self, mdb, old_batch, new_batch):
         for key in mdb.batch_outbound_keys(old_batch):
             msg = mdb.get_outbound_message(key)
-            mdb.add_outbound_message(msg, batch_id=new_batch)
+            mdb.add_outbound_message(msg, batch_ids=[new_batch])
         for key in mdb.batch_inbound_keys(old_batch):
             msg = mdb.get_inbound_message(key)
-            mdb.add_inbound_message(msg, batch_id=new_batch)
+            mdb.add_inbound_message(msg, batch_ids=[new_batch])
 
     def migrate(self, user_api, conv):
         conv_batches = conv.batches.keys()
@@ -136,10 +136,10 @@ class SplitBatches(Migration):
     def _copy_msgs(self, mdb, old_batch, new_batch):
         for key in mdb.batch_outbound_keys(old_batch):
             msg = mdb.get_outbound_message(key)
-            mdb.add_outbound_message(msg, batch_id=new_batch)
+            mdb.add_outbound_message(msg, batch_ids=[new_batch])
         for key in mdb.batch_inbound_keys(old_batch):
             msg = mdb.get_inbound_message(key)
-            mdb.add_inbound_message(msg, batch_id=new_batch)
+            mdb.add_inbound_message(msg, batch_ids=[new_batch])
 
     def migrate(self, user_api, conv):
         old_batch = conv.batch.key

--- a/go/base/tests/test_go_migrate_conversations.py
+++ b/go/base/tests/test_go_migrate_conversations.py
@@ -136,9 +136,9 @@ class TestGoMigrateConversationsCommand(GoDjangoTestCase):
         for i, batch_id in enumerate(batches):
             conv.batches.add_key(batch_id)
             msg1 = msg_helper.make_inbound("in", message_id=u"msg-%d" % i)
-            mdb.add_inbound_message(msg1, batch_id=batch_id)
+            mdb.add_inbound_message(msg1, batch_ids=[batch_id])
             msg2 = msg_helper.make_outbound("out", message_id=u"msg-%d" % i)
-            mdb.add_outbound_message(msg2, batch_id=batch_id)
+            mdb.add_outbound_message(msg2, batch_ids=[batch_id])
 
         conv.save()
 

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -642,13 +642,13 @@ class GoStoringMiddleware(StoringMiddleware):
     @inlineCallbacks
     def handle_inbound(self, message, connector_name):
         batch_id = yield self.get_batch_id(message)
-        yield self.store.add_inbound_message(message, batch_id=batch_id)
+        yield self.store.add_inbound_message(message, batch_ids=[batch_id])
         returnValue(message)
 
     @inlineCallbacks
     def handle_outbound(self, message, connector_name):
         batch_id = yield self.get_batch_id(message)
-        yield self.store.add_outbound_message(message, batch_id=batch_id)
+        yield self.store.add_outbound_message(message, batch_ids=[batch_id])
         returnValue(message)
 
 

--- a/go/vumitools/tests/helpers.py
+++ b/go/vumitools/tests/helpers.py
@@ -139,13 +139,13 @@ class GoMessageHelper(object):
     def store_inbound(self, conv, msg):
         if self.mdb is None:
             raise ValueError("No message store provided.")
-        return self.mdb.add_inbound_message(msg, batch_id=conv.batch.key)
+        return self.mdb.add_inbound_message(msg, batch_ids=[conv.batch.key])
 
     @proxyable
     def store_outbound(self, conv, msg):
         if self.mdb is None:
             raise ValueError("No message store provided.")
-        return self.mdb.add_outbound_message(msg, batch_id=conv.batch.key)
+        return self.mdb.add_outbound_message(msg, batch_ids=[conv.batch.key])
 
     @proxyable
     def store_event(self, event):


### PR DESCRIPTION
The current message store methods accept both `batch_id` and `batch_ids` to specify batches. The new message store only accepts `batch_ids`. Switching everything to `batch_ids` now will simplify later work when we start using the new message store.
