### PR TITLE
Convert message export request to a GET

### DIFF
--- a/go/conversation/templates/conversation/message_list.html
+++ b/go/conversation/templates/conversation/message_list.html
@@ -145,7 +145,7 @@
             </div>
 
             <div class="modal-body">
-                <form method="post" action="{% conversation_screen conversation 'export_messages' %}">
+                <form method="get" action="{% conversation_screen conversation 'export_messages' %}">
                     {% csrf_token %}
                     {% with message_download_form as form %}
 

--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -737,7 +737,7 @@ class TestConversationViews(BaseConversationViewTestCase):
 
     def check_download_messages(self, post_args, url_tmpl, filename_tmpl):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
-        response = self.client.post(
+        response = self.client.get(
             self.get_view_url(conv, 'export_messages'), post_args)
         self.assertEqual(
             response['X-Accel-Redirect'],
@@ -827,11 +827,11 @@ class TestConversationViews(BaseConversationViewTestCase):
             '&end=1985-09-05T00%%3A00%%3A00%%2B00%%3A00',
             '%(conv)s-outbound-19691105T0000-19850904T2359.csv')
 
-    def check_download_messages_error(self, post_args, error_field, error_msg,
+    def check_download_messages_error(self, get_args, error_field, error_msg,
                                       lead=''):
         conv = self.user_helper.create_conversation(u'dummy', started=True)
-        response = self.client.post((
-            self.get_view_url(conv, 'export_messages')), post_args)
+        response = self.client.get((
+            self.get_view_url(conv, 'export_messages')), get_args)
         self.assertEqual(response.status_code, 200)
         form = response.context['message_download_form']
         self.assertEqual(form.errors[error_field], [error_msg])
@@ -852,8 +852,8 @@ class TestConversationViews(BaseConversationViewTestCase):
                         '<ul class="errorlist"><li>%(msg)s</li></ul>'
                         '</li></ul>' % {
                             'field': error_field, 'msg': error_msg}),
-                    'download_form_post':
-                        dict((k, [v]) for k, v in post_args.items()),
+                    'download_form_data':
+                        dict((k, [v]) for k, v in get_args.items()),
                 }
             }),
         ])
@@ -1009,7 +1009,7 @@ class TestConversationViews(BaseConversationViewTestCase):
         response = self.client.get(self.get_view_url(conv, 'message_list'))
         self.assertContains(
             response,
-            '<form method="post" action="%s">'
+            '<form method="get" action="%s">'
             % self.get_view_url(conv, 'export_messages'))
 
     def test_message_list_no_sensitive_msgs(self):

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -199,12 +199,12 @@ class ExportMessageView(ConversationApiView):
     view_name = 'export_messages'
     path_suffix = 'export_messages/'
 
-    def post(self, request, conversation):
-        form = MessageDownloadForm(request.POST)
+    def get(self, request, conversation):
+        form = MessageDownloadForm(request.GET)
         if not form.is_valid():
             extra = {
                 'download_form_errors': str(form.errors),
-                'download_form_post': request.POST,
+                'download_form_data': request.GET,
             }
             logger.error("Message download form contains errors.", extra=extra)
             view = self.view_def.get_view(
@@ -343,8 +343,6 @@ class MessageListView(ConversationTemplateView):
         )
 
     def post(self, request, conversation):
-        if self.message_download_form is not None:
-            return self.get(request, conversation)
         if '_send_one_off_reply' in request.POST:
             form = ReplyToMessageForm(request.POST)
             if form.is_valid():


### PR DESCRIPTION
Currently it's a POST request, which means the Nginx X-Accel redirect remains a POST. The message store exporter expects a GET.

A GET more accurately reflects what this request does though (i.e. retrieve messages).
