### PR TITLE
Better testing for scheduled actions

### DIFF
--- a/go/apps/bulk_message/definition.py
+++ b/go/apps/bulk_message/definition.py
@@ -39,9 +39,7 @@ class BulkSendAction(ConversationAction):
                 'conversation_key': self._conv.key,
                 'action_name': 'bulk_send',
                 'action_kwargs': {
-                    'batch_id': self._conv.batch.key,
-                    'msg_options': {},
-                    'content': action_data['message'],
+                    'message': action_data['message'],
                     'delivery_class': action_data['delivery_class'],
                     'dedupe': action_data['dedupe'],
                 },

--- a/go/apps/bulk_message/tests/test_views.py
+++ b/go/apps/bulk_message/tests/test_views.py
@@ -11,6 +11,7 @@ with djangotest_imports(globals()):
     from go.apps.tests.view_helpers import AppViewsHelper
     from go.base.tests.helpers import GoDjangoTestCase
     from go.scheduler.models import Task
+    from go.scheduler.tasks import perform_conversation_action
 
 
 class TestBulkMessageViews(GoDjangoTestCase):
@@ -230,21 +231,22 @@ class TestBulkMessageViews(GoDjangoTestCase):
 
         conversation = conv_helper.get_conversation()
         [task] = Task.objects.all()
+
+        perform_conversation_action(task)
+        [bulk_send_cmd] = self.app_helper.get_api_commands_sent()
+        self.assertEqual(bulk_send_cmd, VumiApiCommand.command(
+            '%s_application' % (conversation.conversation_type,),
+            'bulk_send', command_id=bulk_send_cmd["command_id"],
+            user_account_key=conversation.user_account.key,
+            conversation_key=conversation.key,
+            batch_id=conversation.batch.key, msg_options={},
+            delivery_class='sms',
+            content='I am ham, not spam.', dedupe=True))
+
         self.assertEqual(
             task.account_id, conversation.user_account.key)
         self.assertEqual(task.label, 'Bulk Message Send')
         self.assertEqual(task.task_type, Task.TYPE_CONVERSATION_ACTION)
-        self.assertEqual(task.task_data, {
-            'conversation_key': conversation.key,
-            'action_name': 'bulk_send',
-            'action_kwargs': {
-                'batch_id': conversation.batch.key,
-                'content': 'I am ham, not spam.',
-                'dedupe': True,
-                'delivery_class': 'sms',
-                'msg_options': {}
-            },
-        })
         self.assertEqual(task.status, Task.STATUS_PENDING)
         self.assertEqual(
             task.scheduled_for, datetime.datetime.strptime(

--- a/go/apps/dialogue/definition.py
+++ b/go/apps/dialogue/definition.py
@@ -22,9 +22,7 @@ class SendDialogueAction(SendJsboxAction):
             task_data={
                 'conversation_key': self._conv.key,
                 'action_name': 'send_jsbox',
-                'action_kwargs': {
-                    'batch_id': self._conv.batch.key,
-                },
+                'action_kwargs': {},
             },
             scheduled_for=action_data['scheduled_datetime'])
         task.save()


### PR DESCRIPTION
At the moment we just test by making sure that the database endtry is correct.
However, this is prone to errors. We change testing to actually run the
task and call the vumi api, in order to catch errors with the `action_kwargs`
field, which has been error prone.
