### PR TITLE
Log download form error data directly in log message

### DIFF
--- a/go/conversation/tests.py
+++ b/go/conversation/tests.py
@@ -845,18 +845,19 @@ class TestConversationViews(BaseConversationViewTestCase):
             '</div>', html=True)
         self.assertContains(response, '$("#download-modal").modal("show");')
         self.assertEqual(self.error_logs, [
-            ('Message download form contains errors.', (), {
-                'extra': {
-                    'download_form_errors': (
-                        '<ul class="errorlist"><li>%(field)s'
-                        '<ul class="errorlist"><li>%(msg)s</li></ul>'
-                        '</li></ul>' % {
-                            'field': error_field, 'msg': error_msg}),
-                    'download_form_data':
-                        dict((k, [v]) for k, v in get_args.items()),
-                }
-            }),
+            ('Message download form contains errors: %s [GET: %r]',
+                (
+                    '<ul class="errorlist"><li>%(field)s'
+                    '<ul class="errorlist"><li>%(msg)s</li></ul>'
+                    '</li></ul>' % {
+                        'field': error_field, 'msg': error_msg},
+                    dict((unicode(k), [unicode(v)])
+                         for k, v in get_args.items()),
+                ),
+                {}),
         ])
+        # check that logs can be formatted
+        [log[0] % log[1] for log in self.error_logs]
 
     def test_download_messages_unknown_direction(self):
         self.check_download_messages_error(

--- a/go/conversation/view_definition.py
+++ b/go/conversation/view_definition.py
@@ -202,11 +202,9 @@ class ExportMessageView(ConversationApiView):
     def get(self, request, conversation):
         form = MessageDownloadForm(request.GET)
         if not form.is_valid():
-            extra = {
-                'download_form_errors': str(form.errors),
-                'download_form_data': request.GET,
-            }
-            logger.error("Message download form contains errors.", extra=extra)
+            logger.error(
+                "Message download form contains errors: %s [GET: %r]",
+                str(form.errors), dict(request.GET))
             view = self.view_def.get_view(
                 'message_list/', message_download_form=form)
             return view(request, conversation)


### PR DESCRIPTION
Currently we include it in `extra`, but that doesn't get logged to the console (maybe Django's error logger is suboptimal?).
