### PR TITLE
Specify valid choices for sequential send recurring value in edit form.

### DIFF
--- a/go/apps/sequential_send/view_definition.py
+++ b/go/apps/sequential_send/view_definition.py
@@ -24,7 +24,7 @@ class ScheduleForm(forms.Form):
                   " sends.")
 
     time = forms.CharField(
-        help_text="Time at which messages should be sent, in 'HH:MM:SS'"
+        help_text="Time in UTC at which messages should be sent, in 'HH:MM:SS'"
                   " format.")
 
 

--- a/go/apps/sequential_send/view_definition.py
+++ b/go/apps/sequential_send/view_definition.py
@@ -5,11 +5,27 @@ from go.conversation.view_definition import (
 
 
 class ScheduleForm(forms.Form):
-    recurring = forms.CharField(
-        help_text="Currently supports 'daily' or 'day_of_month'.")
-    days = forms.CharField(required=False,
-        help_text="Required for 'day_of_month', comma-separated numbers.")
-    time = forms.CharField(help_text="Time in 'HH:MM:SS' format.")
+
+    RECURRING = (
+        ('daily', 'Daily'),
+        ('day_of_week', 'Day of Week'),
+        ('day_of_month', 'Day of Month'),
+        ('never', 'Never'),
+    )
+
+    recurring = forms.ChoiceField(
+        choices=RECURRING,
+        help_text="When messages should be sent.")
+
+    days = forms.CharField(
+        required=False,
+        help_text="Which days of the week or month messages should be sent on."
+                  " List of comma-separated numbers. Not required for daily"
+                  " sends.")
+
+    time = forms.CharField(
+        help_text="Time at which messages should be sent, in 'HH:MM:SS'"
+                  " format.")
 
 
 class MessageForm(forms.Form):

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -116,6 +116,9 @@ class SequentialSendApplication(GoApplicationWorker):
     def process_conversation_schedule(self, then, now, conv):
         schedule = self.get_config_for_conversation(conv).schedule
         if ScheduleManager(schedule).is_scheduled(then, now):
+            log.info(
+                'Sending scheduled messages for conversation %s from'
+                ' account %s' % (conv.key, conv.user_account.key))
             yield self.send_scheduled_messages(conv)
 
     @inlineCallbacks


### PR DESCRIPTION
Currently the sequential send UI does no sanity checking of the `recurring` field and the help for it is out of date.
