### PR TITLE
Change billing statement generation to not perform heavy postgres operations

### DIFF
--- a/go/billing/django_utils.py
+++ b/go/billing/django_utils.py
@@ -24,18 +24,34 @@ class TransactionSerializer(object):
 
 
 class Summaries(object):
+    """
+    Helper class to summarize incrementally given model data.
+
+    The constructor takes in a list of `select` fields and a list of `total`
+    fields. Each summary corresponds to models with the same `select` fields,
+    and results in a summation of those models' `total` fields.
+    """
+
     def __init__(self, select_fields, total_fields):
         self.select_fields = select_fields
         self.total_fields = total_fields
         self.items = {}
 
     def incr(self, model):
+        """
+        Increments the :class:`Summary` matching the given model's `select`
+        fields. If no matching summary is found, a new summary is created.
+        """
         select_values = tuple(pick_attrs(model, self.select_fields))
         summary = self.ensure(select_values)
         summary.incr(model)
         return summary
 
     def ensure(self, select_values):
+        """
+        Gets the summary matching the given `select` values, creating and adding
+        a new summary if no matching summary is found.
+        """
         summary = self.items.get(select_values)
 
         if summary is None:
@@ -45,35 +61,57 @@ class Summaries(object):
         return summary
 
     def create(self, select_values):
+        """
+        Creates a new summary that corresponds to the given `select` values.
+        """
         return Summary(
             selects=dict(zip(self.select_fields, select_values)),
             totals=dict((field, None) for field in self.total_fields))
 
     def serialize(self):
+        """
+        Returns a list of dictionaries representing the current summary
+        results.
+        """
         return [
             self.items[name].serialize()
             for name in sorted(self.items.iterkeys())]
 
 
 class Summary(object):
+    """
+    Helper class to summarize incrementally given model data by adding the given
+    models' `total` fields together.
+    """
+
     def __init__(self, selects, totals):
         self.count = 0
         self.selects = selects
         self.totals = totals
 
     def incr(self, model):
+        """
+        Adds the given model's `total` fields to the summary's current totals.
+        """
         self.count = self.count + 1
 
         for field in self.totals.iterkeys():
             self.incr_total(field, getattr(model, field))
 
     def incr_total(self, field, value):
+        """
+        Increments the given `total` field by the given value.
+        """
         if value is not None:
             current = self.totals[field]
             current = current if current is not None else 0
             self.totals[field] = value + current
 
     def serialize(self):
+        """
+        Returns a dictionary representing the current summation of `total`
+        fields.
+        """
         result = {'count': self.count}
 
         result.update(self.selects)

--- a/go/billing/django_utils.py
+++ b/go/billing/django_utils.py
@@ -70,7 +70,8 @@ class Summary(object):
     def incr_total(self, field, value):
         if value is not None:
             current = self.totals[field]
-            self.totals[field] = value + (current if current is not None else 0)
+            current = current if current is not None else 0
+            self.totals[field] = value + current
 
     def serialize(self):
         result = {'count': self.count}

--- a/go/billing/django_utils.py
+++ b/go/billing/django_utils.py
@@ -121,8 +121,8 @@ def load_account_credits(account, credit_amount):
     transaction.save()
 
 
-def summarize(queryset, select_fields, total_fields, chunk_size=1000):
-    models = chain.from_iterable(chunked_query(queryset, chunk_size))
+def summarize(queryset, select_fields, total_fields, items_per_chunk=1000):
+    models = chain.from_iterable(chunked_query(queryset, items_per_chunk))
     summaries = Summaries(select_fields, total_fields)
 
     for model in models:

--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 
 from celery.task import task, group
 from dateutil.relativedelta import relativedelta
-from django.db.models import Sum, Count
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 from djcelery_email.tasks import send_email

--- a/go/billing/tasks.py
+++ b/go/billing/tasks.py
@@ -16,7 +16,8 @@ from go.billing.django_utils import load_account_credits
 from go.billing.models import (
     Account, MessageCost, Transaction, Statement, LineItem, TransactionArchive,
     LowCreditNotification)
-from go.billing.django_utils import TransactionSerializer, chunked_query
+from go.billing.django_utils import (
+    TransactionSerializer, chunked_query, summarize)
 from go.base.utils import format_currency
 
 
@@ -50,37 +51,33 @@ def get_message_transactions(transactions):
     transactions = transactions.filter(
         transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-    transactions = transactions.values(
-        'tag_pool_name',
-        'tag_name',
-        'provider',
-        'message_direction',
-        'message_cost',
-        'message_credits',
-        'markup_percent')
-
-    transactions = transactions.annotate(
-        count=Count('id'),
-        total_message_cost=Sum('message_cost'),
-        total_message_credits=Sum('message_credits'))
-
-    return transactions
+    return summarize(
+        transactions,
+        select_fields=(
+            'tag_pool_name',
+            'tag_name',
+            'provider',
+            'message_direction',
+            'message_cost',
+            'message_credits',
+            'markup_percent'),
+        total_fields=(
+            'message_cost',
+            'message_credits'))
 
 
 def get_storage_transactions(transactions):
     transactions = transactions.filter(
         transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-    transactions = transactions.values(
-        'storage_cost',
-        'storage_credits')
-
-    transactions = transactions.annotate(
-        count=Count('id'),
-        total_storage_cost=Sum('storage_cost'),
-        total_storage_credits=Sum('storage_credits'))
-
-    return transactions
+    return summarize(
+        transactions,
+        select_fields=(
+            'storage_cost',
+            'storage_credits'),
+        total_fields=(
+            'storage_cost',
+            'storage_credits'))
 
 
 def get_session_transactions(transactions):
@@ -88,20 +85,18 @@ def get_session_transactions(transactions):
         session_created=True,
         transaction_type=Transaction.TRANSACTION_TYPE_MESSAGE)
 
-    transactions = transactions.values(
-        'tag_pool_name',
-        'tag_name',
-        'provider',
-        'session_cost',
-        'session_credits',
-        'markup_percent')
-
-    transactions = transactions.annotate(
-        count=Count('id'),
-        total_session_cost=Sum('session_cost'),
-        total_session_credits=Sum('session_credits'))
-
-    return transactions
+    return summarize(
+        transactions,
+        select_fields=(
+            'tag_pool_name',
+            'tag_name',
+            'provider',
+            'session_cost',
+            'session_credits',
+            'markup_percent'),
+        total_fields=(
+            'session_cost',
+            'session_credits'))
 
 
 def get_session_length_transactions(transactions):
@@ -112,20 +107,18 @@ def get_session_length_transactions(transactions):
     transactions = transactions.exclude(session_length=None)
     transactions = transactions.exclude(session_length_cost=0)
 
-    transactions = transactions.values(
-        'tag_pool_name',
-        'tag_name',
-        'provider',
-        'session_unit_time',
-        'session_unit_cost',
-        'markup_percent')
-
-    transactions = transactions.annotate(
-        count=Count('id'),
-        total_session_length_cost=Sum('session_length_cost'),
-        total_session_length_credits=Sum('session_length_credits'))
-
-    return transactions
+    return summarize(
+        transactions,
+        select_fields=(
+            'tag_pool_name',
+            'tag_name',
+            'provider',
+            'session_unit_time',
+            'session_unit_cost',
+            'markup_percent'),
+        total_fields=(
+            'session_length_cost',
+            'session_length_credits'))
 
 
 def get_tagpool_name(transaction, tagpools):

--- a/go/billing/tests/test_django_utils.py
+++ b/go/billing/tests/test_django_utils.py
@@ -132,38 +132,38 @@ class TestSummarize(GoDjangoTestCase):
     def test_summarize(self):
         account = self.account
 
-        t1 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='a',
             message_cost=Decimal('1.0'),
             session_cost=Decimal('10.0'))
 
-        t2 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='b',
             message_cost=Decimal('3.0'),
             session_cost=Decimal('30.0'))
 
-        t3 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='a',
             message_cost=Decimal('1.0'),
             session_cost=Decimal('10.0'))
 
-        t4 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='b',
             message_cost=Decimal('4.0'),
             session_cost=Decimal('40.0'))
 
-        t5 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='c',
             message_cost=Decimal('5.0'),
             session_cost=Decimal('50.0'))
 
         result = summarize(
-            [t1, t2, t3, t4, t5],
+            Transaction.objects.all(),
             ('tag_name', 'message_cost'),
             ('message_cost', 'session_cost'))
 
@@ -196,18 +196,18 @@ class TestSummarize(GoDjangoTestCase):
     def test_summarize_all_nones(self):
         account = self.account
 
-        t1 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='a',
             message_cost=None)
 
-        t2 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='a',
             message_cost=None)
 
         result = summarize(
-            [t1, t2],
+            Transaction.objects.all(),
             ('tag_name', 'message_cost'),
             ('message_cost',))
 
@@ -221,18 +221,18 @@ class TestSummarize(GoDjangoTestCase):
     def test_summarize_some_nones(self):
         account = self.account
 
-        t1 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='a',
             message_cost=None)
 
-        t2 = mk_transaction(
+        mk_transaction(
             account,
             tag_name='a',
             message_cost=Decimal('23.0'))
 
         result = summarize(
-            [t1, t2],
+            Transaction.objects.all(),
             ('tag_name', 'message_cost'),
             ('message_cost',))
 

--- a/go/billing/tests/test_django_utils.py
+++ b/go/billing/tests/test_django_utils.py
@@ -167,7 +167,7 @@ class TestSummarize(GoDjangoTestCase):
             ('tag_name', 'message_cost'),
             ('message_cost', 'session_cost'))
 
-        self.assertEqual(list(result), [{
+        self.assertEqual(result, [{
             'tag_name': 'a',
             'count': 2,
             'message_cost': Decimal('1.0'),
@@ -191,4 +191,59 @@ class TestSummarize(GoDjangoTestCase):
             'message_cost': Decimal('5.0'),
             'total_message_cost': Decimal('5.0'),
             'total_session_cost': Decimal('50.0')
+        }])
+
+    def test_summarize_all_nones(self):
+        account = self.account
+
+        t1 = mk_transaction(
+            account,
+            tag_name='a',
+            message_cost=None)
+
+        t2 = mk_transaction(
+            account,
+            tag_name='a',
+            message_cost=None)
+
+        result = summarize(
+            [t1, t2],
+            ('tag_name', 'message_cost'),
+            ('message_cost',))
+
+        self.assertEqual(result, [{
+            'tag_name': 'a',
+            'count': 2,
+            'message_cost': None,
+            'total_message_cost': None,
+        }])
+
+    def test_summarize_some_nones(self):
+        account = self.account
+
+        t1 = mk_transaction(
+            account,
+            tag_name='a',
+            message_cost=None)
+
+        t2 = mk_transaction(
+            account,
+            tag_name='a',
+            message_cost=Decimal('23.0'))
+
+        result = summarize(
+            [t1, t2],
+            ('tag_name', 'message_cost'),
+            ('message_cost',))
+
+        self.assertEqual(result, [{
+            'tag_name': 'a',
+            'count': 1,
+            'message_cost': None,
+            'total_message_cost': None,
+        }, {
+            'tag_name': 'a',
+            'count': 1,
+            'message_cost': Decimal('23.0'),
+            'total_message_cost': Decimal('23.0'),
         }])


### PR DESCRIPTION
At the moment, the queries needed for generating statements are heavy operations for accounts with many transactions. Since these queries lock the transaction table, this blocks our message processing (since inserting into the transaction table is a part of processing each message). It would help if we made smaller, chunked queries to postgres (similar to our archiving task) and aggregated on the client side.
