### PR TITLE
Remove Django dependency from vumitools

### DIFF
--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -10,8 +10,9 @@ class ConversationDetailForm(forms.Form):
 class NewConversationForm(ConversationDetailForm):
     def __init__(self, user_api, *args, **kwargs):
         super(NewConversationForm, self).__init__(*args, **kwargs)
+        apps = [v for k, v in sorted(user_api.applications().iteritems())]
         type_choices = [(app['namespace'], app['display_name'])
-                        for app in user_api.applications().itervalues()]
+                        for app in apps]
         self.fields['conversation_type'] = forms.ChoiceField(
             label="Which kind of conversation would you like?",
             choices=type_choices)

--- a/go/conversation/forms.py
+++ b/go/conversation/forms.py
@@ -10,7 +10,7 @@ class ConversationDetailForm(forms.Form):
 class NewConversationForm(ConversationDetailForm):
     def __init__(self, user_api, *args, **kwargs):
         super(NewConversationForm, self).__init__(*args, **kwargs)
-        apps = [v for k, v in sorted(user_api.applications().iteritems())]
+        apps = (v for k, v in sorted(user_api.applications().iteritems()))
         type_choices = [(app['namespace'], app['display_name'])
                         for app in apps]
         self.fields['conversation_type'] = forms.ChoiceField(

--- a/go/conversation/views.py
+++ b/go/conversation/views.py
@@ -17,7 +17,7 @@ CONVERSATIONS_PER_PAGE = 12
 def index(request):
     # grab the fields from the GET request
     user_api = request.user_api
-    apps = [v for k, v in sorted(user_api.applications().iteritems())]
+    apps = (v for k, v in sorted(user_api.applications().iteritems()))
     conversation_types = [(app['namespace'], app['display_name'])
                           for app in apps]
     search_form = ConversationSearchForm(

--- a/go/conversation/views.py
+++ b/go/conversation/views.py
@@ -5,8 +5,7 @@ from django.shortcuts import render, redirect
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.contrib import messages
 
-from go.conversation.forms import (
-    NewConversationForm, ConversationSearchForm, ReplyToMessageForm)
+from go.conversation.forms import NewConversationForm, ConversationSearchForm
 from go.base.utils import (
     get_conversation_view_definition, conversation_or_404)
 
@@ -18,8 +17,9 @@ CONVERSATIONS_PER_PAGE = 12
 def index(request):
     # grab the fields from the GET request
     user_api = request.user_api
+    apps = [v for k, v in sorted(user_api.applications().iteritems())]
     conversation_types = [(app['namespace'], app['display_name'])
-                          for app in user_api.applications().values()]
+                          for app in apps]
     search_form = ConversationSearchForm(
         request.GET, conversation_types=conversation_types)
     search_form.is_valid()
@@ -35,7 +35,7 @@ def index(request):
     }.get(conversation_status, user_api.active_conversations)
 
     conversations = [user_api.wrap_conversation(c)
-                        for c in get_conversations()]
+                     for c in get_conversations()]
 
     if conversation_type:
         conversations = [c for c in conversations
@@ -47,7 +47,7 @@ def index(request):
 
     # sort with newest first
     conversations = sorted(conversations, key=lambda c: c.created_at,
-                            reverse=True)
+                           reverse=True)
 
     paginator = Paginator(conversations, CONVERSATIONS_PER_PAGE)
     try:

--- a/go/router/forms.py
+++ b/go/router/forms.py
@@ -8,7 +8,7 @@ class NewRouterForm(forms.Form):
 
     def __init__(self, user_api, *args, **kwargs):
         super(NewRouterForm, self).__init__(*args, **kwargs)
-        routers = [v for k, v in sorted(user_api.router_types().iteritems())]
+        routers = (v for k, v in sorted(user_api.router_types().iteritems()))
         type_choices = [(router['namespace'], router['display_name'])
                         for router in routers]
         self.fields['router_type'] = forms.ChoiceField(

--- a/go/router/forms.py
+++ b/go/router/forms.py
@@ -8,8 +8,9 @@ class NewRouterForm(forms.Form):
 
     def __init__(self, user_api, *args, **kwargs):
         super(NewRouterForm, self).__init__(*args, **kwargs)
+        routers = [v for k, v in sorted(user_api.router_types().iteritems())]
         type_choices = [(router['namespace'], router['display_name'])
-                        for router in user_api.router_types().itervalues()]
+                        for router in routers]
         self.fields['router_type'] = forms.ChoiceField(
             label="Which kind of router would you like?",
             choices=type_choices)

--- a/go/vumitools/api.py
+++ b/go/vumitools/api.py
@@ -31,8 +31,6 @@ from go.vumitools.router import RouterStore
 from go.vumitools.conversation.utils import ConversationWrapper
 from go.vumitools.token_manager import TokenManager
 
-from django.utils.datastructures import SortedDict
-
 from vumi.message import TransportUserMessage
 
 
@@ -258,17 +256,17 @@ class VumiUserApi(object):
         applications = [permission.application for permission
                         in app_permissions]
         app_settings = configured_conversations()
-        returnValue(SortedDict([(application, app_settings[application])
-                                for application in sorted(applications)
-                                if application in app_settings]))
+        returnValue(dict((application, app_settings[application])
+                         for application in applications
+                         if application in app_settings))
 
     @Manager.calls_manager
     def router_types(self):
         # TODO: Permissions.
         yield None
         router_settings = configured_routers()
-        returnValue(SortedDict([(router_type, router_settings[router_type])
-                                for router_type in sorted(router_settings)]))
+        returnValue(dict((router_type, router_settings[router_type])
+                         for router_type in router_settings))
 
     def list_groups(self):
         return self.contact_store.list_groups()


### PR DESCRIPTION
We use `django.utils.datastructures.SortedDict` in `go.vumitools.api` which pulls Django into places it shouldn't be.
