### PR TITLE
Fix heading of the "created at" column on the Vumi Go dashboards.

### DIFF
--- a/go/conversation/templates/conversation/dashboard.html
+++ b/go/conversation/templates/conversation/dashboard.html
@@ -15,7 +15,7 @@
                 <!-- TODO: We don't have a backend service yet for this value -->
                 <!-- <th>In Last</th> -->
                 <!-- TODO: We're only storing the created_at value :\ -->
-                <th>Last Edited</th>
+                <th>Created At</th>
                 <th></th>
                 <th></th>
             </tr>


### PR DESCRIPTION
Currently the column is labelled "Last Edited". :eyes: 
