### PR TITLE
Remove unneeded riak_manager config from ConversationMetricsMiddleware

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -608,10 +608,6 @@ class ConversationMetricsMiddlewareConfig(BaseMiddleware.CONFIG_CLASS):
     redis_manager = ConfigDict(
         "Redis configuration parameters", default={}, static=True)
 
-    riak_manager = ConfigRiak(
-        "Riak configuration parameters. Must contain at least a bucket_prefix"
-        " key", required=True, static=True)
-
 
 class ConversationMetricsMiddleware(BaseMiddleware):
     """

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -1043,9 +1043,7 @@ class TestConversationMetricsMiddleware(VumiTestCase):
 
     @inlineCallbacks
     def test_inbound_message(self):
-        mw = yield self.mw_helper.create_middleware(
-            {'manager_name': 'metrics_manager', }
-        )
+        mw = yield self.mw_helper.create_middleware()
         msg_helper = GoMessageHelper(vumi_helper=self.mw_helper)
 
         yield self.assert_conv_not_in_redis(mw)
@@ -1055,9 +1053,7 @@ class TestConversationMetricsMiddleware(VumiTestCase):
 
     @inlineCallbacks
     def test_outbound_message(self):
-        mw = yield self.mw_helper.create_middleware(
-            {'manager_name': 'metrics_manager', }
-        )
+        mw = yield self.mw_helper.create_middleware()
         msg_helper = GoMessageHelper(vumi_helper=self.mw_helper)
 
         yield self.assert_conv_not_in_redis(mw)

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -1,6 +1,5 @@
 """Tests for go.vumitools.middleware"""
 import time
-import json
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 


### PR DESCRIPTION
The middleware asks for a riak_manager in its config by doesn't use it.
