### PR TITLE
Fix conversation scheduling

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -36,6 +36,7 @@ class BulkSendAction(ConversationAction):
             label='Bulk Message Send',
             task_type=Task.TYPE_CONVERSATION_ACTION,
             task_data={
+                'conversation_key': self._conv.key,
                 'action_name': 'bulk_send',
                 'action_kwargs': {
                     'batch_id': self._conv.batch.key,

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -235,6 +235,7 @@ class TestBulkMessageViews(GoDjangoTestCase):
         self.assertEqual(task.label, 'Bulk Message Send')
         self.assertEqual(task.task_type, Task.TYPE_CONVERSATION_ACTION)
         self.assertEqual(task.task_data, {
+            'conversation_key': conversation.key,
             'action_name': 'bulk_send',
             'action_kwargs': {
                 'batch_id': conversation.batch.key,

--- a/go/apps/dialogue/definition.py
+++ b/go/apps/dialogue/definition.py
@@ -20,6 +20,7 @@ class SendDialogueAction(SendJsboxAction):
             label='Dialogue Message Send',
             task_type=Task.TYPE_CONVERSATION_ACTION,
             task_data={
+                'conversation_key': self._conv.key,
                 'action_name': 'send_jsbox',
                 'action_kwargs': {
                     'batch_id': self._conv.batch.key,

--- a/go/apps/dialogue/tests/test_views.py
+++ b/go/apps/dialogue/tests/test_views.py
@@ -73,6 +73,7 @@ class TestDialogueViews(GoDjangoTestCase):
         self.assertEqual(task.label, 'Dialogue Message Send')
         self.assertEqual(task.task_type, Task.TYPE_CONVERSATION_ACTION)
         self.assertEqual(task.task_data, {
+            'conversation_key': conversation.key,
             'action_name': 'send_jsbox',
             'action_kwargs': {
                 'batch_id': conversation.batch.key,

--- a/go/scheduler/tasks.py
+++ b/go/scheduler/tasks.py
@@ -42,14 +42,13 @@ def perform_conversation_action(task):
     Perform a conversation action. ``task_data`` must have the following
     fields:
 
-    user_account_key - The key of the user account.
     conversation_key - The key for the conversation.
     action_name - The name of the action to be performed.
     action_kwargs - A dictionary representing the keyword arguments for an
                     action.
     """
     user_api = vumi_api().get_user_api(
-        task.task_data['user_account_key'], cleanup_api=True)
+        task.account_id, cleanup_api=True)
     conv = user_api.get_wrapped_conversation(
         task.task_data['conversation_key'])
     view_def = get_conversation_view_definition(

--- a/go/scheduler/tests/test_tasks.py
+++ b/go/scheduler/tests/test_tasks.py
@@ -20,9 +20,8 @@ class TestPerformTask(GoDjangoTestCase):
         conv = self.user_helper.create_conversation(u'bulk_message')
         now = datetime.datetime.utcnow()
         task = Task.objects.create(
-            account_id="user-1", label="Task 1", scheduled_for=now,
-            task_data={
-                'user_account_key': self.user_helper.account_key,
+            account_id=self.user_helper.account_key, label="Task 1",
+            scheduled_for=now, task_data={
                 'conversation_key': conv.key,
                 'action_name': 'bulk_send',
                 'action_kwargs': {
@@ -42,9 +41,8 @@ class TestPerformTask(GoDjangoTestCase):
         conv = self.user_helper.create_conversation(u'bulk_message')
         now = datetime.datetime.utcnow()
         task = Task.objects.create(
-            account_id="user-1", label="Task 1", scheduled_for=now,
-            task_data={
-                'user_account_key': self.user_helper.account_key,
+            account_id=self.user_helper.account_key, label="Task 1",
+            scheduled_for=now, task_data={
                 'conversation_key': conv.key,
                 'action_name': 'bulk_send',
                 'action_kwargs': {
@@ -66,9 +64,8 @@ class TestPerformTask(GoDjangoTestCase):
         conv = self.user_helper.create_conversation(u'bulk_message')
         now = datetime.datetime.utcnow()
         task = Task.objects.create(
-            account_id="user-1", label="Task 1", scheduled_for=now,
-            task_data={
-                'user_account_key': self.user_helper.account_key,
+            account_id=self.user_helper.account_key, label="Task 1",
+            scheduled_for=now, task_data={
                 'conversation_key': conv.key,
                 'action_name': 'bulk_send',
                 'action_kwargs': {

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ django_requires = [
     'django-crispy-forms==1.4.0',
     'django-loginas==0.1.3',
     'boto',
-    'moto',
+    'moto==0.4.19',
     # https://github.com/sehmaschine/django-grappelli/issues/407
     'django-grappelli==2.4.8',
     # The billing API currently pulls in some Django stuff, so its non-Django


### PR DESCRIPTION
Currently, we are not sending the `conversation_key` to the task for bulk_send and dialogues.
