### PR TITLE
Move extract_auth_from_url to non-Django utils

### DIFF
--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -12,8 +12,8 @@ from vumi import log
 
 from go.apps.http_api_nostream.auth import AuthorizedResource
 from go.apps.http_api_nostream.resource import ConversationResource
-from go.base.utils import extract_auth_from_url
 from go.vumitools.app_worker import GoApplicationWorker
+from go.vumitools.utils import extract_auth_from_url
 
 
 # NOTE: Things in this module are subclassed and used by go.apps.http_api.

--- a/go/base/tests/test_utils.py
+++ b/go/base/tests/test_utils.py
@@ -6,12 +6,11 @@ from decimal import Decimal
 from StringIO import StringIO
 from unittest import TestCase
 
-
 from go.base.tests.helpers import GoDjangoTestCase
 import go.base.utils
 from go.base.utils import (
     get_conversation_view_definition, get_router_view_definition,
-    UnicodeDictWriter, extract_auth_from_url, sendfile, format_currency)
+    UnicodeDictWriter, sendfile, format_currency)
 from go.errors import UnknownConversationType, UnknownRouterType
 
 
@@ -118,22 +117,7 @@ class TestUnicodeDictWriter(TestCase):
             rows)
 
 
-class TestRandomUtils(GoDjangoTestCase):
-
-    def test_extract_auth_from_url_no_auth(self):
-        auth, url = extract_auth_from_url('http://go.vumi.org')
-        self.assertEqual(auth, None)
-        self.assertEqual(url, 'http://go.vumi.org')
-
-    def test_extract_auth_from_url_with_auth(self):
-        auth, url = extract_auth_from_url('http://u:p@go.vumi.org')
-        self.assertEqual(auth, ('u', 'p'))
-        self.assertEqual(url, 'http://go.vumi.org')
-
-    def test_extract_auth_from_url_with_username(self):
-        auth, url = extract_auth_from_url('http://u@go.vumi.org')
-        self.assertEqual(auth, ('u', None))
-        self.assertEqual(url, 'http://go.vumi.org')
+class TestSendfile(GoDjangoTestCase):
 
     def test_sendfile(self):
         resp = sendfile('/foo')

--- a/go/base/utils.py
+++ b/go/base/utils.py
@@ -4,7 +4,6 @@ import csv
 import codecs
 from decimal import Decimal, ROUND_DOWN
 from StringIO import StringIO
-from urlparse import urlparse, urlunparse
 
 from django.http import Http404, HttpResponse
 from django.conf import settings
@@ -212,23 +211,6 @@ def get_router_view_definition(router_type, router=None):
     if not hasattr(router_pkg, 'view_definition'):
         return RouterViewDefinitionBase(router_def)
     return router_pkg.view_definition.RouterViewDefinition(router_def)
-
-
-def extract_auth_from_url(url):
-    parse_result = urlparse(url)
-    if parse_result.username:
-        auth = (parse_result.username, parse_result.password)
-        url = urlunparse(
-            (parse_result.scheme,
-             ('%s:%s' % (parse_result.hostname, parse_result.port)
-              if parse_result.port
-              else parse_result.hostname),
-             parse_result.path,
-             parse_result.params,
-             parse_result.query,
-             parse_result.fragment))
-        return auth, url
-    return None, url
 
 
 def format_currency(

--- a/go/base/views.py
+++ b/go/base/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 
-from go.base.utils import extract_auth_from_url
+from go.vumitools.utils import extract_auth_from_url
 
 
 def todo(request):  # pragma: no cover

--- a/go/vumitools/tests/test_utils.py
+++ b/go/vumitools/tests/test_utils.py
@@ -4,8 +4,27 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.tests.helpers import VumiTestCase, MessageHelper
 
 from go.vumitools.model_object_cache import ModelObjectCache
-from go.vumitools.utils import MessageMetadataDictHelper, MessageMetadataHelper
+from go.vumitools.utils import (
+    extract_auth_from_url, MessageMetadataDictHelper, MessageMetadataHelper)
 from go.vumitools.tests.helpers import VumiApiHelper
+
+
+class TestExtractAuthFromUrl(VumiTestCase):
+
+    def test_extract_auth_from_url_no_auth(self):
+        auth, url = extract_auth_from_url('http://go.vumi.org')
+        self.assertEqual(auth, None)
+        self.assertEqual(url, 'http://go.vumi.org')
+
+    def test_extract_auth_from_url_with_auth(self):
+        auth, url = extract_auth_from_url('http://u:p@go.vumi.org')
+        self.assertEqual(auth, ('u', 'p'))
+        self.assertEqual(url, 'http://go.vumi.org')
+
+    def test_extract_auth_from_url_with_username(self):
+        auth, url = extract_auth_from_url('http://u@go.vumi.org')
+        self.assertEqual(auth, ('u', None))
+        self.assertEqual(url, 'http://go.vumi.org')
 
 
 class TestMessageMetadataDictHelper(VumiTestCase):

--- a/go/vumitools/utils.py
+++ b/go/vumitools/utils.py
@@ -1,8 +1,25 @@
 # -*- test-case-name: go.vumitools.tests.test_utils -*-
+from urlparse import urlparse, urlunparse
 
 from twisted.internet.defer import succeed
-
 from vumi.middleware.tagger import TaggingMiddleware
+
+
+def extract_auth_from_url(url):
+    parse_result = urlparse(url)
+    if parse_result.username:
+        auth = (parse_result.username, parse_result.password)
+        url = urlunparse(
+            (parse_result.scheme,
+             ('%s:%s' % (parse_result.hostname, parse_result.port)
+              if parse_result.port
+              else parse_result.hostname),
+             parse_result.path,
+             parse_result.params,
+             parse_result.query,
+             parse_result.fragment))
+        return auth, url
+    return None, url
 
 
 class MessageMetadataDictHelper(object):


### PR DESCRIPTION
This is causing HTTP API workers to import Django stuff unnecessarily.
