### PR TITLE
HTTP API workers don't catch ResponseNeverReceived errors.

### DIFF
--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -6,6 +6,7 @@ from urlparse import urlparse, urlunparse
 from twisted.internet.defer import inlineCallbacks, DeferredQueue, returnValue
 from twisted.internet.error import DNSLookupError, ConnectionRefusedError
 from twisted.web.error import SchemeNotSupported
+from twisted.web._newclient import ResponseFailed
 from twisted.web import http
 from twisted.web.server import NOT_DONE_YET
 
@@ -1190,6 +1191,16 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
         self.assertTrue(self.mock_push_server.url in dns_log)
 
     @inlineCallbacks
+    def test_post_inbound_message_response_failed_error(self):
+        yield self.start_app_worker()
+        self._patch_http_request_full(lambda: ResponseFailed(reasons=[]))
+        with LogCatcher(message='Response failed') as lc:
+            yield self.app_helper.make_dispatch_inbound(
+                'in 1', message_id='1', conv=self.conversation)
+            [msg_log] = lc.messages()
+        self.assertTrue(self.mock_push_server.url in msg_log)
+
+    @inlineCallbacks
     def test_post_inbound_event(self):
         yield self.start_app_worker()
         msg1 = yield self.app_helper.make_stored_outbound(
@@ -1311,6 +1322,19 @@ class TestNoStreamingHTTPWorker(TestNoStreamingHTTPWorkerBase):
                 msg1, conv=self.conversation)
             [dns_log] = lc.messages()
         self.assertTrue(self.mock_push_server.url in dns_log)
+
+    @inlineCallbacks
+    def test_post_inbound_event_response_failed_error(self):
+        yield self.start_app_worker()
+        msg1 = yield self.app_helper.make_stored_outbound(
+            self.conversation, 'out 1', message_id='1')
+
+        self._patch_http_request_full(lambda: ResponseFailed(reasons=[]))
+        with LogCatcher(message='Response failed') as lc:
+            yield self.app_helper.make_dispatch_ack(
+                msg1, conv=self.conversation)
+            [msg_log] = lc.messages()
+        self.assertTrue(self.mock_push_server.url in msg_log)
 
     @inlineCallbacks
     def test_bad_urls(self):

--- a/go/apps/http_api_nostream/tests/test_vumi_app.py
+++ b/go/apps/http_api_nostream/tests/test_vumi_app.py
@@ -6,7 +6,7 @@ from urlparse import urlparse, urlunparse
 from twisted.internet.defer import inlineCallbacks, DeferredQueue, returnValue
 from twisted.internet.error import DNSLookupError, ConnectionRefusedError
 from twisted.web.error import SchemeNotSupported
-from twisted.web._newclient import ResponseFailed
+from twisted.web.client import ResponseFailed
 from twisted.web import http
 from twisted.web.server import NOT_DONE_YET
 

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -6,7 +6,7 @@ from twisted.internet.defer import (
     inlineCallbacks, returnValue, Deferred, succeed)
 from twisted.internet.error import DNSLookupError, ConnectionRefusedError
 from twisted.web.error import SchemeNotSupported
-from twisted.web._newclient import ResponseFailed
+from twisted.web.client import ResponseFailed
 
 from vumi.config import ConfigInt, ConfigText, ConfigList
 from vumi.utils import http_request_full, HttpTimeoutError

--- a/go/apps/http_api_nostream/vumi_app.py
+++ b/go/apps/http_api_nostream/vumi_app.py
@@ -6,6 +6,7 @@ from twisted.internet.defer import (
     inlineCallbacks, returnValue, Deferred, succeed)
 from twisted.internet.error import DNSLookupError, ConnectionRefusedError
 from twisted.web.error import SchemeNotSupported
+from twisted.web._newclient import ResponseFailed
 
 from vumi.config import ConfigInt, ConfigText, ConfigList
 from vumi.utils import http_request_full, HttpTimeoutError
@@ -386,6 +387,8 @@ class NoStreamingHTTPWorker(GoApplicationWorker):
             log.warning("DNS lookup error pushing message to %s" % (url,))
         except ConnectionRefusedError:
             log.warning("Connection refused pushing message to %s" % (url,))
+        except ResponseFailed:
+            log.warning("Response failed pushing message to %s" % (url,))
         if retry_required:
             yield self.schedule_push_retry(
                 user_account_key, url=url, method='POST', data=data,


### PR DESCRIPTION
E.g.

```
2015-08-24 13:43:33+0000 Unhandled Error
        Traceback (most recent call last):
        Failure: twisted.web._newclient.ResponseNeverReceived: [<twisted.python.failure.Failure <class 'twisted.internet.error.ConnectionLost'>>]
```
