### PR TITLE
Protect against errors in the sequential send polling looping call

### DIFF
--- a/go/apps/sequential_send/tests/test_vumi_app.py
+++ b/go/apps/sequential_send/tests/test_vumi_app.py
@@ -203,7 +203,7 @@ class TestSequentialSendApplication(VumiTestCase):
 
         patch.restore()
 
-        # no conversations processed initiall because of the error
+        # no conversations processed initially because of the error
         yield self.check_message_convs_and_advance([], 3600 * 24 - 70)
         yield self.check_message_convs_and_advance([], 70)
         # now a conversation has been processed

--- a/go/apps/sequential_send/vumi_app.py
+++ b/go/apps/sequential_send/vumi_app.py
@@ -117,6 +117,7 @@ class SequentialSendApplication(GoApplicationWorker):
             if conv.active():
                 yield self.process_conversation_schedule(then, now, conv)
 
+    @catch_and_log_errors
     @inlineCallbacks
     def process_conversation_schedule(self, then, now, conv):
         schedule = self.get_config_for_conversation(conv).schedule


### PR DESCRIPTION
Currently any errors will cause the looping call to exit and sequential send to silently stop doing its job.
