### PR TITLE
Fix spelling of conversation metrics middleware redis keys.

### DIFF
--- a/go/base/tasks.py
+++ b/go/base/tasks.py
@@ -29,11 +29,13 @@ def get_and_reset_recent_conversations(vumi_api):
     # makes use of redis atomic functions to ensure nothing is added to the set
     # before it is deleted
     try:
-        redis.rename("recent_conversations", "old_recent_conversations")
+        redis.rename(ConversationMetricsMiddleware.RECENT_CONV_KEY,
+                     ConversationMetricsMiddleware.OLD_RECENT_CONV_KEY)
     except vumi_api.redis.RESPONSE_ERROR:
         return []
-    conversation_details = redis.smembers("old_recent_conversations")
-    redis.delete("old_recent_conversations")
+    conversation_details = redis.smembers(
+        ConversationMetricsMiddleware.OLD_RECENT_CONV_KEY)
+    redis.delete(ConversationMetricsMiddleware.OLD_RECENT_CONV_KEY)
     return conversation_details
 
 

--- a/go/vumitools/middleware.py
+++ b/go/vumitools/middleware.py
@@ -621,6 +621,8 @@ class ConversationMetricsMiddleware(BaseMiddleware):
 
     CONFIG_CLASS = ConversationMetricsMiddlewareConfig
     SUBMANAGER_PREFIX = "conversation.metrics.middleware"
+    RECENT_CONV_KEY = "recent_conversations"
+    OLD_RECENT_CONV_KEY = "old_recent_conversations"
 
     @inlineCallbacks
     def setup_middleware(self):
@@ -645,7 +647,7 @@ class ConversationMetricsMiddleware(BaseMiddleware):
 
         # Note: This set will be emptied by a celery task that publishes the
         # metrics for conversations we have seen
-        return self.redis.sadd("recent_coversations", conv_details)
+        return self.redis.sadd(self.RECENT_CONV_KEY, conv_details)
 
     @inlineCallbacks
     def handle_inbound(self, message, connector_name):

--- a/go/vumitools/tests/test_middleware.py
+++ b/go/vumitools/tests/test_middleware.py
@@ -1030,7 +1030,8 @@ class TestConversationMetricsMiddleware(VumiTestCase):
 
     @inlineCallbacks
     def assert_conv_in_redis(self, mw, msg):
-        value = yield mw.redis.smembers("recent_coversations")
+        value = yield mw.redis.smembers(
+            ConversationMetricsMiddleware.RECENT_CONV_KEY)
         conv_details = '{"account_key": "%s","conv_key": "%s"}' % \
             (self.conv.user_account.key, self.conv.key)
         self.assertTrue(conv_details in value)
@@ -1038,7 +1039,8 @@ class TestConversationMetricsMiddleware(VumiTestCase):
 
     @inlineCallbacks
     def assert_conv_not_in_redis(self, mw):
-        value = yield mw.redis.smembers("recent_coversations")
+        value = yield mw.redis.smembers(
+            ConversationMetricsMiddleware.RECENT_CONV_KEY)
         self.assertSetEqual(value, set([]))
 
     @inlineCallbacks


### PR DESCRIPTION
Currently we have `recent_coversations` in `go.vumitools` and `recent_conversations` in `go.base.tasks`.
