### PR TITLE
Expose contact meta data on Contact detail view

### DIFF
--- a/go/contacts/forms.py
+++ b/go/contacts/forms.py
@@ -19,8 +19,8 @@ class ContactForm(forms.Form):
     def __init__(self, *args, **kw):
         groups = kw.pop('groups')
         super(ContactForm, self).__init__(*args, **kw)
-        self.fields['groups'] = forms.MultipleChoiceField(required=False,
-            choices=[(g.key, g.name) for g in groups])
+        self.fields['groups'] = forms.MultipleChoiceField(
+            required=False, choices=[(g.key, g.name) for g in groups])
 
     def clean(self):
         """
@@ -43,9 +43,10 @@ class SmartGroupForm(forms.Form):
 
 
 class UploadContactsForm(forms.Form):
-    file = forms.FileField(label="File with Contact data",
+    file = forms.FileField(
+        label="File with Contact data",
         help_text="This can either be a double-quoted UTF-8 encoded CSV file "
-                    "or an Excel spreadsheet")
+                  "or an Excel spreadsheet")
 
 
 class SelectContactGroupForm(forms.Form):

--- a/go/contacts/templates/contacts/contact_detail.html
+++ b/go/contacts/templates/contacts/contact_detail.html
@@ -19,13 +19,15 @@
             <form class="form-horizontal details" method="post" action="">
                 {% csrf_token %}
                     <section class='profile'>
-                        <h4>Profile details</h4>
+                        <h4>Contact details</h4>
+                        {% if contact.created_at %}
+                          <p>Contact record created at {{ contact.created_at }}.</p>
+                        {% endif %}
                         {{ form|crispy }}
                     </section>
 
-                    <hr>
-
                     {% if contact_extra_items %}
+                      <hr>
                       <section class="extras">
                           <h4>Extra details</h4>
                           <table class="table">
@@ -37,6 +39,29 @@
                               </thead>
                               <tbody>
                                   {% for field, value in contact_extra_items %}
+                                  <tr>
+                                      <td>{{ field }}</td>
+                                      <td>{{ value }}</td>
+                                  </tr>
+                                  {% endfor %}
+                              </tbody>
+                        </table>
+                      </section>
+                    {% endif %}
+
+                    {% if contact_subscription_items %}
+                      <hr>
+                      <section class="extras">
+                          <h4>Subscriptions</h4>
+                          <table class="table">
+                              <thead>
+                                  <tr>
+                                      <th>Name</td>
+                                      <th>Position</td>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  {% for field, value in contact_subscription_items %}
                                   <tr>
                                       <td>{{ field }}</td>
                                       <td>{{ value }}</td>

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -427,7 +427,7 @@ def _people(request):
     # production hack if we really need to count all contacts or something.
     fetch_limit = int(request.GET.get('_fetch_limit', 10000))
     if query:
-        if not ':' in query:
+        if ':' not in query:
             query = 'name:%s' % (query,)
 
         # TODO: Use pagination here.
@@ -506,6 +506,7 @@ def person(request, person_key):
     return render(request, 'contacts/contact_detail.html', {
         'contact': contact,
         'contact_extra_items': contact.extra.items(),
+        'contact_subscription_items': contact.subscription.items(),
         'form': form,
     })
 


### PR DESCRIPTION
The only way to see the contact created at information at the moment is via the API, ideally it would be shown in the contact detail view
