### PR TITLE
License name in package.json is not a valid SPDX license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "url": "git://github.com/praekelt/vumi-go"
   },
   "author": "Praekelt Foundation",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/praekelt/vumi-go/issues"
   }


### PR DESCRIPTION
From npm install:

```
npm WARN package.json vumi-go@0.5.0-dev license should be a valid SPDX license expression
```

And indeed, `BSD` is not in the list at https://spdx.org/licenses/
