### PR TITLE
Avoid listifying index pages

### DIFF
--- a/go/base/management/commands/go_account_stats.py
+++ b/go/base/management/commands/go_account_stats.py
@@ -95,7 +95,7 @@ class Command(BaseGoCommand):
     def _count_results(self, index_page):
         count = 0
         while index_page is not None:
-            count += len(list(index_page))
+            count += len(index_page)
             index_page = index_page.next_page()
         return count
 

--- a/go/base/tests/test_go_manage_message_cache.py
+++ b/go/base/tests/test_go_manage_message_cache.py
@@ -33,7 +33,7 @@ class TestGoManageMessageCache(GoCommandTestCase):
     def count_results(self, index_page):
         count = 0
         while index_page is not None:
-            count += len(list(index_page))
+            count += len(index_page)
             index_page = index_page.next_page()
         return count
 

--- a/go/contacts/views.py
+++ b/go/contacts/views.py
@@ -435,7 +435,7 @@ def _people(request):
     else:
         keys = contact_store.list_contacts_page(max_results=fetch_limit)
 
-    key_count = len(list(keys))
+    key_count = len(keys)
     limit = min(int(request.GET.get('limit', 100)), key_count)
     # If we have a continuation token, it means there are more than
     # `fetch_limit` keys.

--- a/go/vumitools/contact/tests/test_models.py
+++ b/go/vumitools/contact/tests/test_models.py
@@ -298,7 +298,7 @@ class TestContactStore(VumiTestCase):
             contact_keys.add(contact.key)
 
         index_page = yield store.get_static_contact_keys_for_group(group)
-        self.assertEqual(len(list(index_page)), 2)
+        self.assertEqual(len(index_page), 2)
         self.assertEqual(index_page.has_next_page(), False)
 
     @inlineCallbacks
@@ -334,7 +334,7 @@ class TestContactStore(VumiTestCase):
             contact_keys.add(contact.key)
 
         index_page = yield store.get_contact_keys_for_group(group)
-        self.assertEqual(len(list(index_page)), 2)
+        self.assertEqual(len(index_page), 2)
         self.assertEqual(index_page.has_next_page(), False)
 
     @inlineCallbacks

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email='dev@praekeltfoundation.org',
     packages=find_packages(),
     install_requires=[
-        'vumi>=0.5.20',
+        'vumi>=0.5.21',
         'vxsandbox>=0.5.0',
         'vxpolls',
         'vumi-wikipedia>=0.2.1',


### PR DESCRIPTION
Index pages now support `len()`, so we don't need `len(list())` anymore.
