### PR TITLE
Channels with the same tag name are difficult to distinguish

### DIFF
--- a/go/api/go_api/api_types.py
+++ b/go/api/go_api/api_types.py
@@ -127,7 +127,8 @@ class ChannelType(Dict):
         uuid = channel.key
         conn = channel.get_connector()
         return {
-            'uuid': uuid, 'tag': (pool, tagname), 'name': tagname,
+            'uuid': uuid, 'tag': (pool, tagname),
+            'name': u'%s (%s)' % (tagname, pool),
             'description': u"%s: %s" % (
                 pool.replace('_', ' ').title(), tagname),
             'endpoints': [


### PR DESCRIPTION
On the campaign routing screen, channels only display their tag name, not their tag pool. This makes distinguishing channels with the same tag name difficult:

![pasted image at 2016_02_17 04_35 pm](https://cloud.githubusercontent.com/assets/165551/13127091/4169bade-d5d6-11e5-981a-f5954475af15.png)
