### PR TITLE
Add connector_name to ConversationMetricsMiddleware handlers.

### DIFF
--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -648,12 +648,12 @@ class ConversationMetricsMiddleware(BaseMiddleware):
         return self.redis.sadd("recent_coversations", conv_details)
 
     @inlineCallbacks
-    def handle_inbound(self, message):
+    def handle_inbound(self, message, connector_name):
         yield self.record_conv_seen(message)
         returnValue(message)
 
     @inlineCallbacks
-    def handle_outbound(self, message):
+    def handle_outbound(self, message, connector_name):
         yield self.record_conv_seen(message)
         returnValue(message)
 

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -1048,7 +1048,7 @@ class TestConversationMetricsMiddleware(VumiTestCase):
 
         yield self.assert_conv_not_in_redis(mw)
         [msg] = yield msg_helper.add_inbound_to_conv(self.conv, 1)
-        yield mw.handle_inbound(msg)
+        yield mw.handle_inbound(msg, "conn_1")
         yield self.assert_conv_in_redis(mw, msg)
 
     @inlineCallbacks
@@ -1058,5 +1058,5 @@ class TestConversationMetricsMiddleware(VumiTestCase):
 
         yield self.assert_conv_not_in_redis(mw)
         [msg] = yield msg_helper.add_outbound_to_conv(self.conv, 1)
-        yield mw.handle_outbound(msg)
+        yield mw.handle_outbound(msg, "conn_1")
         yield self.assert_conv_in_redis(mw, msg)


### PR DESCRIPTION
The method signature for handlers should be `handle_xxx(message, connector_name)`.
