### PR TITLE
Post message export form to the correct URL

### DIFF
--- a/go/conversation/templates/conversation/message_list.html
+++ b/go/conversation/templates/conversation/message_list.html
@@ -145,7 +145,7 @@
             </div>
 
             <div class="modal-body">
-                <form method="post">
+                <form method="post" action="{% conversation_screen conversation 'export_messages' %}">
                     {% csrf_token %}
                     {% with message_download_form as form %}
 

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -1003,6 +1003,15 @@ class TestConversationViews(BaseConversationViewTestCase):
         self.assertContains(response, 'value="01/12/1969" name="date_from"')
         self.assertContains(response, 'value="01/12/1969" name="date_to"')
 
+    def test_message_list_download_model_form_action(self):
+        conv = self.user_helper.create_conversation(
+            u'dummy', name=u'Foo', started=True)
+        response = self.client.get(self.get_view_url(conv, 'message_list'))
+        self.assertContains(
+            response,
+            '<form method="post" action="%s">'
+            % self.get_view_url(conv, 'export_messages'))
+
     def test_message_list_no_sensitive_msgs(self):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
 


### PR DESCRIPTION
Current we post it to the message list display URL, instead of the message export URL.
