### PR TITLE
Split JS tests into a separate build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
     # This is a separate matrix inclusion to avoid spawning unnecessary builds.
     - python: "2.7"
       env: RIAK_VERSION="1.4.12" VUMITEST_REDIS_DB=1 VUMI_TEST_TIMEOUT=10 VUMIGO_SKIP_DJANGO=1
+    # Test JS stuff.
+    - python: "2.7"
+      env: TEST_JS_ONLY=1 VUMIGO_SKIP_DJANGO=1
 
 cache:
   directories:
@@ -36,7 +39,9 @@ install:
   - "if [ $VUMIGO_SKIP_DJANGO ]; then pip install -e .; else pip install -r requirements.pip; fi"
   - "pip install -r requirements-dev.pip"
   - "pip install overalls"
-  - "npm install"
+  # Minimal set of JS libs necessary for jsbox and dialogue app tests.
+  - "npm install --production --no-optional"
+  - "if [ $TEST_JS_ONLY ]; then npm install; fi"
 
 before_script:
   - "if [ ! $VUMIGO_SKIP_DJANGO ]; then utils/setup-test-database.sh; fi"
@@ -46,8 +51,8 @@ before_script:
   - $HOME/riak/bin/riak version
   - $HOME/riak/bin/riak-admin member-status
 script:
-  - ./run-tests.sh
-  - grunt test
+  - "if [ ! $TEST_JS_ONLY ]; then ./run-tests.sh; else grunt test; fi"
 
 after_success:
   - "if [ ! $VUMIGO_SKIP_DJANGO ]; then overalls --py --lcov mochacov.lcov --lcov coverage/*/lcov.info; fi"
+  - "if [ $TEST_JS_ONLY ]; then overalls --lcov mochacov.lcov --lcov coverage/*/lcov.info; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ services:
 
 before_install:
   # Set up an appropriate version of Riak.
-  - "[ ! $TEST_JS_ONLY ] && utils/setup_travis_riak.sh ${RIAK_VERSION}"
+  - "if [ ! $TEST_JS_ONLY ]; then utils/setup_travis_riak.sh ${RIAK_VERSION}; fi"
 install:
   # Travis seems to have pip 6.x, which doesn't build and cache wheels.
   - "pip install 'pip>=7.1.0'"
@@ -48,8 +48,8 @@ before_script:
   - "export PYTHONPATH=."
   - "pip list"
   # To see what version of Riak we're running and check that it's happy.
-  - "[ ! $TEST_JS_ONLY ] && $HOME/riak/bin/riak version"
-  - "[ ! $TEST_JS_ONLY ] && $HOME/riak/bin/riak-admin member-status"
+  - "if [ ! $TEST_JS_ONLY ]; then $HOME/riak/bin/riak version; fi"
+  - "if [ ! $TEST_JS_ONLY ]; then $HOME/riak/bin/riak-admin member-status; fi"
 script:
   - "if [ ! $TEST_JS_ONLY ]; then ./run-tests.sh; else grunt test; fi"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ services:
 
 before_install:
   # Set up an appropriate version of Riak.
-  - "if [ ! $TEST_JS_ONLY ]; then utils/setup_travis_riak.sh ${RIAK_VERSION}; fi"
+  - "[ ! $TEST_JS_ONLY ] && utils/setup_travis_riak.sh ${RIAK_VERSION}"
 install:
   # Travis seems to have pip 6.x, which doesn't build and cache wheels.
   - "pip install 'pip>=7.1.0'"
@@ -48,8 +48,8 @@ before_script:
   - "export PYTHONPATH=."
   - "pip list"
   # To see what version of Riak we're running and check that it's happy.
-  - $HOME/riak/bin/riak version
-  - $HOME/riak/bin/riak-admin member-status
+  - "[ ! $TEST_JS_ONLY ] && $HOME/riak/bin/riak version"
+  - "[ ! $TEST_JS_ONLY ] && $HOME/riak/bin/riak-admin member-status"
 script:
   - "if [ ! $TEST_JS_ONLY ]; then ./run-tests.sh; else grunt test; fi"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ services:
 
 before_install:
   # Set up an appropriate version of Riak.
-  - utils/setup_travis_riak.sh "${RIAK_VERSION}"
+  - "if [ ! $TEST_JS_ONLY ]; then utils/setup_travis_riak.sh ${RIAK_VERSION}; fi"
 install:
   # Travis seems to have pip 6.x, which doesn't build and cache wheels.
   - "pip install 'pip>=7.1.0'"

--- a/package.json
+++ b/package.json
@@ -9,17 +9,19 @@
     }
   },
   "dependencies": {
+    "lodash": "~2.4.1",
+    "q": "~0.9.7",
+    "vumigo_v01": "~0.1.22",
+    "vumigo_v02": "~0.2"
+  },
+  "optionalDependencies": {
     "go-jsbox-location": "^0.2.0",
     "go-jsbox-ona": "^0.1.0",
     "go-jsbox-metrics-helper": "^0.1.0",
     "go-jsbox-xform": "^0.0.1",
     "jed": "~0.5.4",
     "libxmljs": "~0.8.1",
-    "lodash": "~2.4.1",
-    "moment": "~2.6",
-    "q": "~0.9.7",
-    "vumigo_v01": "~0.1.22",
-    "vumigo_v02": "~0.2"
+    "moment": "~2.6"
   },
   "devDependencies": {
     "bower": "^1.3.11",


### PR DESCRIPTION
They often fail spuriously (yay npm) and don't depend on Python version. Putting them in their own build should give us a speed boost and make it easier to rerun just the broken things.
