### PR TITLE
Fix DummyRequest headers retrieval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
     # Test against Riak 2.1.1.
     - python: "2.7"
       env: RIAK_VERSION="2.1.1" VUMIGO_TEST_DB=postgres
+    # Test against Twisted 15.4
+    - python: "2.7"
+      env: TWISTED_VERSION="Twisted==15.4"
     # Test without Django.
     - python: "2.7"
       env: VUMIGO_SKIP_DJANGO=1 NO_COVERAGE=1
@@ -36,9 +39,11 @@ before_install:
   # Set up an appropriate version of Riak.
   - export RIAK_VERSION="${RIAK_VERSION-1.4.12}"
   - utils/setup_travis_riak.sh "${RIAK_VERSION}"
+  - export TWISTED_VERSION="${TWISTED_VERSION-Twisted}"
 install:
   # Travis seems to have pip 6.x, which doesn't build and cache wheels.
   - "pip install 'pip>=7.1.0'"
+  - "pip install ${TWISTED_VERSION}"
   - "if [ $VUMIGO_SKIP_DJANGO ]; then pip install -e .; else pip install -r requirements.pip; fi"
   - "pip install -r requirements-dev.pip"
   - "pip install overalls"

--- a/go/api/go_api/tests/test_auth.py
+++ b/go/api/go_api/tests/test_auth.py
@@ -146,7 +146,8 @@ class TestGoAuthBouncerAccessChecker(VumiTestCase):
         request = DummyRequest([''])
         request.path = ''
         if token is not None:
-            request.headers["authorization"] = "Bearer %s" % (token,)
+            request.requestHeaders.addRawHeader(
+                "authorization", "Bearer %s" % (token,))
         return request
 
     @inlineCallbacks
@@ -212,11 +213,12 @@ class TestGoUserAuthSessionWrapper(VumiTestCase):
         request = DummyRequest([''])
         request.path = ''
         if user is not None:
-            request.headers["authorization"] = (
+            request.requestHeaders.addRawHeader("authorization", (
                 "Basic %s" % base64.b64encode("%s:%s" % (user, password))
-            )
+            ))
         elif bearer is not None:
-            request.headers["authorization"] = "Bearer %s" % (bearer,)
+            request.requestHeaders.addRawHeader(
+                "authorization", "Bearer %s" % (bearer,))
         return request
 
     def mk_wrapper(self, text, bouncer=False):

--- a/go/api/go_api/tests/test_auth.py
+++ b/go/api/go_api/tests/test_auth.py
@@ -6,7 +6,7 @@ from twisted.cred import error
 from twisted.cred.credentials import UsernamePassword
 from twisted.internet.defer import inlineCallbacks
 from twisted.web import resource
-from twisted.web.test.test_web import DummyRequest
+from twisted.web.test import test_web
 from twisted.web.iweb import ICredentialFactory
 
 from vumi.tests.helpers import VumiTestCase, PersistenceHelper
@@ -20,6 +20,15 @@ from go.vumitools.tests.helpers import VumiApiHelper
 from .utils import MockAuthServer
 
 import mock
+
+
+class DummyRequest(test_web.DummyRequest):
+    def addRawRequestHeader(self, name, value):
+        if not hasattr(self, 'headers'):
+            # Twisted >= 16.0
+            self.requestHeaders.addRawHeader(name, value)
+        else:
+            self.headers[name] = value
 
 
 class TestGoUserRealm(VumiTestCase):
@@ -146,7 +155,7 @@ class TestGoAuthBouncerAccessChecker(VumiTestCase):
         request = DummyRequest([''])
         request.path = ''
         if token is not None:
-            request.requestHeaders.addRawHeader(
+            request.addRawRequestHeader(
                 "authorization", "Bearer %s" % (token,))
         return request
 
@@ -213,11 +222,11 @@ class TestGoUserAuthSessionWrapper(VumiTestCase):
         request = DummyRequest([''])
         request.path = ''
         if user is not None:
-            request.requestHeaders.addRawHeader("authorization", (
+            request.addRawRequestHeader("authorization", (
                 "Basic %s" % base64.b64encode("%s:%s" % (user, password))
             ))
         elif bearer is not None:
-            request.requestHeaders.addRawHeader(
+            request.addRawRequestHeader(
                 "authorization", "Bearer %s" % (bearer,))
         return request
 

--- a/go/billing/utils.py
+++ b/go/billing/utils.py
@@ -71,7 +71,7 @@ class DummyRequest(test_web.DummyRequest):
             self.content = None
         headers = headers or {}
         for header, value in headers.items():
-            self.requestHeaders.addRawHeader(header, value)
+            self.addRawRequestHeader(header, value)
 
         args = args or {}
         for k, v in args.items():
@@ -79,6 +79,13 @@ class DummyRequest(test_web.DummyRequest):
 
     def value(self):
         return "".join(self.written)
+
+    def addRawRequestHeader(self, name, value):
+        if not hasattr(self, 'headers'):
+            # Twisted >= 16.0
+            self.requestHeaders.addRawHeader(name, value)
+        else:
+            self.headers[name] = value
 
 
 class DummySite(server.Site):

--- a/go/billing/utils.py
+++ b/go/billing/utils.py
@@ -69,7 +69,9 @@ class DummyRequest(test_web.DummyRequest):
             self.content = StringIO(json.dumps(content, cls=JSONEncoder))
         else:
             self.content = None
-        self.headers.update(headers or {})
+        headers = headers or {}
+        for header, value in headers.items():
+            self.requestHeaders.addRawHeader(header, value)
 
         args = args or {}
         for k, v in args.items():


### PR DESCRIPTION
Twisted 16.0 changed the way DummyRequest store headers (to match real requests more closely). We need to update our tests to match.
