### PR TITLE
Session state race condition in app multiplexer

### DIFF
--- a/go/routers/app_multiplexer/tests/test_vumi_app.py
+++ b/go/routers/app_multiplexer/tests/test_vumi_app.py
@@ -498,7 +498,7 @@ class TestApplicationMultiplexerRouter(VumiTestCase):
         unpause_handler_d.callback(None)
 
         # assert that the user received a response
-        [msg] = self.router_helper.ri.get_dispatched_outbound()
+        [msg] = yield self.router_helper.ri.wait_for_dispatched_outbound()
         self.assertEqual(msg['content'],
                          'Please select a choice.\n1) Flappy Bird')
         # assert that session data updated correctly


### PR DESCRIPTION
Currently, the app multiplexer sends its reply message before it updates its state. In addition to the annoying random build failures this causes, there's also a risk of the session state being inconsistent when the next message arrives.
